### PR TITLE
Add patch to not inline the default constructor of UnicodeString

### DIFF
--- a/patches/third_party/icu/no_inline_default_constructor.patch
+++ b/patches/third_party/icu/no_inline_default_constructor.patch
@@ -1,0 +1,46 @@
+diff --git a/source/common/unicode/unistr.h b/source/common/unicode/unistr.h
+index c98aec7..85b035a 100644
+--- a/source/common/unicode/unistr.h
++++ b/source/common/unicode/unistr.h
+@@ -2851,7 +2851,7 @@ public:
+   /** Construct an empty UnicodeString.
+    * @stable ICU 2.0
+    */
+-  inline UnicodeString();
++  UnicodeString();
+ 
+   /**
+    * Construct a UnicodeString with capacity to hold <TT>capacity</TT> UChars
+@@ -3602,16 +3602,6 @@ UnicodeString::getArrayStart() const
+ { return (fFlags&kUsingStackBuffer) ? fUnion.fStackBuffer : fUnion.fFields.fArray; }
+ 
+ //========================================
+-// Default constructor
+-//========================================
+-
+-inline
+-UnicodeString::UnicodeString()
+-  : fShortLength(0),
+-    fFlags(kShortString)
+-{}
+-
+-//========================================
+ // Read-only implementation methods
+ //========================================
+ inline int32_t
+diff --git a/source/common/unistr.cpp b/source/common/unistr.cpp
+index f103e81..ce1452e 100644
+--- a/source/common/unistr.cpp
++++ b/source/common/unistr.cpp
+@@ -144,7 +144,10 @@ UnicodeString::releaseArray() {
+ // Constructors
+ //========================================
+ 
+-// The default constructor is inline in unistr.h.
++UnicodeString::UnicodeString()
++  : fShortLength(0),
++    fFlags(kShortString)
++{}
+ 
+ UnicodeString::UnicodeString(int32_t capacity, UChar32 c, int32_t count)
+   : fShortLength(0),


### PR DESCRIPTION
It seems that when building with Visual Studio 2015, the inline default constructor of UnicodeString gets compiled in each compilation unit instead of being inlined, results in linking error of the Release build of Electron:

```
blink_platform.lib(blink_platform.SimpleFontData.obj) : error LNK2005: "public: __cdecl icu_54::UnicodeString::UnicodeString(void)" (??0UnicodeString@icu_54@@QEAA@XZ) already defined in node.dll.lib(node.dll)
blink_platform.lib(blink_platform.StringTruncator.obj) : error LNK2005: "public: __cdecl icu_54::UnicodeString::UnicodeString(void)" (??0UnicodeString@icu_54@@QEAA@XZ) already defined in node.dll.lib(node.dll)
blink_platform.lib(blink_platform.FontCacheSkiaWin.obj) : error LNK2005: "public: __cdecl icu_54::UnicodeString::UnicodeString(void)" (??0UnicodeString@icu_54@@QEAA@XZ) already defined in node.dll.lib(node.dll)
blink_platform.lib(blink_platform.FontCacheSkia.obj) : error LNK2005: "public: __cdecl icu_54::UnicodeString::UnicodeString(void)" (??0UnicodeString@icu_54@@QEAA@XZ) already defined in node.dll.lib(node.dll)
```

It is very likely a bug of Visual Studio 2015, hope we can work around it with this patch.