### PR TITLE
Remove verification of external snapshot data

### DIFF
--- a/patches/verify_snapshot.patch
+++ b/patches/verify_snapshot.patch
@@ -1,0 +1,25 @@
+diff --git a/gin/gin.gyp b/gin/gin.gyp
+index 0ea039f..7d3b8975 100644
+--- a/gin/gin.gyp
++++ b/gin/gin.gyp
+@@ -84,20 +84,6 @@
+         'wrappable.h',
+         'wrapper_info.cc',
+       ],
+-      'conditions': [
+-        ['v8_use_external_startup_data==1 and OS=="win"', {
+-          'dependencies': [
+-            'gin_v8_snapshot_fingerprint',
+-            '../crypto/crypto.gyp:crypto',
+-          ],
+-          'sources': [
+-            '<(gin_gen_path)/v8_snapshot_fingerprint.cc',
+-          ],
+-          'defines': [
+-            'V8_VERIFY_EXTERNAL_STARTUP_DATA',
+-          ]
+-        }],
+-      ],
+     },
+     {
+       'target_name': 'gin_v8_snapshot_fingerprint',

--- a/script/cibuild-libchromiumcontent-linux-arm
+++ b/script/cibuild-libchromiumcontent-linux-arm
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export TARGET_ARCH=arm
+
+script/cibuild-libchromiumcontent-linux

--- a/script/cibuild-libchromiumcontent-linux-ia32
+++ b/script/cibuild-libchromiumcontent-linux-ia32
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export TARGET_ARCH=ia32
+
+script/cibuild-libchromiumcontent-linux

--- a/script/cibuild-libchromiumcontent-linux-x64
+++ b/script/cibuild-libchromiumcontent-linux-x64
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export TARGET_ARCH=x64
+
+script/cibuild-libchromiumcontent-linux

--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -1,0 +1,35 @@
+function Run-Command([scriptblock]$Command, [switch]$Fatal, [switch]$Quiet) {
+  $output = ""
+  try {
+    if ($Quiet) {
+      $output = & $Command 2>&1
+    } else {
+      & $Command
+    }
+  } catch {
+    throw
+  }
+
+  if (!$Fatal) {
+    return
+  }
+
+  $exitCode = 0
+  if ($LastExitCode -ne 0) {
+    $exitCode = $LastExitCode
+  } elseif (!$?) {
+    $exitCode = 1
+  } else {
+    return
+  }
+
+  $error = "Error executing command ``$Command``."
+  if ($output) {
+    $error += " Output:" + [System.Environment]::NewLine + $output
+  }
+  Write-Output $error
+  exit $exitCode
+}
+
+Write-Output ""
+Run-Command -Fatal { python .\script\cibuild }


### PR DESCRIPTION
Backports https://codereview.chromium.org/2680653002 to Chrome 52 so Atom can use snapshots on Windows against Electron 1.3.

Refs https://github.com/atom/atom/pull/13916

/cc @electron/atom 