### PR TITLE
Add patch to expose ScopedClipboardWriter::WriteData

### DIFF
--- a/patches/scoped_clipboard_writer.patch
+++ b/patches/scoped_clipboard_writer.patch
@@ -1,0 +1,57 @@
+diff --git a/ui/base/clipboard/scoped_clipboard_writer.cc b/ui/base/clipboard/scoped_clipboard_writer.cc
+index 6850cd460b1d..6d652cca59b4 100644
+--- a/ui/base/clipboard/scoped_clipboard_writer.cc
++++ b/ui/base/clipboard/scoped_clipboard_writer.cc
+@@ -102,17 +102,16 @@ void ScopedClipboardWriter::WriteImage(const SkBitmap& bitmap) {
+   objects_[Clipboard::CBF_SMBITMAP] = parameters;
+ }
+ 
+-void ScopedClipboardWriter::WritePickledData(
+-    const base::Pickle& pickle,
+-    const Clipboard::FormatType& format) {
++void ScopedClipboardWriter::WriteData(const char* data,
++                                      int size,
++                                      const Clipboard::FormatType& format) {
+   std::string format_string = format.Serialize();
+   Clipboard::ObjectMapParam format_parameter(format_string.begin(),
+                                              format_string.end());
+   Clipboard::ObjectMapParam data_parameter;
+ 
+-  data_parameter.resize(pickle.size());
+-  memcpy(const_cast<char*>(&data_parameter.front()),
+-         pickle.data(), pickle.size());
++  data_parameter.resize(size);
++  memcpy(const_cast<char*>(&data_parameter.front()), data, size);
+ 
+   Clipboard::ObjectMapParams parameters;
+   parameters.push_back(format_parameter);
+@@ -120,6 +119,13 @@ void ScopedClipboardWriter::WritePickledData(
+   objects_[Clipboard::CBF_DATA] = parameters;
+ }
+ 
++void ScopedClipboardWriter::WritePickledData(
++    const base::Pickle& pickle,
++    const Clipboard::FormatType& format) {
++  WriteData(reinterpret_cast<const char*>(pickle.data()), pickle.size(),
++            format);
++}
++
+ void ScopedClipboardWriter::Reset() {
+   url_text_.clear();
+   objects_.clear();
+diff --git a/ui/base/clipboard/scoped_clipboard_writer.h b/ui/base/clipboard/scoped_clipboard_writer.h
+index a7e064561ca9..d5a1b76bc6a7 100644
+--- a/ui/base/clipboard/scoped_clipboard_writer.h
++++ b/ui/base/clipboard/scoped_clipboard_writer.h
+@@ -61,6 +61,11 @@ class UI_BASE_EXPORT ScopedClipboardWriter {
+   // Used by WebKit to determine whether WebKit wrote the clipboard last
+   void WriteWebSmartPaste();
+ 
++  // Adds arbitrary data to clipboard.
++  void WriteData(const char* data,
++                 int size,
++                 const Clipboard::FormatType& format);
++
+   // Adds arbitrary pickled data to clipboard.
+   void WritePickledData(const base::Pickle& pickle,
+                         const Clipboard::FormatType& format);


### PR DESCRIPTION
This is required to implement `clipboard.writeBuffer()` in Electron.

This patch has also been upstreamed:
https://codereview.chromium.org/2777723002