### PR TITLE
Backport calling EnableNonClientDpiScaling

### DIFF
--- a/patches/enable_non_client_dpi_scaling.patch
+++ b/patches/enable_non_client_dpi_scaling.patch
@@ -1,0 +1,110 @@
+diff --git a/ui/gfx/win/window_impl.cc b/ui/gfx/win/window_impl.cc
+index f7744687c97b..bf6994d94b1a 100644
+--- a/ui/gfx/win/window_impl.cc
++++ b/ui/gfx/win/window_impl.cc
+@@ -283,19 +283,20 @@ LRESULT CALLBACK WindowImpl::WndProc(HWND hwnd,
+                                      UINT message,
+                                      WPARAM w_param,
+                                      LPARAM l_param) {
++  WindowImpl* window = nullptr;
+   if (message == WM_NCCREATE) {
+     CREATESTRUCT* cs = reinterpret_cast<CREATESTRUCT*>(l_param);
+-    WindowImpl* window = reinterpret_cast<WindowImpl*>(cs->lpCreateParams);
++    window = reinterpret_cast<WindowImpl*>(cs->lpCreateParams);
+     DCHECK(window);
+     gfx::SetWindowUserData(hwnd, window);
+     window->hwnd_ = hwnd;
+     window->got_create_ = true;
+     if (hwnd)
+       window->got_valid_hwnd_ = true;
+-    return TRUE;
++  } else {
++    window = reinterpret_cast<WindowImpl*>(GetWindowUserData(hwnd));
+   }
+ 
+-  WindowImpl* window = reinterpret_cast<WindowImpl*>(GetWindowUserData(hwnd));
+   if (!window)
+     return 0;
+ 
+diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
+index c9eb44424c31..54116a2f52c5 100644
+--- a/ui/views/win/hwnd_message_handler.cc
++++ b/ui/views/win/hwnd_message_handler.cc
+@@ -330,6 +330,7 @@ HWNDMessageHandler::HWNDMessageHandler(HWNDMessageHandlerDelegate* delegate)
+       current_cursor_(NULL),
+       previous_cursor_(NULL),
+       dpi_(0),
++      called_enable_non_client_dpi_scaling_(false),
+       active_mouse_tracking_flags_(0),
+       is_right_mouse_pressed_on_caption_(false),
+       lock_updates_count_(0),
+@@ -363,7 +364,9 @@ void HWNDMessageHandler::Init(HWND parent, const gfx::Rect& bounds) {
+   // Create the window.
+   WindowImpl::Init(parent, bounds);
+ 
+-  if (delegate_->HasFrame() && base::win::IsProcessPerMonitorDpiAware()) {
++  if (!called_enable_non_client_dpi_scaling_ &&
++      delegate_->HasFrame() &&
++      base::win::IsProcessPerMonitorDpiAware()) {
+     static auto enable_child_window_dpi_message_func = []() {
+       // Derived signature; not available in headers.
+       // This call gets Windows to scale the non-client area when WM_DPICHANGED
+@@ -1797,6 +1800,24 @@ LRESULT HWNDMessageHandler::OnNCCalcSize(BOOL mode, LPARAM l_param) {
+   return mode ? WVR_REDRAW : 0;
+ }
+ 
++LRESULT HWNDMessageHandler::OnNCCreate(LPCREATESTRUCT lpCreateStruct) {
++  SetMsgHandled(FALSE);
++  if (delegate_->HasFrame() && base::win::IsProcessPerMonitorDpiAware()) {
++    static auto enable_non_client_dpi_scaling_func = []() {
++      // Signature only available in the 10.0.14393.0 API. As of this writing,
++      // Chrome built against 10.0.10586.0.
++      using EnableNonClientDpiScalingPtr = LRESULT (WINAPI*)(HWND);
++      return reinterpret_cast<EnableNonClientDpiScalingPtr>(
++                 GetProcAddress(GetModuleHandle(L"user32.dll"),
++                                "EnableNonClientDpiScaling"));
++    }();
++    called_enable_non_client_dpi_scaling_ =
++        !!(enable_non_client_dpi_scaling_func &&
++           enable_non_client_dpi_scaling_func(hwnd()));
++  }
++  return FALSE;
++}
++
+ LRESULT HWNDMessageHandler::OnNCHitTest(const gfx::Point& point) {
+   if (!delegate_->HasNonClientView()) {
+     SetMsgHandled(FALSE);
+diff --git a/ui/views/win/hwnd_message_handler.h b/ui/views/win/hwnd_message_handler.h
+index 622696f2f30f..0ae7bbfb522f 100644
+--- a/ui/views/win/hwnd_message_handler.h
++++ b/ui/views/win/hwnd_message_handler.h
+@@ -411,6 +411,7 @@ class VIEWS_EXPORT HWNDMessageHandler :
+     CR_MSG_WM_MOVE(OnMove)
+     CR_MSG_WM_MOVING(OnMoving)
+     CR_MSG_WM_NCCALCSIZE(OnNCCalcSize)
++    CR_MSG_WM_NCCREATE(OnNCCreate)
+     CR_MSG_WM_NCHITTEST(OnNCHitTest)
+     CR_MSG_WM_NCPAINT(OnNCPaint)
+     CR_MSG_WM_NOTIFY(OnNotify)
+@@ -462,6 +463,7 @@ class VIEWS_EXPORT HWNDMessageHandler :
+   void OnMoving(UINT param, const RECT* new_bounds);
+   LRESULT OnNCActivate(UINT message, WPARAM w_param, LPARAM l_param);
+   LRESULT OnNCCalcSize(BOOL mode, LPARAM l_param);
++  LRESULT OnNCCreate(LPCREATESTRUCT lpCreateStruct);
+   LRESULT OnNCHitTest(const gfx::Point& point);
+   void OnNCPaint(HRGN rgn);
+   LRESULT OnNCUAHDrawCaption(UINT message, WPARAM w_param, LPARAM l_param);
+@@ -577,6 +579,13 @@ class VIEWS_EXPORT HWNDMessageHandler :
+   // The current DPI.
+   int dpi_;
+ 
++  // Whether EnableNonClientDpiScaling was called successfully with this window.
++  // This flag exists because EnableNonClientDpiScaling must be called during
++  // WM_NCCREATE and EnableChildWindowDpiMessage is called after window
++  // creation. We don't want to call both, so this helps us determine if a call
++  // to EnableChildWindowDpiMessage is necessary.
++  bool called_enable_non_client_dpi_scaling_;
++
+   // Event handling ------------------------------------------------------------
+ 
+   // The flags currently being used with TrackMouseEvent to track mouse


### PR DESCRIPTION
This is needed to enable non-client area scaling when the screen DPI changes on Windows 10.
It can be removed after upgrade beyond Chromium 56.