### PR TITLE
Add patch to disable snapshot verification on Windows

### DIFF
--- a/patches/verify_snapshot.patch
+++ b/patches/verify_snapshot.patch
@@ -1,0 +1,25 @@
+diff --git a/gin/gin.gyp b/gin/gin.gyp
+index 0ea039f..7d3b8975 100644
+--- a/gin/gin.gyp
++++ b/gin/gin.gyp
+@@ -84,20 +84,6 @@
+         'wrappable.h',
+         'wrapper_info.cc',
+       ],
+-      'conditions': [
+-        ['v8_use_external_startup_data==1 and OS=="win"', {
+-          'dependencies': [
+-            'gin_v8_snapshot_fingerprint',
+-            '../crypto/crypto.gyp:crypto',
+-          ],
+-          'sources': [
+-            '<(gin_gen_path)/v8_snapshot_fingerprint.cc',
+-          ],
+-          'defines': [
+-            'V8_VERIFY_EXTERNAL_STARTUP_DATA',
+-          ]
+-        }],
+-      ],
+     },
+     {
+       'target_name': 'gin_v8_snapshot_fingerprint',

--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -1,0 +1,39 @@
+function Run-Command([scriptblock]$Command, [switch]$Fatal, [switch]$Quiet) {
+  $output = ""
+  try {
+    if ($Quiet) {
+      $output = & $Command 2>&1
+    } else {
+      & $Command
+    }
+  } catch {
+    throw
+  }
+
+  if (!$Fatal) {
+    return
+  }
+
+  $exitCode = 0
+  if ($LastExitCode -ne 0) {
+    $exitCode = $LastExitCode
+  } elseif (!$?) {
+    $exitCode = 1
+  } else {
+    return
+  }
+
+  $error = "Error executing command ``$Command``."
+  if ($output) {
+    $error += " Output:" + [System.Environment]::NewLine + $output
+  }
+  Write-Output $error
+  exit $exitCode
+}
+
+# Make the output width reeeeeaaaaaly wide so our output doesn't get hard-wrapped.
+# <http://stackoverflow.com/questions/978777/powershell-output-column-width>
+$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size -ArgumentList 5000, 25
+
+Write-Output ""
+Run-Command -Fatal { python .\script\cibuild }

--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -31,9 +31,5 @@ function Run-Command([scriptblock]$Command, [switch]$Fatal, [switch]$Quiet) {
   exit $exitCode
 }
 
-# Make the output width reeeeeaaaaaly wide so our output doesn't get hard-wrapped.
-# <http://stackoverflow.com/questions/978777/powershell-output-column-width>
-$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size -ArgumentList 5000, 25
-
 Write-Output ""
 Run-Command -Fatal { python .\script\cibuild }


### PR DESCRIPTION
Adds the patch from #271 against Chrome 53.

This is in case Atom needs a Electron 1.4.x release cut with this patch applied.

Pulls in https://codereview.chromium.org/2680653002

/cc @electron/atom 