### PR TITLE
Stop using experimental allocator shim on win32

### DIFF
--- a/script/update
+++ b/script/update
@@ -234,6 +234,8 @@ def run_gn(target_arch, defines):
 
   for component in COMPONENTS:
     args = 'import("//chromiumcontent/args/{0}.gn") target_cpu="{1}"'.format(component, target_cpu)
+    if sys.platform in ['win32', 'cygwin']:
+      args += ' use_experimental_allocator_shim=false'
     output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
     subprocess.call([gn, 'gen', os.path.relpath(output_dir, SRC_DIR), '--args=' + args],
                     cwd=SRC_DIR, env=env)


### PR DESCRIPTION
It is causing electron.exe and node.dll to use different allocators, this is fine in Chromium becuase everything has been compiled into the same exe, while in Electron lots of components have been put into node.dll and we have to make sure electron.exe and node.dll use the same allocator.

This is to fix the crash in https://github.com/electron/electron/pull/9116.