### PR TITLE
Split up Linux CI jobs

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -23,9 +23,12 @@ def main():
     return (run_ci(['-t', 'x64']) or
             run_ci(['-t', 'ia32']))
   elif sys.platform == 'linux2':
-    return (run_ci(['-t', 'x64']) or
-            run_ci(['-t', 'ia32']) or
-            run_ci(['-t', 'arm']))
+    if 'TARGET_ARCH' in os.environ:
+      return run_ci(['-t', os.environ['TARGET_ARCH']])
+    else:
+      return (run_ci(['-t', 'x64']) or
+              run_ci(['-t', 'ia32']) or
+              run_ci(['-t', 'arm']))
   else:
     return run_ci([])
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -19,16 +19,16 @@ def main():
     return 'Error: Can\'t find {0}'.format(S3_CREDENTIALS_FILE)
   copy_to_environment(S3_CREDENTIALS_FILE)
 
+  if 'TARGET_ARCH' in os.environ:
+    return run_ci(['-t', os.environ['TARGET_ARCH']])
+
   if sys.platform in ['win32', 'cygwin']:
     return (run_ci(['-t', 'x64']) or
             run_ci(['-t', 'ia32']))
   elif sys.platform == 'linux2':
-    if 'TARGET_ARCH' in os.environ:
-      return run_ci(['-t', os.environ['TARGET_ARCH']])
-    else:
-      return (run_ci(['-t', 'x64']) or
-              run_ci(['-t', 'ia32']) or
-              run_ci(['-t', 'arm']))
+    return (run_ci(['-t', 'x64']) or
+            run_ci(['-t', 'ia32']) or
+            run_ci(['-t', 'arm']))
   else:
     return run_ci([])
 

--- a/script/cibuild-libchromiumcontent-linux-arm
+++ b/script/cibuild-libchromiumcontent-linux-arm
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export TARGET_ARCH=arm
+
+script/cibuild-libchromiumcontent-linux

--- a/script/cibuild-libchromiumcontent-linux-ia32
+++ b/script/cibuild-libchromiumcontent-linux-ia32
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export TARGET_ARCH=ia32
+
+script/cibuild-libchromiumcontent-linux

--- a/script/cibuild-libchromiumcontent-linux-x64
+++ b/script/cibuild-libchromiumcontent-linux-x64
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export TARGET_ARCH=x64
+
+script/cibuild-libchromiumcontent-linux


### PR DESCRIPTION
Split up the Linux CI into three jobs for each target architecture, x64, ia32, and arm.

This allows individual statuses for each build and the ability to run each build in parallel (someday).