### PR TITLE
Add HeapSnapshotGenerator crash patch

### DIFF
--- a/patches/v8/heap-snapshot-generator.patch
+++ b/patches/v8/heap-snapshot-generator.patch
@@ -1,0 +1,34 @@
+diff --git a/src/profiler/heap-snapshot-generator.cc b/src/profiler/heap-snapshot-generator.cc
+index 2fd682e..ae44227 100644
+--- a/src/profiler/heap-snapshot-generator.cc
++++ b/src/profiler/heap-snapshot-generator.cc
+@@ -2491,6 +2491,20 @@ HeapSnapshotGenerator::HeapSnapshotGenerator(
+       heap_(heap) {
+ }
+ 
++namespace {
++class NullContextScope {
++ public:
++  explicit NullContextScope(Isolate* isolate)
++      : isolate_(isolate), prev_(isolate->context()) {
++    isolate_->set_context(nullptr);
++  }
++  ~NullContextScope() { isolate_->set_context(prev_); }
++
++ private:
++  Isolate* isolate_;
++  Context* prev_;
++};
++}  //  namespace
+ 
+ bool HeapSnapshotGenerator::GenerateSnapshot() {
+   v8_heap_explorer_.TagGlobalObjects();
+@@ -2504,6 +2518,8 @@ bool HeapSnapshotGenerator::GenerateSnapshot() {
+   heap_->CollectAllGarbage(Heap::kMakeHeapIterableMask,
+                            GarbageCollectionReason::kHeapProfiler);
+ 
++  NullContextScope null_context_scope(heap_->isolate());
++
+ #ifdef VERIFY_HEAP
+   Heap* debug_heap = heap_;
+   if (FLAG_verify_heap) {


### PR DESCRIPTION
Pulls in https://codereview.chromium.org/2669393002 to prevent crashes when taking heap snapshots, https://bugs.chromium.org/p/chromium/issues/detail?id=661223

This can be dropped once Chrome 58 is upgraded to.

Refs https://github.com/electron/electron/issues/8791