### PR TITLE
Update Skia to dd45f8195783efc7b8044b006eae5ea5ac127cc2

### DIFF
--- a/patches/skia-update.patch
+++ b/patches/skia-update.patch
@@ -1,0 +1,1086 @@
+diff --git a/third_party/skia/gm/imagealphathreshold.cpp b/third_party/skia/gm/imagealphathreshold.cpp
+index 1e90f76bf0..302cdeea52 100644
+--- a/third_party/skia/gm/imagealphathreshold.cpp
++++ b/third_party/skia/gm/imagealphathreshold.cpp
+@@ -7,27 +7,25 @@
+ 
+ #include "gm.h"
+ #include "SkAlphaThresholdFilter.h"
+-#include "SkRandom.h"
++#include "SkOffsetImageFilter.h"
+ #include "SkSurface.h"
+ 
+ #define WIDTH 500
+ #define HEIGHT 500
+ 
+-namespace {
+-
+-void draw_rects(SkCanvas* canvas) {
++static void draw_rects(SkCanvas* canvas) {
+     SkPaint rectPaint;
+-    rectPaint.setColor(0xFF0000FF);
++    rectPaint.setColor(SK_ColorBLUE);
+     canvas->drawRect(SkRect::MakeXYWH(0, 0, WIDTH / 2, HEIGHT / 2), rectPaint);
+     rectPaint.setColor(0xBFFF0000);
+     canvas->drawRect(SkRect::MakeXYWH(WIDTH / 2, 0, WIDTH / 2, HEIGHT / 2), rectPaint);
+     rectPaint.setColor(0x3F00FF00);
+     canvas->drawRect(SkRect::MakeXYWH(0, HEIGHT / 2, WIDTH / 2, HEIGHT / 2), rectPaint);
+-    rectPaint.setColor(0x00000000);
++    rectPaint.setColor(SK_ColorTRANSPARENT);
+     canvas->drawRect(SkRect::MakeXYWH(WIDTH / 2, HEIGHT / 2, WIDTH / 2, HEIGHT / 2), rectPaint);
+ }
+ 
+-SkPaint create_filter_paint(SkImageFilter::CropRect* cropRect = nullptr) {
++static SkPaint create_filter_paint(SkImageFilter::CropRect* cropRect = nullptr) {
+     SkIRect rects[2];
+     rects[0] = SkIRect::MakeXYWH(0, 150, WIDTH, HEIGHT - 300);
+     rects[1] = SkIRect::MakeXYWH(150, 0, WIDTH - 300, HEIGHT);
+@@ -35,18 +33,15 @@ SkPaint create_filter_paint(SkImageFilter::CropRect* cropRect = nullptr) {
+     region.setRects(rects, 2);
+ 
+     SkPaint paint;
+-    paint.setImageFilter(SkAlphaThresholdFilter::Make(region, 0.2f, 0.7f, nullptr, cropRect));
++    sk_sp<SkImageFilter> offset(SkOffsetImageFilter::Make(25, 25, nullptr));
++    paint.setImageFilter(SkAlphaThresholdFilter::Make(region, 0.2f, 0.7f, std::move(offset), cropRect));
+     return paint;
+ }
+ 
+-};
+-
+-namespace skiagm {
+-
+-class ImageAlphaThresholdGM : public GM {
++class ImageAlphaThresholdGM : public skiagm::GM {
+ public:
+     ImageAlphaThresholdGM(bool useCropRect) : fUseCropRect(useCropRect) {
+-        this->setBGColor(0xFFFFFFFF);
++        this->setBGColor(SK_ColorWHITE);
+     }
+ 
+ protected:
+@@ -87,8 +82,31 @@ private:
+     typedef GM INHERITED;
+ };
+ 
++// Create a 'width' x 'height' SkSurface that matches the colorType of 'canvas' as
++// best we can
++static sk_sp<SkSurface> make_color_matching_surface(SkCanvas* canvas, int width, int height,
++                                                    SkAlphaType alphaType) {
++
++    SkColorType ct = canvas->imageInfo().colorType();
++    sk_sp<SkColorSpace> cs(sk_ref_sp(canvas->imageInfo().colorSpace()));
++
++    if (kUnknown_SkColorType == ct) {
++        // For backends that aren't yet color-space aware we just fallback to N32.
++        ct = kN32_SkColorType;
++        cs = nullptr;
++    }
++
++    SkImageInfo info = SkImageInfo::Make(width, height, ct, alphaType, std::move(cs));
++
++    sk_sp<SkSurface> result = canvas->makeSurface(info);
++    if (!result) {
++        result = SkSurface::MakeRaster(info);
++    }
++
++    return result;
++}
+ 
+-class ImageAlphaThresholdSurfaceGM : public GM {
++class ImageAlphaThresholdSurfaceGM : public skiagm::GM {
+ public:
+     ImageAlphaThresholdSurfaceGM() {
+         this->setBGColor(0xFFFFFFFF);
+@@ -104,12 +122,17 @@ protected:
+     }
+ 
+     void onDraw(SkCanvas* canvas) override {
+-        SkImageInfo info = SkImageInfo::MakeS32(WIDTH, HEIGHT, kOpaque_SkAlphaType);
+-        auto surface(canvas->makeSurface(info));
+-        if (nullptr == surface) {
+-            surface = SkSurface::MakeRaster(info);
+-        }
+-        surface->getCanvas()->clear(SK_ColorWHITE);
++        SkMatrix matrix;
++        matrix.reset();
++        matrix.setTranslate(WIDTH * .1f, HEIGHT * .1f);
++        matrix.postScale(.8f, .8f);
++
++        canvas->concat(matrix);
++
++        sk_sp<SkSurface> surface(make_color_matching_surface(canvas, WIDTH, HEIGHT,
++                                                             kPremul_SkAlphaType));
++
++        surface->getCanvas()->clear(SK_ColorTRANSPARENT);
+         draw_rects(surface->getCanvas());
+ 
+         SkPaint paint = create_filter_paint();
+@@ -118,7 +141,7 @@ protected:
+     }
+ 
+ private:
+-    typedef GM INHERITED;
++    typedef skiagm::GM INHERITED;
+ };
+ 
+ //////////////////////////////////////////////////////////////////////////////
+@@ -126,5 +149,3 @@ private:
+ DEF_GM(return new ImageAlphaThresholdGM(true);)
+ DEF_GM(return new ImageAlphaThresholdGM(false);)
+ DEF_GM(return new ImageAlphaThresholdSurfaceGM();)
+-
+-}
+diff --git a/third_party/skia/gm/pathfill.cpp b/third_party/skia/gm/pathfill.cpp
+index 3496cfd04d..2562e7c9a5 100644
+--- a/third_party/skia/gm/pathfill.cpp
++++ b/third_party/skia/gm/pathfill.cpp
+@@ -50,15 +50,15 @@ static SkScalar make_oval(SkPath* path) {
+     return SkIntToScalar(30);
+ }
+ 
+-static SkScalar make_sawtooth(SkPath* path) {
++static SkScalar make_sawtooth(SkPath* path, int teeth) {
+     SkScalar x = SkIntToScalar(20);
+     SkScalar y = SkIntToScalar(20);
+     const SkScalar x0 = x;
+-    const SkScalar dx = SK_Scalar1 * 5;
+-    const SkScalar dy = SK_Scalar1 * 10;
++    const SkScalar dx = SkIntToScalar(5);
++    const SkScalar dy = SkIntToScalar(10);
+ 
+     path->moveTo(x, y);
+-    for (int i = 0; i < 32; i++) {
++    for (int i = 0; i < teeth; i++) {
+         x += dx;
+         path->lineTo(x, y - dy);
+         x += dx;
+@@ -70,6 +70,44 @@ static SkScalar make_sawtooth(SkPath* path) {
+     return SkIntToScalar(30);
+ }
+ 
++static SkScalar make_sawtooth_3(SkPath* path) { return make_sawtooth(path, 3); }
++static SkScalar make_sawtooth_32(SkPath* path) { return make_sawtooth(path, 32); }
++
++static SkScalar make_house(SkPath* path) {
++    path->moveTo(21, 23);
++    path->lineTo(21, 11.534f);
++    path->lineTo(22.327f, 12.741f);
++    path->lineTo(23.673f, 11.261f);
++    path->lineTo(12, 0.648f);
++    path->lineTo(8, 4.285f);
++    path->lineTo(8, 2);
++    path->lineTo(4, 2);
++    path->lineTo(4, 7.921f);
++    path->lineTo(0.327f, 11.26f);
++    path->lineTo(1.673f, 12.74f);
++    path->lineTo(3, 11.534f);
++    path->lineTo(3, 23);
++    path->lineTo(11, 23);
++    path->lineTo(11, 18);
++    path->lineTo(13, 18);
++    path->lineTo(13, 23);
++    path->lineTo(21, 23);
++    path->close();
++    path->lineTo(9, 16);
++    path->lineTo(9, 21);
++    path->lineTo(5, 21);
++    path->lineTo(5, 9.715f);
++    path->lineTo(12, 3.351f);
++    path->lineTo(19, 9.715f);
++    path->lineTo(19, 21);
++    path->lineTo(15, 21);
++    path->lineTo(15, 16);
++    path->lineTo(9, 16);
++    path->close();
++    path->offset(20, 0);
++    return SkIntToScalar(30);
++}
++
+ static SkScalar make_star(SkPath* path, int n) {
+     const SkScalar c = SkIntToScalar(45);
+     const SkScalar r = SkIntToScalar(20);
+@@ -102,15 +140,60 @@ static SkScalar make_line(SkPath* path) {
+     return SkIntToScalar(40);
+ }
+ 
++static SkScalar make_info(SkPath* path) {
++    path->moveTo(24, 4);
++    path->cubicTo(12.94999980926514f,
++                  4,
++                  4,
++                  12.94999980926514f,
++                  4,
++                  24);
++    path->cubicTo(4,
++                  35.04999923706055f,
++                  12.94999980926514f,
++                  44,
++                  24,
++                  44);
++    path->cubicTo(35.04999923706055f,
++                  44,
++                  44,
++                  35.04999923706055f,
++                  44,
++                  24);
++    path->cubicTo(44,
++                  12.95000076293945f,
++                  35.04999923706055f,
++                  4,
++                  24,
++                  4);
++    path->close();
++    path->moveTo(26, 34);
++    path->lineTo(22, 34);
++    path->lineTo(22, 22);
++    path->lineTo(26, 22);
++    path->lineTo(26, 34);
++    path->close();
++    path->moveTo(26, 18);
++    path->lineTo(22, 18);
++    path->lineTo(22, 14);
++    path->lineTo(26, 14);
++    path->lineTo(26, 18);
++    path->close();
++
++    return SkIntToScalar(44);
++}
++
+ constexpr MakePathProc gProcs[] = {
+     make_frame,
+     make_triangle,
+     make_rect,
+     make_oval,
+-    make_sawtooth,
++    make_sawtooth_32,
+     make_star_5,
+     make_star_13,
+     make_line,
++    make_house,
++    make_sawtooth_3,
+ };
+ 
+ #define N   SK_ARRAY_COUNT(gProcs)
+@@ -118,11 +201,14 @@ constexpr MakePathProc gProcs[] = {
+ class PathFillGM : public skiagm::GM {
+     SkPath  fPath[N];
+     SkScalar fDY[N];
++    SkPath  fInfoPath;
+ protected:
+     void onOnceBeforeDraw() override {
+         for (size_t i = 0; i < N; i++) {
+             fDY[i] = gProcs[i](&fPath[i]);
+         }
++
++        (void) make_info(&fInfoPath);
+     }
+ 
+ 
+@@ -142,6 +228,10 @@ protected:
+             canvas->drawPath(fPath[i], paint);
+             canvas->translate(SkIntToScalar(0), fDY[i]);
+         }
++
++        canvas->scale(0.300000011920929f, 0.300000011920929f);
++        canvas->translate(50, 50);
++        canvas->drawPath(fInfoPath, paint);
+     }
+ 
+ private:
+diff --git a/third_party/skia/include/core/SkColorSpace.h b/third_party/skia/include/core/SkColorSpace.h
+index 2139cf8451..6c0db85d7b 100644
+--- a/third_party/skia/include/core/SkColorSpace.h
++++ b/third_party/skia/include/core/SkColorSpace.h
+@@ -33,8 +33,8 @@ struct SK_API SkColorSpacePrimaries {
+  *  Contains the coefficients for a common transfer function equation, specified as
+  *  a transformation from a curved space to linear.
+  *
+- *  LinearVal = E*InputVal + F        , for 0.0f <= InputVal <  D
+- *  LinearVal = (A*InputVal + B)^G + C, for D    <= InputVal <= 1.0f
++ *  LinearVal = C*InputVal + F        , for 0.0f <= InputVal <  D
++ *  LinearVal = (A*InputVal + B)^G + E, for D    <= InputVal <= 1.0f
+  *
+  *  Function is undefined if InputVal is not in [ 0.0f, 1.0f ].
+  *  Resulting LinearVals must be in [ 0.0f, 1.0f ].
+diff --git a/third_party/skia/include/gpu/GrTextureProvider.h b/third_party/skia/include/gpu/GrTextureProvider.h
+index efecc96358..f3ecfed0ef 100644
+--- a/third_party/skia/include/gpu/GrTextureProvider.h
++++ b/third_party/skia/include/gpu/GrTextureProvider.h
+@@ -139,6 +139,7 @@ protected:
+         kExact_ScratchTextureFlag           = 0x1,
+         kNoPendingIO_ScratchTextureFlag     = 0x2, // (http://skbug.com/4156)
+         kNoCreate_ScratchTextureFlag        = 0x4,
++        kLastScratchTextureFlag = kNoCreate_ScratchTextureFlag
+     };
+ 
+     /** A common impl for GrTextureProvider and GrResourceProvider variants. */
+diff --git a/third_party/skia/src/core/SkColorLookUpTable.cpp b/third_party/skia/src/core/SkColorLookUpTable.cpp
+index 73f3e8836c..76e0bca369 100644
+--- a/third_party/skia/src/core/SkColorLookUpTable.cpp
++++ b/third_party/skia/src/core/SkColorLookUpTable.cpp
+@@ -92,6 +92,13 @@ void SkColorLookUpTable::interp3D(float dst[3], float src[3]) const {
+             }
+         }
+ 
++        // TODO(raftias): Figure out why this is going out of range (up to 1.0359!)
++        if (dst[i] > 1.f) {
++            dst[i] = 1.f;
++        } else if (dst[i] < 0.f) {
++            dst[i] = 0.f;
++        }
++
+         // Increment the table ptr in order to handle the next component.
+         // Note that this is the how table is designed: all of nXXX
+         // variables are multiples of 3 because there are 3 output
+diff --git a/third_party/skia/src/core/SkColorSpacePriv.h b/third_party/skia/src/core/SkColorSpacePriv.h
+index 73038738ff..606442d160 100644
+--- a/third_party/skia/src/core/SkColorSpacePriv.h
++++ b/third_party/skia/src/core/SkColorSpacePriv.h
+@@ -37,7 +37,7 @@ static inline bool is_valid_transfer_fn(const SkColorSpaceTransferFn& coeffs) {
+         }
+     }
+ 
+-    if (coeffs.fD == 1.0f) {
++    if (coeffs.fD >= 1.0f) {
+         // Y = eX + f          for always
+         if (0.0f == coeffs.fE) {
+             SkColorSpacePrintf("E is zero, constant transfer function is "
+@@ -46,13 +46,13 @@ static inline bool is_valid_transfer_fn(const SkColorSpaceTransferFn& coeffs) {
+         }
+     }
+ 
+-    if ((0.0f == coeffs.fA || 0.0f == coeffs.fG) && 0.0f == coeffs.fE) {
++    if ((0.0f == coeffs.fA || 0.0f == coeffs.fG) && 0.0f == coeffs.fC) {
+         SkColorSpacePrintf("A or G, and E are zero, constant transfer function "
+                            "is nonsense");
+         return false;
+     }
+ 
+-    if (coeffs.fE < 0.0f) {
++    if (coeffs.fC < 0.0f) {
+         SkColorSpacePrintf("Transfer function must be increasing");
+         return false;
+     }
+@@ -66,13 +66,13 @@ static inline bool is_valid_transfer_fn(const SkColorSpaceTransferFn& coeffs) {
+ }
+ 
+ static inline bool is_almost_srgb(const SkColorSpaceTransferFn& coeffs) {
+-    return color_space_almost_equal(0.9479f, coeffs.fA) &&
+-           color_space_almost_equal(0.0521f, coeffs.fB) &&
+-           color_space_almost_equal(0.0000f, coeffs.fC) &&
+-           color_space_almost_equal(0.0405f, coeffs.fD) &&
+-           color_space_almost_equal(0.0774f, coeffs.fE) &&
+-           color_space_almost_equal(0.0000f, coeffs.fF) &&
+-           color_space_almost_equal(2.4000f, coeffs.fG);
++    return color_space_almost_equal(1.0f / 1.055f,   coeffs.fA) &&
++           color_space_almost_equal(0.055f / 1.055f, coeffs.fB) &&
++           color_space_almost_equal(1.0f / 12.92f,   coeffs.fC) &&
++           color_space_almost_equal(0.04045f,        coeffs.fD) &&
++           color_space_almost_equal(0.00000f,        coeffs.fE) &&
++           color_space_almost_equal(0.00000f,        coeffs.fF) &&
++           color_space_almost_equal(2.40000f,        coeffs.fG);
+ }
+ 
+ static inline bool is_almost_2dot2(const SkColorSpaceTransferFn& coeffs) {
+diff --git a/third_party/skia/src/core/SkColorSpaceXform.cpp b/third_party/skia/src/core/SkColorSpaceXform.cpp
+index 450a643cfc..cadf675988 100644
+--- a/third_party/skia/src/core/SkColorSpaceXform.cpp
++++ b/third_party/skia/src/core/SkColorSpaceXform.cpp
+@@ -117,13 +117,13 @@ static inline float clamp_0_1(float v) {
+ 
+ static void build_table_linear_from_gamma(float* outTable, float g, float a, float b, float c,
+                                           float d, float e, float f) {
+-    // Y = (aX + b)^g + c  for X >= d
+-    // Y = eX + f          otherwise
++    // Y = (aX + b)^g + e  for X >= d
++    // Y = cX + f          otherwise
+     for (float x = 0.0f; x <= 1.0f; x += (1.0f/255.0f)) {
+         if (x >= d) {
+-            *outTable++ = clamp_0_1(powf(a * x + b, g) + c);
++            *outTable++ = clamp_0_1(powf(a * x + b, g) + e);
+         } else {
+-            *outTable++ = clamp_0_1(e * x + f);
++            *outTable++ = clamp_0_1(c * x + f);
+         }
+     }
+ }
+@@ -173,26 +173,26 @@ static float inverse_parametric(float x, float g, float a, float b, float c, flo
+     // Assume that the gamma function is continuous, or this won't make much sense anyway.
+     // Plug in |d| to the first equation to calculate the new piecewise interval.
+     // Then simply use the inverse of the original functions.
+-    float interval = e * d + f;
++    float interval = c * d + f;
+     if (x < interval) {
+-        // X = (Y - F) / E
+-        if (0.0f == e) {
++        // X = (Y - F) / C
++        if (0.0f == c) {
+             // The gamma curve for this segment is constant, so the inverse is undefined.
+             // Since this is the lower segment, guess zero.
+             return 0.0f;
+         }
+ 
+-        return (x - f) / e;
++        return (x - f) / c;
+     }
+ 
+-    // X = ((Y - C)^(1 / G) - B) / A
++    // X = ((Y - E)^(1 / G) - B) / A
+     if (0.0f == a || 0.0f == g) {
+         // The gamma curve for this segment is constant, so the inverse is undefined.
+         // Since this is the upper segment, guess one.
+         return 1.0f;
+     }
+ 
+-    return (powf(x - c, 1.0f / g) - b) / a;
++    return (powf(x - e, 1.0f / g) - b) / a;
+ }
+ 
+ static void build_table_linear_to_gamma(uint8_t* outTable, float g, float a,
+@@ -256,8 +256,8 @@ static void build_gamma_tables(const T* outGammaTables[3], T* gammaTableStorage,
+                     switch (gammas->data(i).fNamed) {
+                         case kSRGB_SkGammaNamed:
+                             (*fns.fBuildFromParam)(&gammaTableStorage[i * gammaTableSize], 2.4f,
+-                                                   (1.0f / 1.055f), (0.055f / 1.055f), 0.0f,
+-                                                   0.04045f, (1.0f / 12.92f), 0.0f);
++                                                   (1.0f / 1.055f), (0.055f / 1.055f),
++                                                   (1.0f / 12.92f), 0.04045f, 0.0f, 0.0f);
+                             outGammaTables[i] = &gammaTableStorage[i * gammaTableSize];
+                             break;
+                         case k2Dot2Curve_SkGammaNamed:
+diff --git a/third_party/skia/src/core/SkColorSpaceXform_A2B.cpp b/third_party/skia/src/core/SkColorSpaceXform_A2B.cpp
+index ead48f33fd..9db2ba5026 100644
+--- a/third_party/skia/src/core/SkColorSpaceXform_A2B.cpp
++++ b/third_party/skia/src/core/SkColorSpaceXform_A2B.cpp
+@@ -81,7 +81,7 @@ static inline SkColorSpaceTransferFn gammanamed_to_parametric(SkGammaNamed gamma
+         case kLinear_SkGammaNamed:
+             return value_to_parametric(1.f);
+         case kSRGB_SkGammaNamed:
+-            return {2.4f, (1.f / 1.055f), (0.055f / 1.055f), 0.f, 0.04045f, (1.f / 12.92f), 0.f};
++            return {2.4f, (1.f / 1.055f), (0.055f / 1.055f), (1.f / 12.92f), 0.04045f, 0.f, 0.f};
+         case k2Dot2Curve_SkGammaNamed:
+             return value_to_parametric(2.2f);
+         default:
+@@ -104,49 +104,49 @@ static inline SkColorSpaceTransferFn gamma_to_parametric(const SkGammas& gammas,
+     }
+ }
+ static inline SkColorSpaceTransferFn invert_parametric(const SkColorSpaceTransferFn& fn) {
+-    // Original equation is:       y = (ax + b)^g + c   for x >= d
+-    //                             y = ex + f           otherwise
++    // Original equation is:       y = (ax + b)^g + e   for x >= d
++    //                             y = cx + f           otherwise
+     //
+-    // so 1st inverse is:          (y - c)^(1/g) = ax + b
+-    //                             x = ((y - c)^(1/g) - b) / a
++    // so 1st inverse is:          (y - e)^(1/g) = ax + b
++    //                             x = ((y - e)^(1/g) - b) / a
+     //
+-    // which can be re-written as: x = (1/a)(y - c)^(1/g) - b/a
+-    //                             x = ((1/a)^g)^(1/g) * (y - c)^(1/g) - b/a
+-    //                             x = ([(1/a)^g]y + [-((1/a)^g)c]) ^ [1/g] + [-b/a]
++    // which can be re-written as: x = (1/a)(y - e)^(1/g) - b/a
++    //                             x = ((1/a)^g)^(1/g) * (y - e)^(1/g) - b/a
++    //                             x = ([(1/a)^g]y + [-((1/a)^g)e]) ^ [1/g] + [-b/a]
+     //
+-    // and 2nd inverse is:         x = (y - f) / e
+-    // which can be re-written as: x = [1/e]y + [-f/e]
++    // and 2nd inverse is:         x = (y - f) / c
++    // which can be re-written as: x = [1/c]y + [-f/c]
+     //
+     // and now both can be expressed in terms of the same parametric form as the
+     // original - parameters are enclosed in square barckets.
+ 
+     // find inverse for linear segment (if possible)
+-    float e, f;
+-    if (0.f == fn.fE) {
++    float c, f;
++    if (0.f == fn.fC) {
+         // otherwise assume it should be 0 as it is the lower segment
+         // as y = f is a constant function
+-        e = 0.f;
++        c = 0.f;
+         f = 0.f;
+     } else {
+-        e = 1.f / fn.fE;
+-        f = -fn.fF / fn.fE;
++        c = 1.f / fn.fC;
++        f = -fn.fF / fn.fC;
+     }
+     // find inverse for the other segment (if possible)
+-    float g, a, b, c;
++    float g, a, b, e;
+     if (0.f == fn.fA || 0.f == fn.fG) {
+         // otherwise assume it should be 1 as it is the top segment
+         // as you can't invert the constant functions y = b^g + c, or y = 1 + c
+         g = 1.f;
+         a = 0.f;
+         b = 0.f;
+-        c = 1.f;
++        e = 1.f;
+     } else {
+         g = 1.f / fn.fG;
+         a = powf(1.f / fn.fA, fn.fG);
+-        b = -a * fn.fC;
+-        c = -fn.fB / fn.fA;
++        b = -a * fn.fE;
++        e = -fn.fB / fn.fA;
+     }
+-    const float d = fn.fE * fn.fD + fn.fF;
++    const float d = fn.fC * fn.fD + fn.fF;
+     return {g, a, b, c, d, e, f};
+ }
+ 
+diff --git a/third_party/skia/src/core/SkColorSpace_ICC.cpp b/third_party/skia/src/core/SkColorSpace_ICC.cpp
+index e365e8ac14..72a20a8635 100644
+--- a/third_party/skia/src/core/SkColorSpace_ICC.cpp
++++ b/third_party/skia/src/core/SkColorSpace_ICC.cpp
+@@ -419,8 +419,8 @@ static SkGammas::Type parse_gamma(SkGammas::Data* outData, SkColorSpaceTransferF
+             // Here's where the real parametric gammas start.  There are many
+             // permutations of the same equations.
+             //
+-            // Y = (aX + b)^g + c  for X >= d
+-            // Y = eX + f          otherwise
++            // Y = (aX + b)^g + e  for X >= d
++            // Y = cX + f          otherwise
+             //
+             // We will fill in with zeros as necessary to always match the above form.
+             if (len < 24) {
+@@ -446,11 +446,11 @@ static SkGammas::Type parse_gamma(SkGammas::Data* outData, SkColorSpaceTransferF
+                         return SkGammas::Type::kNone_Type;
+                     }
+ 
+-                    // Y = (aX + b)^g + c  for X >= -b/a
+-                    // Y = c               otherwise
+-                    c = read_big_endian_16_dot_16(src + 24);
++                    // Y = (aX + b)^g + e  for X >= -b/a
++                    // Y = e               otherwise
++                    e = read_big_endian_16_dot_16(src + 24);
+                     d = -b / a;
+-                    f = c;
++                    f = e;
+                     break;
+                 case kGABDE_ParaCurveType:
+                     tagBytes = 12 + 20;
+@@ -460,14 +460,9 @@ static SkGammas::Type parse_gamma(SkGammas::Data* outData, SkColorSpaceTransferF
+                     }
+ 
+                     // Y = (aX + b)^g  for X >= d
+-                    // Y = eX          otherwise
++                    // Y = cX          otherwise
++                    c = read_big_endian_16_dot_16(src + 24);
+                     d = read_big_endian_16_dot_16(src + 28);
+-
+-                    // Not a bug!  We define |e| to always be the coefficient on X in the
+-                    // second equation.  The spec calls this |c| in this particular equation.
+-                    // We don't follow their convention because then |c| would have a
+-                    // different meaning in each of our cases.
+-                    e = read_big_endian_16_dot_16(src + 24);
+                     break;
+                 case kGABCDEF_ParaCurveType:
+                     tagBytes = 12 + 28;
+@@ -476,10 +471,8 @@ static SkGammas::Type parse_gamma(SkGammas::Data* outData, SkColorSpaceTransferF
+                         return SkGammas::Type::kNone_Type;
+                     }
+ 
+-                    // Y = (aX + b)^g + c  for X >= d
+-                    // Y = eX + f          otherwise
+-                    // NOTE: The ICC spec writes "cX" in place of "eX" but I think
+-                    //       it's a typo.
++                    // Y = (aX + b)^g + e  for X >= d
++                    // Y = cX + f          otherwise
+                     c = read_big_endian_16_dot_16(src + 24);
+                     d = read_big_endian_16_dot_16(src + 28);
+                     e = read_big_endian_16_dot_16(src + 32);
+diff --git a/third_party/skia/src/core/SkImageFilter.cpp b/third_party/skia/src/core/SkImageFilter.cpp
+index 09c26d387e..1974dcc08d 100644
+--- a/third_party/skia/src/core/SkImageFilter.cpp
++++ b/third_party/skia/src/core/SkImageFilter.cpp
+@@ -205,9 +205,9 @@ sk_sp<SkSpecialImage> SkImageFilter::filterImage(SkSpecialImage* src, const Cont
+     const SkIRect srcSubset = fUsesSrcInput ? src->subset() : SkIRect::MakeWH(0, 0);
+     SkImageFilterCacheKey key(fUniqueID, context.ctm(), context.clipBounds(), srcGenID, srcSubset);
+     if (context.cache()) {
+-        SkSpecialImage* result = context.cache()->get(key, offset);
++        sk_sp<SkSpecialImage> result = context.cache()->get(key, offset);
+         if (result) {
+-            return sk_sp<SkSpecialImage>(SkRef(result));
++            return result;
+         }
+     }
+ 
+diff --git a/third_party/skia/src/core/SkImageFilterCache.cpp b/third_party/skia/src/core/SkImageFilterCache.cpp
+index 889e81f9d2..0d9e367790 100644
+--- a/third_party/skia/src/core/SkImageFilterCache.cpp
++++ b/third_party/skia/src/core/SkImageFilterCache.cpp
+@@ -52,7 +52,7 @@ public:
+         SK_DECLARE_INTERNAL_LLIST_INTERFACE(Value);
+     };
+ 
+-    SkSpecialImage* get(const Key& key, SkIPoint* offset) const override {
++    sk_sp<SkSpecialImage> get(const Key& key, SkIPoint* offset) const override {
+         SkAutoMutexAcquire mutex(fMutex);
+         if (Value* v = fLookup.find(key)) {
+             *offset = v->fOffset;
+@@ -60,7 +60,7 @@ public:
+                 fLRU.remove(v);
+                 fLRU.addToHead(v);
+             }
+-            return v->fImage.get();
++            return v->fImage;
+         }
+         return nullptr;
+     }
+diff --git a/third_party/skia/src/core/SkImageFilterCache.h b/third_party/skia/src/core/SkImageFilterCache.h
+index a65357f69c..8f0d9f10fc 100644
+--- a/third_party/skia/src/core/SkImageFilterCache.h
++++ b/third_party/skia/src/core/SkImageFilterCache.h
+@@ -53,7 +53,7 @@ public:
+     virtual ~SkImageFilterCache() {}
+     static SkImageFilterCache* Create(size_t maxBytes);
+     static SkImageFilterCache* Get();
+-    virtual SkSpecialImage* get(const SkImageFilterCacheKey& key, SkIPoint* offset) const = 0;
++    virtual sk_sp<SkSpecialImage> get(const SkImageFilterCacheKey& key, SkIPoint* offset) const = 0;
+     virtual void set(const SkImageFilterCacheKey& key, SkSpecialImage* image,
+                      const SkIPoint& offset) = 0;
+     virtual void purge() = 0;
+diff --git a/third_party/skia/src/effects/SkAlphaThresholdFilter.cpp b/third_party/skia/src/effects/SkAlphaThresholdFilter.cpp
+index b1c8b21460..63e352b773 100644
+--- a/third_party/skia/src/effects/SkAlphaThresholdFilter.cpp
++++ b/third_party/skia/src/effects/SkAlphaThresholdFilter.cpp
+@@ -217,8 +217,9 @@ sk_sp<SkSpecialImage> SkAlphaThresholdFilterImpl::onFilterImage(SkSpecialImage*
+     U8CPU outerThreshold = (U8CPU)(fOuterThreshold * 0xFF);
+     SkColor* dptr = dst.getAddr32(0, 0);
+     int dstWidth = dst.width(), dstHeight = dst.height();
++    SkIPoint srcOffset = { bounds.fLeft - inputOffset.fX, bounds.fTop - inputOffset.fY };
+     for (int y = 0; y < dstHeight; ++y) {
+-        const SkColor* sptr = inputBM.getAddr32(bounds.fLeft, bounds.fTop+y);
++        const SkColor* sptr = inputBM.getAddr32(srcOffset.fX, srcOffset.fY+y);
+ 
+         for (int x = 0; x < dstWidth; ++x) {
+             const SkColor& source = sptr[x];
+diff --git a/third_party/skia/src/gpu/GrResourceProvider.h b/third_party/skia/src/gpu/GrResourceProvider.h
+index abcd699957..a0459e9880 100644
+--- a/third_party/skia/src/gpu/GrResourceProvider.h
++++ b/third_party/skia/src/gpu/GrResourceProvider.h
+@@ -94,6 +94,7 @@ public:
+     using GrTextureProvider::findAndRefTextureByUniqueKey;
+     using GrTextureProvider::abandon;
+ 
++    /** These flags alias/extend GrTextureProvider::ScratchTextureFlags */
+     enum Flags {
+         /** If the caller intends to do direct reads/writes to/from the CPU then this flag must be
+          *  set when accessing resources during a GrOpList flush. This includes the execution of
+@@ -101,12 +102,12 @@ public:
+          *  will occur out of order WRT the operations being flushed.
+          *  Make this automatic: https://bug.skia.org/4156
+          */
+-        kNoPendingIO_Flag = 0x1,
++        kNoPendingIO_Flag = GrTextureProvider::kNoPendingIO_ScratchTextureFlag,
+ 
+         /** Normally the caps may indicate a preference for client-side buffers. Set this flag when
+          *  creating a buffer to guarantee it resides in GPU memory.
+          */
+-        kRequireGpuMemory_Flag = 0x2,
++        kRequireGpuMemory_Flag = GrTextureProvider::kLastScratchTextureFlag << 1,
+     };
+ 
+     /**
+diff --git a/third_party/skia/src/gpu/GrTextureProvider.cpp b/third_party/skia/src/gpu/GrTextureProvider.cpp
+index b49c2c96d6..000dcf4dff 100644
+--- a/third_party/skia/src/gpu/GrTextureProvider.cpp
++++ b/third_party/skia/src/gpu/GrTextureProvider.cpp
+@@ -18,12 +18,6 @@
+ #define ASSERT_SINGLE_OWNER \
+     SkDEBUGCODE(GrSingleOwner::AutoEnforce debug_SingleOwner(fSingleOwner);)
+ 
+-enum ScratchTextureFlags {
+-    kExact_ScratchTextureFlag           = 0x1,
+-    kNoPendingIO_ScratchTextureFlag     = 0x2,
+-    kNoCreate_ScratchTextureFlag        = 0x4,
+-};
+-
+ GrTextureProvider::GrTextureProvider(GrGpu* gpu, GrResourceCache* cache, GrSingleOwner* singleOwner)
+     : fCache(cache)
+     , fGpu(gpu)
+diff --git a/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.cpp b/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.cpp
+index bea604d702..a4d166cade 100644
+--- a/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.cpp
++++ b/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.cpp
+@@ -103,9 +103,9 @@ bool GrAADistanceFieldPathRenderer::onCanDrawPath(const CanDrawPathArgs& args) c
+         return false;
+     }
+ 
+-    // only support paths with bounds within kMediumMIP by kMediumMIP,
+-    // scaled to have bounds within 2.0f*kLargeMIP by 2.0f*kLargeMIP
+-    // the goal is to accelerate rendering of lots of small paths that may be scaling
++    // Only support paths with bounds within kMediumMIP by kMediumMIP,
++    // scaled to have bounds within 2.0f*kLargeMIP by 2.0f*kLargeMIP.
++    // The goal is to accelerate rendering of lots of small paths that may be scaling.
+     SkScalar maxScale = args.fViewMatrix->getMaxScale();
+     SkRect bounds = args.fShape->styledBounds();
+     SkScalar maxDim = SkMaxScalar(bounds.width(), bounds.height());
+@@ -146,7 +146,6 @@ public:
+         // Compute bounds
+         this->setTransformedBounds(shape.bounds(), viewMatrix, HasAABloat::kYes, IsZeroArea::kNo);
+     }
+-
+     const char* name() const override { return "AADistanceFieldPathBatch"; }
+ 
+     void computePipelineOptimizations(GrInitInvariantOutput* color,
+@@ -233,9 +232,16 @@ private:
+             const SkRect& bounds = args.fShape.bounds();
+             SkScalar maxDim = SkMaxScalar(bounds.width(), bounds.height());
+             SkScalar size = maxScale * maxDim;
+-            uint32_t desiredDimension;
+-            if (size <= kSmallMIP) {
++            SkScalar desiredDimension;
++            // For minimizing (or the common case of identity) transforms, we try to
++            // create the DF at the appropriately sized native src-space path resolution.
++            // In the majority of cases this will yield a crisper rendering.
++            if (size <= maxDim && maxDim < kSmallMIP) {
++                desiredDimension = maxDim;
++            } else if (size <= kSmallMIP) {
+                 desiredDimension = kSmallMIP;
++            } else if (size <= maxDim) {
++                desiredDimension = maxDim;
+             } else if (size <= kMediumMIP) {
+                 desiredDimension = kMediumMIP;
+             } else {
+@@ -243,7 +249,7 @@ private:
+             }
+ 
+             // check to see if path is cached
+-            ShapeData::Key key(args.fShape, desiredDimension);
++            ShapeData::Key key(args.fShape, SkScalarCeilToInt(desiredDimension));
+             ShapeData* shapeData = fShapeCache->find(key);
+             if (nullptr == shapeData || !atlas->hasID(shapeData->fID)) {
+                 // Remove the stale cache entry
+@@ -253,6 +259,7 @@ private:
+                     delete shapeData;
+                 }
+                 SkScalar scale = desiredDimension/maxDim;
++
+                 shapeData = new ShapeData;
+                 if (!this->addPathToAtlas(target,
+                                           &flushInfo,
+@@ -260,7 +267,7 @@ private:
+                                           shapeData,
+                                           args.fShape,
+                                           args.fAntiAlias,
+-                                          desiredDimension,
++                                          SkScalarCeilToInt(desiredDimension),
+                                           scale)) {
+                     delete shapeData;
+                     SkDebugf("Can't rasterize path\n");
+@@ -275,7 +282,7 @@ private:
+                                     offset,
+                                     args.fColor,
+                                     vertexStride,
+-                                    this->viewMatrix(),
++                                    maxScale,
+                                     shapeData);
+             offset += kVerticesPerQuad * vertexStride;
+             flushInfo.fInstancesToFlush++;
+@@ -301,29 +308,25 @@ private:
+         scaledBounds.fTop *= scale;
+         scaledBounds.fRight *= scale;
+         scaledBounds.fBottom *= scale;
+-        // move the origin to an integer boundary (gives better results)
+-        SkScalar dx = SkScalarFraction(scaledBounds.fLeft);
+-        SkScalar dy = SkScalarFraction(scaledBounds.fTop);
++        // subtract out integer portion of origin
++        // (SDF created will be placed with fractional offset burnt in)
++        SkScalar dx = SkScalarFloorToInt(scaledBounds.fLeft);
++        SkScalar dy = SkScalarFloorToInt(scaledBounds.fTop);
+         scaledBounds.offset(-dx, -dy);
+         // get integer boundary
+         SkIRect devPathBounds;
+         scaledBounds.roundOut(&devPathBounds);
+         // pad to allow room for antialiasing
+         const int intPad = SkScalarCeilToInt(kAntiAliasPad);
+-        // pre-move origin (after outset, will be 0,0)
+-        int width = devPathBounds.width();
+-        int height = devPathBounds.height();
+-        devPathBounds.fLeft = intPad;
+-        devPathBounds.fTop = intPad;
+-        devPathBounds.fRight = intPad + width;
+-        devPathBounds.fBottom = intPad + height;
+-        devPathBounds.outset(intPad, intPad);
++        // place devBounds at origin
++        int width = devPathBounds.width() + 2*intPad;
++        int height = devPathBounds.height() + 2*intPad;
++        devPathBounds = SkIRect::MakeWH(width, height);
+ 
+         // draw path to bitmap
+         SkMatrix drawMatrix;
+-        drawMatrix.setTranslate(-bounds.left(), -bounds.top());
+-        drawMatrix.postScale(scale, scale);
+-        drawMatrix.postTranslate(kAntiAliasPad, kAntiAliasPad);
++        drawMatrix.setScale(scale, scale);
++        drawMatrix.postTranslate(intPad - dx, intPad - dy);
+ 
+         // setup bitmap backing
+         SkASSERT(devPathBounds.fLeft == 0);
+@@ -368,7 +371,7 @@ private:
+         // add to atlas
+         SkIPoint16 atlasLocation;
+         GrBatchAtlas::AtlasID id;
+-       if (!atlas->addToAtlas(&id, target, width, height, dfStorage.get(), &atlasLocation)) {
++        if (!atlas->addToAtlas(&id, target, width, height, dfStorage.get(), &atlasLocation)) {
+             this->flush(target, flushInfo);
+             if (!atlas->addToAtlas(&id, target, width, height, dfStorage.get(), &atlasLocation)) {
+                 return false;
+@@ -377,22 +380,17 @@ private:
+ 
+         // add to cache
+         shapeData->fKey.set(shape, dimension);
+-        shapeData->fScale = scale;
+         shapeData->fID = id;
+-        // change the scaled rect to match the size of the inset distance field
+-        scaledBounds.fRight = scaledBounds.fLeft +
+-            SkIntToScalar(devPathBounds.width() - 2*SK_DistanceFieldInset);
+-        scaledBounds.fBottom = scaledBounds.fTop +
+-            SkIntToScalar(devPathBounds.height() - 2*SK_DistanceFieldInset);
+-        // shift the origin to the correct place relative to the distance field
+-        // need to also restore the fractional translation
+-        scaledBounds.offset(-SkIntToScalar(SK_DistanceFieldInset) - kAntiAliasPad + dx,
+-                            -SkIntToScalar(SK_DistanceFieldInset) - kAntiAliasPad + dy);
+-        shapeData->fBounds = scaledBounds;
+-        // origin we render from is inset from distance field edge
+-        atlasLocation.fX += SK_DistanceFieldInset;
+-        atlasLocation.fY += SK_DistanceFieldInset;
+-        shapeData->fAtlasLocation = atlasLocation;
++
++        // set the bounds rect to the original bounds
++        shapeData->fBounds = bounds;
++
++        // set up path to texture coordinate transform
++        shapeData->fScale = scale;
++        dx -= SK_DistanceFieldPad + kAntiAliasPad;
++        dy -= SK_DistanceFieldPad + kAntiAliasPad;
++        shapeData->fTranslate.fX = atlasLocation.fX - dx;
++        shapeData->fTranslate.fY = atlasLocation.fY - dy;
+ 
+         fShapeCache->add(shapeData);
+         fShapeList->addToTail(shapeData);
+@@ -407,27 +405,20 @@ private:
+                            intptr_t offset,
+                            GrColor color,
+                            size_t vertexStride,
+-                           const SkMatrix& viewMatrix,
++                           SkScalar maxScale,
+                            const ShapeData* shapeData) const {
+-        GrTexture* texture = atlas->getTexture();
+-
+-        SkScalar dx = shapeData->fBounds.fLeft;
+-        SkScalar dy = shapeData->fBounds.fTop;
+-        SkScalar width = shapeData->fBounds.width();
+-        SkScalar height = shapeData->fBounds.height();
+-
+-        SkScalar invScale = 1.0f / shapeData->fScale;
+-        dx *= invScale;
+-        dy *= invScale;
+-        width *= invScale;
+-        height *= invScale;
+ 
+         SkPoint* positions = reinterpret_cast<SkPoint*>(offset);
+ 
++        // outset bounds to include ~1 pixel of AA in device space
++        SkRect bounds = shapeData->fBounds;
++        SkScalar outset = SkScalarInvert(maxScale);
++        bounds.outset(outset, outset);
++
+         // vertex positions
+         // TODO make the vertex attributes a struct
+-        SkRect r = SkRect::MakeXYWH(dx, dy, width, height);
+-        positions->setRectFan(r.left(), r.top(), r.right(), r.bottom(), vertexStride);
++        positions->setRectFan(bounds.left(), bounds.top(), bounds.right(), bounds.bottom(),
++                              vertexStride);
+ 
+         // colors
+         for (int i = 0; i < kVerticesPerQuad; i++) {
+@@ -435,15 +426,32 @@ private:
+             *colorPtr = color;
+         }
+ 
+-        const SkScalar tx = SkIntToScalar(shapeData->fAtlasLocation.fX);
+-        const SkScalar ty = SkIntToScalar(shapeData->fAtlasLocation.fY);
++        // set up texture coordinates
++        SkScalar texLeft = bounds.fLeft;
++        SkScalar texTop = bounds.fTop;
++        SkScalar texRight = bounds.fRight;
++        SkScalar texBottom = bounds.fBottom;
++
++        // transform original path's bounds to texture space
++        SkScalar scale = shapeData->fScale;
++        const SkVector& translate = shapeData->fTranslate;
++        texLeft *= scale;
++        texTop *= scale;
++        texRight *= scale;
++        texBottom *= scale;
++        texLeft += translate.fX;
++        texTop += translate.fY;
++        texRight += translate.fX;
++        texBottom += translate.fY;
+ 
+         // vertex texture coords
++        // TODO make these int16_t
+         SkPoint* textureCoords = (SkPoint*)(offset + sizeof(SkPoint) + sizeof(GrColor));
+-        textureCoords->setRectFan(tx / texture->width(),
+-                                  ty / texture->height(),
+-                                  (tx + shapeData->fBounds.width()) / texture->width(),
+-                                  (ty + shapeData->fBounds.height())  / texture->height(),
++        GrTexture* texture = atlas->getTexture();
++        textureCoords->setRectFan(texLeft / texture->width(),
++                                  texTop / texture->height(),
++                                  texRight / texture->width(),
++                                  texBottom / texture->height(),
+                                   vertexStride);
+     }
+ 
+diff --git a/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.h b/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.h
+index 171108af91..51dca86d30 100644
+--- a/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.h
++++ b/third_party/skia/src/gpu/batches/GrAADistanceFieldPathRenderer.h
+@@ -69,11 +69,11 @@ private:
+             // 64x64 max, 128x128 max) and the GrShape's key.
+             SkAutoSTArray<24, uint32_t> fKey;
+         };
+-        Key                   fKey;
+-        SkScalar              fScale;
++        Key fKey;
+         GrBatchAtlas::AtlasID fID;
+-        SkRect                fBounds;
+-        SkIPoint16            fAtlasLocation;
++        SkRect   fBounds;
++        SkScalar fScale;
++        SkVector fTranslate;
+         SK_DECLARE_INTERNAL_LLIST_INTERFACE(ShapeData);
+ 
+         static inline const Key& GetKey(const ShapeData& data) {
+diff --git a/third_party/skia/src/image/SkImage_Gpu.cpp b/third_party/skia/src/image/SkImage_Gpu.cpp
+index c75e36b9d9..c08a38c0a8 100644
+--- a/third_party/skia/src/image/SkImage_Gpu.cpp
++++ b/third_party/skia/src/image/SkImage_Gpu.cpp
+@@ -390,24 +390,10 @@ struct DeferredTextureImage {
+ }  // anonymous namespace
+ 
+ static bool should_use_mip_maps(const SkImage::DeferredTextureImageUsageParams & param) {
+-    bool shouldUseMipMaps = false;
+-
+-    // Use mipmaps if either
+-    // 1.) it is a perspective matrix, or
+-    // 2.) the quality is med/high and the scale is < 1
+-    if (param.fMatrix.hasPerspective()) {
+-        shouldUseMipMaps = true;
+-    }
+-    if (param.fQuality == kMedium_SkFilterQuality ||
+-        param.fQuality == kHigh_SkFilterQuality) {
+-        SkScalar minAxisScale = param.fMatrix.getMinScale();
+-        if (minAxisScale != -1.f && minAxisScale < 1.f) {
+-            shouldUseMipMaps = true;
+-        }
+-    }
+-
+-
+-    return shouldUseMipMaps;
++    // There is a bug in the mipmap pre-generation logic in use in getDeferredTextureImageData.
++    // This can cause runaway memory leaks, so we are disabling this path until we can
++    // investigate further. crbug.com/669775
++    return false;
+ }
+ 
+ namespace {
+diff --git a/third_party/skia/src/opts/SkRasterPipeline_opts.h b/third_party/skia/src/opts/SkRasterPipeline_opts.h
+index f1aa250d21..2a9200f4b0 100644
+--- a/third_party/skia/src/opts/SkRasterPipeline_opts.h
++++ b/third_party/skia/src/opts/SkRasterPipeline_opts.h
+@@ -578,8 +578,8 @@ SI SkNf parametric(const SkNf& v, const SkColorSpaceTransferFn& p) {
+     float result[N];   // Unconstrained powf() doesn't vectorize well...
+     for (int i = 0; i < N; i++) {
+         float s = v[i];
+-        result[i] = (s <= p.fD) ? p.fE * s + p.fF
+-                                : powf(s * p.fA + p.fB, p.fG) + p.fC;
++        result[i] = (s <= p.fD) ? p.fC * s + p.fF
++                                : powf(s * p.fA + p.fB, p.fG) + p.fE;
+     }
+     return SkNf::Load(result);
+ }
+diff --git a/third_party/skia/tests/ColorSpaceTest.cpp b/third_party/skia/tests/ColorSpaceTest.cpp
+index e1ff1609b2..070d50264f 100644
+--- a/third_party/skia/tests/ColorSpaceTest.cpp
++++ b/third_party/skia/tests/ColorSpaceTest.cpp
+@@ -240,9 +240,9 @@ DEF_TEST(ColorSpace_Serialize, r) {
+     SkColorSpaceTransferFn fn;
+     fn.fA = 1.0f;
+     fn.fB = 0.0f;
+-    fn.fC = 0.0f;
++    fn.fC = 1.0f;
+     fn.fD = 0.5f;
+-    fn.fE = 1.0f;
++    fn.fE = 0.0f;
+     fn.fF = 0.0f;
+     fn.fG = 1.0f;
+     SkMatrix44 toXYZ(SkMatrix44::kIdentity_Constructor);
+@@ -265,9 +265,9 @@ DEF_TEST(ColorSpace_Equals, r) {
+     SkColorSpaceTransferFn fn;
+     fn.fA = 1.0f;
+     fn.fB = 0.0f;
+-    fn.fC = 0.0f;
++    fn.fC = 1.0f;
+     fn.fD = 0.5f;
+-    fn.fE = 1.0f;
++    fn.fE = 0.0f;
+     fn.fF = 0.0f;
+     fn.fG = 1.0f;
+     SkMatrix44 toXYZ(SkMatrix44::kIdentity_Constructor);
+diff --git a/third_party/skia/tests/ColorSpaceXformTest.cpp b/third_party/skia/tests/ColorSpaceXformTest.cpp
+index 0e67fe497d..3b95d0681f 100644
+--- a/third_party/skia/tests/ColorSpaceXformTest.cpp
++++ b/third_party/skia/tests/ColorSpaceXformTest.cpp
+@@ -172,18 +172,18 @@ DEF_TEST(ColorSpaceXform_ParametricGamma, r) {
+     SkColorSpaceTransferFn* params = SkTAddOffset<SkColorSpaceTransferFn>
+             (memory, sizeof(SkGammas));
+ 
+-    // Interval, switch xforms at 0.0031308f
++    // Interval.
+     params->fD = 0.04045f;
+ 
+     // First equation:
+-    params->fE = 1.0f / 12.92f;
++    params->fC = 1.0f / 12.92f;
+     params->fF = 0.0f;
+ 
+     // Second equation:
+     // Note that the function is continuous (it's actually sRGB).
+     params->fA = 1.0f / 1.055f;
+     params->fB = 0.055f / 1.055f;
+-    params->fC = 0.0f;
++    params->fE = 0.0f;
+     params->fG = 2.4f;
+     test_identity_xform(r, gammas, true);
+     test_identity_xform_A2B(r, kNonStandard_SkGammaNamed, gammas, true);
+@@ -233,9 +233,9 @@ DEF_TEST(ColorSpaceXform_NonMatchingGamma, r) {
+             sizeof(SkGammas) + sizeof(float) * tableSize);
+     params->fA = 1.0f / 1.055f;
+     params->fB = 0.055f / 1.055f;
+-    params->fC = 0.0f;
++    params->fC = 1.0f / 12.92f;
+     params->fD = 0.04045f;
+-    params->fE = 1.0f / 12.92f;
++    params->fE = 0.0f;
+     params->fF = 0.0f;
+     params->fG = 2.4f;
+ 
+diff --git a/third_party/skia/tests/ImageFilterCacheTest.cpp b/third_party/skia/tests/ImageFilterCacheTest.cpp
+index ebd3186e01..1f8ab8d98d 100644
+--- a/third_party/skia/tests/ImageFilterCacheTest.cpp
++++ b/third_party/skia/tests/ImageFilterCacheTest.cpp
+@@ -41,7 +41,7 @@ static void test_find_existing(skiatest::Reporter* reporter,
+ 
+     SkIPoint foundOffset;
+ 
+-    SkSpecialImage* foundImage = cache->get(key1, &foundOffset);
++    sk_sp<SkSpecialImage> foundImage = cache->get(key1, &foundOffset);
+     REPORTER_ASSERT(reporter, foundImage);
+     REPORTER_ASSERT(reporter, offset == foundOffset);
+ 

--- a/script/cibuild
+++ b/script/cibuild
@@ -63,7 +63,7 @@ def run_ci(args):
     os.environ.update(vs_env)
 
   return (run_script('bootstrap') or
-          run_script('update', args) or
+          run_script('update', args + ['--force-download-source-tarball']) or
           run_script('build', args) or
           run_script('create-dist', args) or
           run_script('upload', args))

--- a/script/update
+++ b/script/update
@@ -32,9 +32,9 @@ TARBALL_URL = 'https://github.com/{0}/releases/download/{1}/chromium-{1}.tar.xz'
 def main():
   args = parse_args()
 
-  if not args.no_download:
+  if args.force_download or not args.no_download:
     version = chromium_version()
-    if not is_source_tarball_updated(version):
+    if args.force_download or not is_source_tarball_updated(version):
       download_source_tarball(version)
   else:
     print "Skipping Chromium Source Tarball Download"
@@ -55,6 +55,12 @@ def main():
 def parse_args():
   parser = argparse.ArgumentParser(description='Update build configuration')
   parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  parser.add_argument('--force-download-source-tarball',
+                      default=False,
+                      required=False,
+                      action='store_true',
+                      dest='force_download',
+                      help='Always redownload Chromium source tarball')
   parser.add_argument('-N', '--no-download-source-tarball',
                       default=False,
                       required=False,


### PR DESCRIPTION
This updates Skia from [524f11a50ab05f412c4f87baf7cce5573bd2188c to the
latest chrome/m56 revision](https://skia.googlesource.com/skia.git/+log/524f11a50ab05f412c4f87baf7cce5573bd2188c..dd45f8195783efc7b8044b006eae5ea5ac127cc2). Chrome 56 never shipped with these Skia
fixes, but they are needed to address
https://bugs.chromium.org/p/chromium/issues/detail?id=668550