### PR TITLE
Dont include widevine stub code in non component build

### DIFF
--- a/chromiumcontent/build_libs.py
+++ b/chromiumcontent/build_libs.py
@@ -81,7 +81,6 @@ with open(args.out, 'w') as out:
             "third_party/sqlite",
             "third_party/sudden_motion_sensor",
             "third_party/usrsctp",
-            "third_party/widevine/cdm/widevinecdm",
             "third_party/woff2",
             "third_party/zlib",
             "tools",


### PR DESCRIPTION
This fixes widevine failures with release builds of Electron.

Fixes https://github.com/electron/electron/issues/8824
Ref https://github.com/electron/electron/issues/6516

Since we ask users to use the adapter and plugin from the official chrome builds, do we need to build the `widevinecdmadapter` target ?