### PR TITLE
Use the Debug config for shared_library builds

### DIFF
--- a/script/build
+++ b/script/build
@@ -11,7 +11,10 @@ from lib.util import get_configuration, get_output_dir
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
 TARGETS = ['chromiumcontent_all']
-COMPONENTS = ['static_library', 'shared_library']
+FLAVORS = [
+  { 'config': 'Release', 'component': 'static_library' },
+  { 'config': 'Debug', 'component': 'shared_library' },
+]
 
 NINJA = os.path.join(VENDOR_DIR, 'depot_tools', 'ninja')
 if sys.platform == 'win32':
@@ -24,11 +27,11 @@ def main():
 
   os.chdir(SOURCE_ROOT)
 
-  for component in COMPONENTS:
-    if args.component == 'all' or args.component == component:
+  for flavor in FLAVORS:
+    if args.component == 'all' or args.component == flavor['component']:
       out_dir = os.path.join(VENDOR_DIR, 'chromium', 'src',
-                             get_output_dir(target_arch, component))
-      config = get_configuration(target_arch)
+                             get_output_dir(target_arch, flavor['component']))
+      config = get_configuration(flavor['config'], target_arch)
       config_dir = os.path.relpath(os.path.join(out_dir, config))
       subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
 

--- a/script/create-dist
+++ b/script/create-dist
@@ -43,7 +43,10 @@ STATIC_LIBRARY_SUFFIX = {
   'win32': 'lib',
 }[TARGET_PLATFORM]
 
-COMPONENTS = ['static_library', 'shared_library']
+FLAVORS = [
+  { 'config': 'Release', 'component': 'static_library' },
+  { 'config': 'Debug', 'component': 'shared_library' },
+]
 BINARIES = {
   'all': [
     'content_shell.pak',
@@ -162,11 +165,11 @@ def main():
   rm_rf(DIST_DIR)
   os.makedirs(DIST_DIR)
 
-  for component in COMPONENTS:
-    if args.component == 'all' or args.component == component:
-      output_dir = os.path.join(SRC_DIR, get_output_dir(target_arch, component))
-      copy_binaries(target_arch, component, output_dir)
-      copy_generated_sources(target_arch, component, output_dir)
+  for flavor in FLAVORS:
+    if args.component == 'all' or args.component == flavor['component']:
+      output_dir = os.path.join(SRC_DIR, get_output_dir(target_arch, flavor['component']))
+      copy_binaries(target_arch, flavor, output_dir)
+      copy_generated_sources(target_arch, flavor, output_dir)
 
   copy_sources()
   create_zip()
@@ -180,15 +183,15 @@ def parse_args():
   return parser.parse_args()
 
 
-def copy_binaries(target_arch, component, output_dir):
-  config_dir = os.path.join(output_dir, get_configuration(target_arch))
-  target_dir = os.path.join(MAIN_DIR, component)
+def copy_binaries(target_arch, flavor, output_dir):
+  config_dir = os.path.join(output_dir, get_configuration(flavor['config'], target_arch))
+  target_dir = os.path.join(MAIN_DIR, flavor['component'])
   mkdir_p(target_dir)
 
   for binary in BINARIES['all'] + BINARIES[TARGET_PLATFORM]:
     shutil.copy2(os.path.join(config_dir, binary), target_dir)
 
-  if component == 'shared_library':
+  if flavor['component'] == 'shared_library':
     match = '*.{0}'.format(SHARED_LIBRARY_SUFFIX)
   else:
     match = '*.{0}'.format(STATIC_LIBRARY_SUFFIX)
@@ -199,7 +202,7 @@ def copy_binaries(target_arch, component, output_dir):
       shutil.copy2(library, target_dir)
 
   if TARGET_PLATFORM == 'win32':
-    if component == 'shared_library':
+    if flavor['component'] == 'shared_library':
       # out/Release/*.dll(.lib)
       for dll in glob.glob(os.path.join(config_dir, '*.dll')):
         lib = dll + '.lib'
@@ -229,7 +232,7 @@ def copy_binaries(target_arch, component, output_dir):
           shutil.copy2(os.path.join(root, filename), target_dir)
 
   if TARGET_PLATFORM == 'linux':
-    if component == 'shared_library':
+    if flavor['component'] == 'shared_library':
       # out/Release/lib/*.so
       for library in glob.glob(os.path.join(config_dir, 'lib', '*.so')):
         shutil.copy2(library, target_dir)
@@ -244,14 +247,14 @@ def copy_binaries(target_arch, component, output_dir):
       run_strip(os.path.join(target_dir, os.path.basename(binary)))
     # We do not need debug info in "shared_library" build, since it will only
     # be used for Release build.
-    if component == 'shared_library':
+    if flavor['component'] == 'shared_library':
       for library in glob.glob(os.path.join(target_dir, match)):
         run_strip(library)
 
 
-def copy_generated_sources(target_arch, component, output_dir):
-  config = get_configuration(target_arch)
-  target_dir = os.path.join(MAIN_DIR, component)
+def copy_generated_sources(target_arch, flavor, output_dir):
+  config = get_configuration(flavor['config'], target_arch)
+  target_dir = os.path.join(MAIN_DIR, flavor['component'])
   for include_path in GENERATED_INCLUDE_DIRS:
     copy_headers(include_path,
                  relative_to=os.path.join(output_dir, config, 'gen'),

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -15,8 +15,7 @@ def get_output_dir(target_arch, component):
   return output_dir
 
 
-def get_configuration(target_arch):
-  config = 'Release'
+def get_configuration(config, target_arch):
   if target_arch == 'x64' and sys.platform in ['win32', 'cygwin']:
     config += '_x64'
   return config

--- a/script/update
+++ b/script/update
@@ -18,7 +18,10 @@ VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
 SRC_DIR = os.path.join(VENDOR_DIR, 'chromium', 'src')
 CHROMIUMCONTENT_SOURCE_DIR = os.path.join(SOURCE_ROOT, 'chromiumcontent')
 CHROMIUMCONTENT_DESTINATION_DIR = os.path.join(SRC_DIR, 'chromiumcontent')
-COMPONENTS = ['static_library', 'shared_library']
+FLAVORS = [
+  { 'config': 'Release', 'component': 'static_library' },
+  { 'config': 'Debug', 'component': 'shared_library' },
+]
 
 TARBALL_REPO = 'zcbenz/chromium-source-tarball'
 TARBALL_URL = 'https://github.com/{0}/releases/download/{1}/chromium-{1}.tar.xz'
@@ -166,8 +169,8 @@ def run_gyp(target_arch):
   relative_dir = os.path.relpath(CHROMIUMCONTENT_DESTINATION_DIR, SRC_DIR)
   args = [sys.executable, gyp, '-Ichromiumcontent/chromiumcontent.gypi',
           os.path.join(relative_dir, 'chromiumcontent.gyp')]
-  for component in COMPONENTS:
-    subprocess.call(args, env=gyp_env(target_arch, component))
+  for flavor in FLAVORS:
+    subprocess.call(args, env=gyp_env(target_arch, flavor['component']))
 
 
 def xz():


### PR DESCRIPTION
Instead of building both shared_library and static_library in Release, we now build shared_library in Debug. This will let applications that link against the shared_library build take advantage of Chromium's assertions that check for things like accessing objects from the proper thread.

This should help with bug reports like https://github.com/atom/electron/issues/951.

/cc @zcbenz 