### PR TITLE
Fix for webviews using default (empty) BeginFrameSubscription implementation

### DIFF
--- a/patches/guest_view.patch
+++ b/patches/guest_view.patch
@@ -1,0 +1,67 @@
+diff --git a/content/browser/frame_host/render_widget_host_view_child_frame.cc b/content/browser/frame_host/render_widget_host_view_child_frame.cc
+index 7101a90..8349471 100644
+--- a/content/browser/frame_host/render_widget_host_view_child_frame.cc
++++ b/content/browser/frame_host/render_widget_host_view_child_frame.cc
+@@ -28,8 +28,10 @@
+ #include "content/common/text_input_state.h"
+ #include "content/common/view_messages.h"
+ #include "content/public/browser/render_process_host.h"
++#include "content/public/browser/render_widget_host_view_frame_subscriber.h"
+ #include "content/public/common/browser_plugin_guest_mode.h"
+ #include "gpu/ipc/common/gpu_messages.h"
++#include "media/base/video_frame.h"
+ #include "ui/gfx/geometry/size_conversions.h"
+ #include "ui/gfx/geometry/size_f.h"
+
+@@ -691,4 +693,26 @@ cc::SurfaceId RenderWidgetHostViewChildFrame::SurfaceIdForTesting() const {
+   return surface_id_;
+ };
+
++void RenderWidgetHostViewChildFrame::WillDrawSurface(
++    cc::SurfaceId id,
++    const gfx::Rect& damage_rect) {
++  if (id != surface_id_ || damage_rect.IsEmpty() || !frame_subscriber_.get())
++    return;
++
++  base::TimeTicks present_time;
++  scoped_refptr<media::VideoFrame> frame;
++  RenderWidgetHostViewFrameSubscriber::DeliverFrameCallback callback;
++  frame_subscriber_->ShouldCaptureFrame(damage_rect, present_time, &frame,
++                                        &callback);
++}
++
++void RenderWidgetHostViewChildFrame::BeginFrameSubscription(
++    std::unique_ptr<RenderWidgetHostViewFrameSubscriber> subscriber) {
++  frame_subscriber_ = std::move(subscriber);
++}
++
++void RenderWidgetHostViewChildFrame::EndFrameSubscription() {
++  frame_subscriber_.reset();
++}
++
+ }  // namespace content
+diff --git a/content/browser/frame_host/render_widget_host_view_child_frame.h b/content/browser/frame_host/render_widget_host_view_child_frame.h
+index 9a2bd5e..bdf22f3 100644
+--- a/content/browser/frame_host/render_widget_host_view_child_frame.h
++++ b/content/browser/frame_host/render_widget_host_view_child_frame.h
+@@ -190,6 +190,11 @@ class CONTENT_EXPORT RenderWidgetHostViewChildFrame
+
+   void RegisterSurfaceNamespaceId();
+   void UnregisterSurfaceNamespaceId();
++
++  void WillDrawSurface(cc::SurfaceId id, const gfx::Rect& damage_rect) override;
++  void BeginFrameSubscription(
++     std::unique_ptr<RenderWidgetHostViewFrameSubscriber> subscriber) override;
++  void EndFrameSubscription() override;
+
+  protected:
+   friend class RenderWidgetHostView;
+@@ -245,6 +250,8 @@ class CONTENT_EXPORT RenderWidgetHostViewChildFrame
+   bool observing_begin_frame_source_;
+   // The surface id namespace of the parent RenderWidgetHostView.  0 if none.
+   uint32_t parent_surface_id_namespace_;
++
++  std::unique_ptr<RenderWidgetHostViewFrameSubscriber> frame_subscriber_;
+
+   base::WeakPtrFactory<RenderWidgetHostViewChildFrame> weak_factory_;
+   DISALLOW_COPY_AND_ASSIGN(RenderWidgetHostViewChildFrame);


### PR DESCRIPTION
This PR adds a small patch to fix electron/electron#5665
`RenderWidgetHostViewChildFrame` was missing some functions, I tried to keep the implementation as small as possible for easier maintenance.