### PR TITLE
Add patch to always call InitializeDWriteFontProxy

### DIFF
--- a/patches/initialize_direct_write_font_proxy.patch
+++ b/patches/initialize_direct_write_font_proxy.patch
@@ -1,0 +1,17 @@
+diff --git a/content/renderer/renderer_main_platform_delegate_win.cc b/content/renderer/renderer_main_platform_delegate_win.cc
+index 20efc6dc0319238ce80218cdc6977775b375d2c2..74ddc56dde3ac79459756628e3d0323cb0568c26 100644
+--- a/content/renderer/renderer_main_platform_delegate_win.cc
++++ b/content/renderer/renderer_main_platform_delegate_win.cc
+@@ -52,9 +52,10 @@ void RendererMainPlatformDelegate::PlatformInitialize() {
+     // cached and there's no more need to access the registry. If the sandbox
+     // is disabled, we don't have to make this dummy call.
+     std::unique_ptr<icu::TimeZone> zone(icu::TimeZone::createDefault());
+-
+-    InitializeDWriteFontProxy();
+   }
++
++  InitializeDWriteFontProxy();
++
+   // TODO(robliao): This should use WebScreenInfo. See http://crbug.com/604555.
+   blink::WebFontRendering::setDeviceScaleFactor(display::win::GetDPIScale());
+ }


### PR DESCRIPTION
Port over https://codereview.chromium.org/2387373003 which can be removed if/when that lands.

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=620419
Refs https://github.com/electron/electron/issues/7334