### PR TITLE
Backport Chrome 56 Linux Control key fix to Chrome 53

### DIFF
--- a/patches/dom_key_control.patch
+++ b/patches/dom_key_control.patch
@@ -1,0 +1,77 @@
+diff --git a/third_party/WebKit/Source/core/editing/EditingBehavior.cpp b/third_party/WebKit/Source/core/editing/EditingBehavior.cpp
+index 39922f8..566ff89 100644
+--- a/third_party/WebKit/Source/core/editing/EditingBehavior.cpp
++++ b/third_party/WebKit/Source/core/editing/EditingBehavior.cpp
+@@ -244,7 +244,13 @@ bool EditingBehavior::shouldInsertCharacter(const KeyboardEvent& event) const
+     // unexpected behaviour
+     if (ch < ' ')
+         return false;
+-#if !OS(WIN)
++#if OS(LINUX)
++    // According to XKB map no keyboard combinations with ctrl key are mapped to
++    // printable characters, however we need the filter as the DomKey/text could
++    // contain printable characters.
++    if (event.ctrlKey())
++      return false;
++#elif !OS(WIN)
+     // Don't insert ASCII character if ctrl w/o alt or meta is on.
+     // On Mac, we should ignore events when meta is on (Command-<x>).
+     if (ch < 0x80) {
+@@ -260,4 +266,3 @@ bool EditingBehavior::shouldInsertCharacter(const KeyboardEvent& event) const
+     return true;
+ }
+ } // namespace blink
+-
+diff --git a/ui/events/event.cc b/ui/events/event.cc
+index 978d305..98e6329 100644
+--- a/ui/events/event.cc
++++ b/ui/events/event.cc
+@@ -1092,11 +1092,7 @@ void KeyEvent::ApplyLayout() const {
+ // so this is a synthetic or native keystroke event.
+ // Therefore, perform only the fallback action.
+ #elif defined(USE_X11)
+-  // When a control key is held, prefer ASCII characters to non ASCII
+-  // characters in order to use it for shortcut keys.  GetCharacterFromKeyCode
+-  // returns 'a' for VKEY_A even if the key is actually bound to 'à' in X11.
+-  // GetCharacterFromXEvent returns 'à' in that case.
+-  if (!IsControlDown() && native_event()) {
++  if (native_event()) {
+     key_ = GetDomKeyFromXEvent(native_event());
+     return;
+   }
+diff --git a/ui/events/keycodes/keyboard_code_conversion_x.cc b/ui/events/keycodes/keyboard_code_conversion_x.cc
+index dfac6ed..c6f2bfe 100644
+--- a/ui/events/keycodes/keyboard_code_conversion_x.cc
++++ b/ui/events/keycodes/keyboard_code_conversion_x.cc
+@@ -904,17 +904,27 @@ uint16_t GetCharacterFromXEvent(const XEvent* xev) {
+ 
+ DomKey GetDomKeyFromXEvent(const XEvent* xev) {
+   XEvent xkeyevent = {0};
+-  const XKeyEvent* xkey = NULL;
++  XKeyEvent xkey;
+   if (xev->type == GenericEvent) {
+     // Convert the XI2 key event into a core key event so that we can
+     // continue to use XLookupString() until crbug.com/367732 is complete.
+     InitXKeyEventFromXIDeviceEvent(*xev, &xkeyevent);
+-    xkey = &xkeyevent.xkey;
++    xkey = xkeyevent.xkey;
+   } else {
+-    xkey = &xev->xkey;
++    xkey = xev->xkey;
+   }
++  // There is no good way to check whether a key combination will print a
++  // character on screen.
++  // e.g. On Linux US keyboard with French layout, |XLookupString()|
++  //        * Returns '?' for ctrl-shift-/
++  //        * Returns '§' for shift-/
++  //      According to spec the DomKey for ctrl-shift-/ should also be '§'.
++  // The solution is to take out ctrl modifier directly, as according to XKB map
++  // no keyboard combinations with ctrl key are mapped to printable character.
++  // https://crbug.com/633838
++  xkey.state &= ~ControlMask;
+   KeySym keysym = XK_VoidSymbol;
+-  XLookupString(const_cast<XKeyEvent*>(xkey), NULL, 0, &keysym, NULL);
++  XLookupString(&xkey, NULL, 0, &keysym, NULL);
+   base::char16 ch = GetUnicodeCharacterFromXKeySym(keysym);
+   return XKeySymToDomKey(keysym, ch);
+ }


### PR DESCRIPTION
This pull request backports the fix for https://codereview.chromium.org/2474083002 to Chrome 53 so apps using `KeyboardEvent.key` on Linux will get correct results.

This patch can be removed when Chrome 56 is upgraded to.

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=633838
Refs https://github.com/electron/electron/issues/8116