### PR TITLE
Ship simd_c.pdb for shared_library build

### DIFF
--- a/script/create-dist
+++ b/script/create-dist
@@ -172,6 +172,7 @@ BINARIES_SHARED_LIBRARY = {
     os.path.join('obj', 'ppapi', 'cpp', 'objects_cc.pdb'),
     os.path.join('obj', 'ppapi', 'cpp', 'private', 'internal_module_cc.pdb'),
     os.path.join('obj', 'third_party', 'libjpeg_turbo', 'libjpeg_c.pdb'),
+    os.path.join('obj', 'third_party', 'libjpeg_turbo', 'simd_c.pdb'),
     os.path.join('obj', 'third_party', 'libyuv', 'libyuv_cc.pdb'),
     os.path.join('obj', 'third_party', 'webrtc', 'modules', 'desktop_capture', 'desktop_capture_cc.pdb'),
     os.path.join('obj', 'third_party', 'webrtc', 'modules', 'desktop_capture', 'desktop_capture_differ_sse2_cc.pdb'),


### PR DESCRIPTION
Fix the warning:

```
libyuv.lib(jsimd_x86_64.obj) : warning LNK4099: PDB 'simd_c.pdb' was not found with 'libyuv.lib(jsimd_x86_64.obj)' or at 'C:\cygwin\home\zcbenz\codes\electron\out\D\simd_c.pdb'; linking object as if no debug info
```