### PR TITLE
Pass RenderFrameHost to OverrideSiteInstanceForNavigation()

### DIFF
--- a/patches/can_create_window.patch
+++ b/patches/can_create_window.patch
@@ -131,12 +131,13 @@ index a802ece..eab03ea 100644
  class SiteInstance;
  class SpeechRecognitionManagerDelegate;
  class TracingDelegate;
-@@ -141,6 +142,13 @@ class CONTENT_EXPORT ContentBrowserClient {
+@@ -141,6 +142,14 @@ class CONTENT_EXPORT ContentBrowserClient {
   public:
    virtual ~ContentBrowserClient() {}
  
 +  // Electron: Allows overriding the SiteInstance when navigating.
 +  virtual void OverrideSiteInstanceForNavigation(
++      RenderFrameHost* render_frame_host,
 +      BrowserContext* browser_context,
 +      SiteInstance* current_instance,
 +      const GURL& dest_url,
@@ -145,7 +146,7 @@ index a802ece..eab03ea 100644
    // Allows the embedder to set any number of custom BrowserMainParts
    // implementations for the browser startup code. See comments in
    // browser_main_parts.h.
-@@ -506,6 +514,8 @@ class CONTENT_EXPORT ContentBrowserClient {
+@@ -506,6 +515,8 @@ class CONTENT_EXPORT ContentBrowserClient {
                                 const std::string& frame_name,
                                 WindowOpenDisposition disposition,
                                 const blink::WebWindowFeatures& features,

--- a/patches/frame_host_manager.patch
+++ b/patches/frame_host_manager.patch
@@ -2,13 +2,14 @@ diff --git a/content/browser/frame_host/render_frame_host_manager.cc b/content/b
 index 380f687..303f0c9 100644
 --- a/content/browser/frame_host/render_frame_host_manager.cc
 +++ b/content/browser/frame_host/render_frame_host_manager.cc
-@@ -1208,6 +1208,16 @@ RenderFrameHostManager::GetSiteInstanceForNavigation(
+@@ -1208,6 +1208,17 @@ RenderFrameHostManager::GetSiteInstanceForNavigation(
  
    SiteInstance* current_instance = render_frame_host_->GetSiteInstance();
  
 +  // Gives user a chance to pass a custom side instance.
 +  SiteInstance* client_custom_instance = current_instance;
 +  GetContentClient()->browser()->OverrideSiteInstanceForNavigation(
++      render_frame_host_.get(),
 +      delegate_->GetControllerForRenderManager().GetBrowserContext(),
 +      current_instance,
 +      dest_url,


### PR DESCRIPTION
This PR adds `RenderFrameHost` as an argument of `OverrideSiteInstanceForNavigation()`.

This change is used in https://github.com/electron/electron/pull/8963.