### PR TITLE
Streamline build output directories

### DIFF
--- a/script/build
+++ b/script/build
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 
-from lib.config import get_configuration, get_output_dir
+from lib.config import get_output_dir
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -34,12 +34,9 @@ def main():
     if args.component == 'all' or args.component == component:
       if component == 'shared_library' and args.no_shared_library:
         continue
-      out_dir = os.path.join(SOURCE_ROOT, 'src',
-                             get_output_dir(target_arch, component))
-      config = get_configuration(target_arch)
-      config_dir = os.path.relpath(os.path.join(out_dir, config))
+      out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
       target = 'chromiumcontent:chromiumcontent'
-      subprocess.check_call([NINJA, '-C', config_dir, target], env=env)
+      subprocess.check_call([NINJA, '-C', os.path.relpath(out_dir), target], env=env)
 
 
 def parse_args():

--- a/script/create-dist
+++ b/script/create-dist
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import zipfile
 
-from lib.config import get_configuration, get_output_dir
+from lib.config import get_output_dir
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -308,10 +308,9 @@ def main():
 
   for component in COMPONENTS:
     if args.component == 'all' or args.component == component:
-      output_dir = os.path.join(SRC_DIR, get_output_dir(target_arch, component))
-      copy_binaries(target_arch, component, output_dir, create_debug_archive)
-      copy_generated_sources(target_arch, component, output_dir)
-      copy_locales(target_arch, component, output_dir)
+      copy_binaries(target_arch, component, create_debug_archive)
+      copy_generated_sources(target_arch, component)
+      copy_locales(target_arch, component)
 
   copy_ffmpeg(target_arch)
   copy_sources()
@@ -359,8 +358,8 @@ def copy_with_blacklist(target_arch, src, dest):
   shutil.copy2(src, dest)
 
 
-def copy_binaries(target_arch, component, output_dir, create_debug_archive):
-  config_dir = os.path.join(output_dir, get_configuration(target_arch))
+def copy_binaries(target_arch, component, create_debug_archive):
+  output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
   target_dir = os.path.join(MAIN_DIR, component)
   mkdir_p(target_dir)
 
@@ -368,10 +367,10 @@ def copy_binaries(target_arch, component, output_dir, create_debug_archive):
   if component == 'shared_library':
     binaries += BINARIES_SHARED_LIBRARY[TARGET_PLATFORM]
   for binary in binaries:
-    copy_with_blacklist(target_arch, os.path.join(config_dir, binary), target_dir)
+    copy_with_blacklist(target_arch, os.path.join(output_dir, binary), target_dir)
 
   # Copy all static libraries from chromiumcontent
-  for library in glob.glob(os.path.join(config_dir, 'obj', 'chromiumcontent', '*.' + STATIC_LIBRARY_SUFFIX)):
+  for library in glob.glob(os.path.join(output_dir, 'obj', 'chromiumcontent', '*.' + STATIC_LIBRARY_SUFFIX)):
     shutil.copy2(library, target_dir)
 
   if component == 'shared_library':
@@ -381,20 +380,20 @@ def copy_binaries(target_arch, component, output_dir, create_debug_archive):
 
   if TARGET_PLATFORM == 'darwin':
     if component == 'shared_library':
-      for library in glob.glob(os.path.join(config_dir, '*.dylib')):
+      for library in glob.glob(os.path.join(output_dir, '*.dylib')):
         copy_with_blacklist(target_arch, library, target_dir)
 
   if TARGET_PLATFORM == 'win32':
     if component == 'shared_library':
       # out/Release/*.dll(.lib)
-      for dll in glob.glob(os.path.join(config_dir, '*.dll')):
+      for dll in glob.glob(os.path.join(output_dir, '*.dll')):
         lib = dll + '.lib'
         if os.path.exists(lib):
           copy_with_blacklist(target_arch, dll, target_dir)
           copy_with_blacklist(target_arch, lib, target_dir)
     elif component == 'static_library':
       # out/Release/*.pdb
-      for root, _, filenames in os.walk(config_dir):
+      for root, _, filenames in os.walk(output_dir):
         for pdb in filenames:
           if pdb.endswith('.pdb'):
             shutil.copy2(os.path.join(root, pdb), target_dir)
@@ -402,7 +401,7 @@ def copy_binaries(target_arch, component, output_dir, create_debug_archive):
   if TARGET_PLATFORM == 'linux':
     if component == 'shared_library':
       # out/Release/lib/*.so
