### PR TITLE
Add patch to disable snapshot verification on Windows

### DIFF
--- a/patches/verify_snapshot.patch
+++ b/patches/verify_snapshot.patch
@@ -1,0 +1,16 @@
+diff --git a/gin/BUILD.gn b/gin/BUILD.gn
+index 72d0125..bdf9ff9 100644
+--- a/gin/BUILD.gn
++++ b/gin/BUILD.gn
+@@ -86,11 +86,6 @@ component("gin") {
+     "//base/third_party/dynamic_annotations",
+     "//crypto",
+   ]
+-  if (v8_use_external_startup_data && is_win) {
+-    public_deps += [ ":gin_v8_snapshot_fingerprint" ]
+-    sources += [ "$target_gen_dir/v8_snapshot_fingerprint.cc" ]
+-    defines += [ "V8_VERIFY_EXTERNAL_STARTUP_DATA" ]
+-  }
+ 
+   if (is_mac) {
+     libs = [ "CoreFoundation.framework" ]


### PR DESCRIPTION
Adds the patch from #271 against master.

Pulls in https://codereview.chromium.org/2680653002