### PR TITLE
Don't include ffmpeg as a build lib

### DIFF
--- a/chromiumcontent/build_libs.py
+++ b/chromiumcontent/build_libs.py
@@ -46,7 +46,6 @@ with open(args.out, 'w') as out:
             "third_party/ced/ced",
             "third_party/decklink",
             "third_party/expat",
-            "third_party/ffmpeg",
             "third_party/flac",
             "third_party/harfbuzz-ng",
             "third_party/iaccessible2",


### PR DESCRIPTION
Previously this was statically linking in `ffmpeg` which meant you couldn't swap in the version without the proprietary codecs.

Closes #268 

### 1.4.15

```sh
> ./node_modules/electron/dist/electron -v
v1.4.15
> nm -D node_modules/electron/dist/electron | grep av_buffer_create
                 U av_buffer_create
> readelf -d ./node_modules/electron/dist/electron | grep ffmpeg
 0x0000000000000001 (NEEDED)             Shared library: [libffmpeg.so]

```

### 1.6.4

```sh
> ./node_modules/electron/dist/electron -v
v1.6.4
> nm -D node_modules/electron/dist/electron | grep av_buffer_create
000000000349c7a0 T av_buffer_create
> readelf -d node_modules/electron/dist/electron | grep ffmpeg
```

### This branch

```sh
> ~/Downloads/electron-ffmpeg/electron -v
v1.6.5
> nm -D ~/Downloads/electron-ffmpeg/electron | grep av_buffer_create
                 U av_buffer_create
> readelf -d ~/Downloads/electron-ffmpeg/electron | grep ffmpeg
 0x0000000000000001 (NEEDED)             Shared library: [libffmpeg.so]
```

### Testing

Tested using http://www.quirksmode.org/html5/tests/video.html

| With proprietary codecs | Without proprietary codecs |
|---|---|
| <img width="819" alt="screen shot 2017-03-29 at 10 00 16 am" src="https://cloud.githubusercontent.com/assets/671378/24466699/9e3e1758-1466-11e7-9589-ed9213065a04.png"> | <img width="821" alt="screen shot 2017-03-29 at 10 00 50 am" src="https://cloud.githubusercontent.com/assets/671378/24466698/9e3dc0b4-1466-11e7-9ec4-30440ea151d4.png"> |