-      for library in glob.glob(os.path.join(config_dir, '*.so')):
+      for library in glob.glob(os.path.join(output_dir, '*.so')):
         copy_with_blacklist(target_arch, library, target_dir)
 
   if TARGET_PLATFORM in ['linux', 'darwin']:
@@ -432,26 +431,24 @@ def copy_binaries(target_arch, component, output_dir, create_debug_archive):
     else:
       binaries = [ 'chromedriver', 'mksnapshot' ]
 
-    ffmpeg_output_dir = os.path.join(SRC_DIR,
-                                     get_output_dir(target_arch, 'ffmpeg'),
-                                     get_configuration(target_arch))
+    ffmpeg_output_dir = get_output_dir(SOURCE_ROOT, target_arch, 'ffmpeg')
     for binary in binaries:
       shutil.copy2(os.path.join(ffmpeg_output_dir, binary), target_dir)
 
 
-def copy_generated_sources(target_arch, component, output_dir):
-  config = get_configuration(target_arch)
+def copy_generated_sources(target_arch, component):
+  output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
   target_dir = os.path.join(MAIN_DIR, component)
   for include_path in GENERATED_INCLUDE_DIRS:
     copy_headers(include_path,
-                 relative_to=os.path.join(output_dir, config, 'gen'),
+                 relative_to=os.path.join(output_dir, 'gen'),
                  destination=os.path.join(target_dir, 'gen'))
 
-def copy_locales(target_arch, component, output_dir):
-  config = get_configuration(target_arch)
+def copy_locales(target_arch, component):
+  output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
   target_dir = os.path.join(MAIN_DIR, component, 'locales')
   mkdir_p(target_dir)
-  src_dir = os.path.join(output_dir, config, 'gen', 'content', 'app', 'strings')
+  src_dir = os.path.join(output_dir, 'gen', 'content', 'app', 'strings')
   for src_file in glob.glob(os.path.join(src_dir, 'content_strings_*.pak')):
     filename = os.path.basename(src_file)
     new_name = re.sub('content_strings_', '', filename)
@@ -470,9 +467,7 @@ def copy_sources():
 
 
 def copy_ffmpeg(target_arch):
-  output_dir = os.path.join(SRC_DIR,
-                            get_output_dir(target_arch, 'ffmpeg'),
-                            get_configuration(target_arch))
+  output_dir = get_output_dir(SOURCE_ROOT, target_arch, 'ffmpeg')
   if TARGET_PLATFORM == 'darwin':
     binary = 'libffmpeg.dylib'
   elif TARGET_PLATFORM == 'linux':

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -1,29 +1,7 @@
 #!/usr/bin/env python
 
-import sys
+import os
 
 
-def get_output_dir(target_arch, component):
-  # Build in "out_ffmpeg" for Chromium branding of ffmpeg.
-  if component == 'ffmpeg':
-    return 'out_ffmpeg'
-
-  # Build in "out_component" for component build.
-  output_dir = 'out'
-  if component == 'shared_library':
-    output_dir += '_component'
-
-  # Build in "out_32" for 32bit target.
-  if target_arch == 'ia32':
-    output_dir += '_32'
-  elif target_arch == 'arm':
-    output_dir += '_arm'
-
-  return output_dir
-
-
-def get_configuration(target_arch):
-  config = 'Release'
-  if target_arch == 'x64' and sys.platform in ['win32', 'cygwin']:
-    config += '_x64'
-  return config
+def get_output_dir(source_root, target_arch, component):
+  return os.path.join(source_root, 'src', 'out-' + target_arch, component)

--- a/script/update
+++ b/script/update
@@ -11,7 +11,7 @@ import tarfile
 import tempfile
 import urllib2
 
-from lib.config import get_configuration, get_output_dir
+from lib.config import get_output_dir
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -207,9 +207,8 @@ def run_gn(target_arch, defines):
 
   for component in COMPONENTS:
     args = 'import("//chromiumcontent/args/{0}.gn") target_cpu="{1}"'.format(component, target_cpu)
-    output_dir = os.path.join(get_output_dir(target_arch, component),
-                              get_configuration(target_arch))
-    subprocess.call([gn, 'gen', output_dir, '--args=' + args],
+    output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
+    subprocess.call([gn, 'gen', os.path.relpath(output_dir, SRC_DIR), '--args=' + args],
                     cwd=SRC_DIR, env=env)
 
 


### PR DESCRIPTION
This is to make the output directory structure more sensible in light of the new GN build. Each configuration (shared_library, etc.) has an equally named subdirectory under an architecture-based `out` directory, e.g.:
```
out-x64
├ ffmpeg
├ shared_library
└ static_library
```
 