### PR TITLE
Allow running script in willReleaseScriptContext

### DIFF
--- a/patches/blink_local_frame.patch
+++ b/patches/blink_local_frame.patch
@@ -1,0 +1,23 @@
+diff --git a/third_party/WebKit/Source/core/frame/LocalFrame.cpp b/third_party/WebKit/Source/core/frame/LocalFrame.cpp
+index 9808948..856c318 100644
+--- a/third_party/WebKit/Source/core/frame/LocalFrame.cpp
++++ b/third_party/WebKit/Source/core/frame/LocalFrame.cpp
+@@ -336,10 +336,6 @@ void LocalFrame::detach(FrameDetachType type)
+     m_loader.stopAllLoaders();
+     m_loader.detach();
+     document()->detach();
+-    // This is the earliest that scripting can be disabled:
+-    // - FrameLoader::detach() can fire XHR abort events
+-    // - Document::detach()'s deferred widget updates can run script.
+-    ScriptForbiddenScope forbidScript;
+     m_loader.clear();
+     if (!client())
+         return;
+@@ -348,6 +344,7 @@ void LocalFrame::detach(FrameDetachType type)
+     // Notify ScriptController that the frame is closing, since its cleanup ends up calling
+     // back to FrameLoaderClient via WindowProxy.
+     script().clearForClose();
++    ScriptForbiddenScope forbidScript;
+     setView(nullptr);
+     willDetachFrameHost();
+     InspectorInstrumentation::frameDetachedFromParent(this);


### PR DESCRIPTION
According to electron/electron#3699, it is unreliable to use |unload| event for process.exit('exit'), so we have to do that in willReleaseScriptContext.

However Chromium then disallowed scripting in willReleaseScriptContext in https://codereview.chromium.org/1657583002, and crash will happen when there is code doing that.

This patch reverts the change to fix the crash in Electron.