### PR TITLE
Filter out BFD assertion from CI logs

### DIFF
--- a/script/cibuild-libchromiumcontent-linux
+++ b/script/cibuild-libchromiumcontent-linux
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Workaround for massive amounts of the following being logged in binutils 2.22:
+# /usr/bin/arm-linux-gnueabihf-ld: BFD (GNU Binutils for Ubuntu) 2.22 assertion fail ../../bfd/elf32-arm.c:12049
+#
+# This should be fixed in binutils 2.2.4, https://sourceware.org/bugzilla/show_bug.cgi?id=14189
+# and can be removed when CI is upgraded to that version or later.
+script/cibuild 2>&1 | grep -v "elf32-arm.c:12049"


### PR DESCRIPTION
Our Linux CI machine is currently filling up the logs with thousands of these:

```
/usr/bin/arm-linux-gnueabihf-ld: BFD (GNU Binutils for Ubuntu) 2.22 assertion fail ../../bfd/elf32-arm.c:12049
```

This pull request filters them out so they don't trigger the output limits on Jenkins. This is just a short-term solution, the long-term solution is to upgrade to binutils 2.24+.

https://sourceware.org/bugzilla/show_bug.cgi?id=14189