### PR TITLE
Ship dom_keycode_converter

### DIFF
--- a/chromiumcontent/chromiumcontent.gyp
+++ b/chromiumcontent/chromiumcontent.gyp
@@ -45,6 +45,7 @@
         '<(DEPTH)/third_party/webrtc/modules/modules.gyp:desktop_capture',
         '<(DEPTH)/third_party/widevine/cdm/widevine_cdm.gyp:widevinecdmadapter',
         '<(DEPTH)/third_party/widevine/cdm/widevine_cdm.gyp:widevine_cdm_version_h',
+        '<(DEPTH)/ui/events/events.gyp:dom_keycode_converter',
       ],
       'sources': [
         'empty.cc',

--- a/script/create-dist
+++ b/script/create-dist
@@ -73,6 +73,7 @@ BINARIES = {
     'libsecurity_state.a',
     'libcookie_config.a',
     'libos_crypt.a',
+    'libdom_keycode_converter.a',
   ],
   'linux': [
     'chromedriver',
@@ -93,6 +94,7 @@ BINARIES = {
     'libsecurity_state.a',
     'libcookie_config.a',
     'libos_crypt.a',
+    'libdom_keycode_converter.a',
     os.path.join('lib', 'libffmpeg.so'),
   ],
   'win32': [
@@ -184,6 +186,8 @@ BINARIES = {
     os.path.join('obj', 'third_party', 'webrtc', 'system_wrappers', 'system_wrappers.lib'),
     os.path.join('obj', 'third_party', 'webrtc', 'webrtc_common.cc.pdb'),
     os.path.join('obj', 'third_party', 'webrtc', 'webrtc_common.lib'),
+    os.path.join('obj', 'ui', 'events', 'dom_keycode_converter.cc.pdb'),
+    os.path.join('obj', 'ui', 'events', 'dom_keycode_converter.lib'),
   ],
 }
 


### PR DESCRIPTION
This is needed for electron/electron#7586 for which we will need to use `ui::KeycodeConverter::DomKeyToKeyString`.