### PR TITLE
Add inspector number parsing patch

### DIFF
--- a/patches/number_parsing.patch
+++ b/patches/number_parsing.patch
@@ -1,0 +1,80 @@
+diff --git a/components/ui_devtools/string_util.h b/components/ui_devtools/string_util.h
+index 4efb835380f6..d08b8b6f22f6 100644
+--- a/components/ui_devtools/string_util.h
++++ b/components/ui_devtools/string_util.h
+@@ -45,6 +45,11 @@ class StringUtil {
+   static String fromDouble(double number) {
+     return base::DoubleToString(number);
+   }
++  static double toDouble(const char* s, size_t len, bool* ok) {
++    double v = 0.0;
++    *ok = base::StringToDouble(std::string(s, len), &v);
++    return *ok ? v : 0.0;
++  }
+   static void builderAppend(StringBuilder& builder, const String& s) {
+     builder.append(s);
+   }
+diff --git a/content/browser/devtools/protocol_string.h b/content/browser/devtools/protocol_string.h
+index 90dbd4abf7cf..38dd03e41c34 100644
+--- a/content/browser/devtools/protocol_string.h
++++ b/content/browser/devtools/protocol_string.h
+@@ -52,6 +52,11 @@ class CONTENT_EXPORT StringUtil {
+       s = "0" + s;
+     return s;
+   }
++  static double toDouble(const char* s, size_t len, bool* ok) {
++    double v = 0.0;
++    *ok = base::StringToDouble(std::string(s, len), &v);
++    return *ok ? v : 0.0;
++  }
+   static size_t find(const String& s, const char* needle) {
+     return s.find(needle);
+   }
+diff --git a/third_party/WebKit/Source/core/inspector/V8InspectorString.h b/third_party/WebKit/Source/core/inspector/V8InspectorString.h
+index c2d74494dcad..e86c6650b1d3 100644
+--- a/third_party/WebKit/Source/core/inspector/V8InspectorString.h
++++ b/third_party/WebKit/Source/core/inspector/V8InspectorString.h
+@@ -11,6 +11,7 @@
+ #include "wtf/Assertions.h"
+ #include "wtf/text/StringBuilder.h"
+ #include "wtf/text/StringHash.h"
++#include "wtf/text/StringToNumber.h"
+ #include "wtf/text/StringView.h"
+ #include "wtf/text/WTFString.h"
+ 
+@@ -45,6 +46,9 @@ class CORE_EXPORT StringUtil {
+   static String fromDouble(double number) {
+     return Decimal::fromDouble(number).toString();
+   }
++  static double toDouble(const char* s, size_t len, bool* ok) {
++    return WTF::charactersToDouble(reinterpret_cast<const LChar*>(s), len, ok);
++  }
+   static size_t find(const String& s, const char* needle) {
+     return s.find(needle);
+   }
+diff --git a/third_party/inspector_protocol/lib/Parser_cpp.template b/third_party/inspector_protocol/lib/Parser_cpp.template
+index 4bf6bebc467e..f3dde5ac218e 100644
+--- a/third_party/inspector_protocol/lib/Parser_cpp.template
++++ b/third_party/inspector_protocol/lib/Parser_cpp.template
+@@ -51,19 +51,13 @@ double charactersToDouble(const uint16_t* characters, size_t length, bool* ok)
+         buffer.push_back(static_cast<char>(characters[i]));
+     }
+     buffer.push_back('\0');
+-    char* endptr;
+-    double result = std::strtod(buffer.data(), &endptr);
+-    *ok = !(*endptr);
+-    return result;
++    return StringUtil::toDouble(buffer.data(), length, ok);
+ }
+ 
+ double charactersToDouble(const uint8_t* characters, size_t length, bool* ok)
+ {
+     std::string buffer(reinterpret_cast<const char*>(characters), length);
+-    char* endptr;
+-    double result = std::strtod(buffer.data(), &endptr);
+-    *ok = !(*endptr);
+-    return result;
++    return StringUtil::toDouble(buffer.data(), length, ok);
+ }
+ 
+ template<typename Char>

--- a/patches/v8/number_parsing.patch
+++ b/patches/v8/number_parsing.patch
@@ -1,0 +1,81 @@
+diff --git a/src/inspector/DEPS b/src/inspector/DEPS
+index 2d77fb7aa7..b69626cdb8 100644
+--- a/src/inspector/DEPS
++++ b/src/inspector/DEPS
+@@ -6,6 +6,7 @@ include_rules = [
+   "+src/base/logging.h",
+   "+src/base/platform/platform.h",
+   "+src/conversions.h",
++  "+src/unicode-cache.h",
+   "+src/inspector",
+   "+src/tracing",
+   "+src/debug/debug-interface.h",
+diff --git a/src/inspector/string-util.cc b/src/inspector/string-util.cc
+index 31b2db572d..95d4247d14 100644
+--- a/src/inspector/string-util.cc
++++ b/src/inspector/string-util.cc
+@@ -4,7 +4,9 @@
+ 
+ #include "src/inspector/string-util.h"
+ 
++#include "src/conversions.h"
+ #include "src/inspector/protocol/Protocol.h"
++#include "src/unicode-cache.h"
+ 
+ namespace v8_inspector {
+ 
+@@ -92,6 +94,16 @@ bool stringViewStartsWith(const StringView& string, const char* prefix) {
+ 
+ namespace protocol {
+ 
++// static
++double StringUtil::toDouble(const char* s, size_t len, bool* isOk) {
++  v8::internal::UnicodeCache unicode_cache;
++  int flags = v8::internal::ALLOW_HEX | v8::internal::ALLOW_OCTAL |
++              v8::internal::ALLOW_BINARY;
++  double result = StringToDouble(&unicode_cache, s, flags);
++  *isOk = !std::isnan(result);
++  return result;
++}
++
+ std::unique_ptr<protocol::Value> StringUtil::parseJSON(
+     const StringView& string) {
+   if (!string.length()) return nullptr;
+diff --git a/src/inspector/string-util.h b/src/inspector/string-util.h
+index 6f0e3d5ff5..134ff425e1 100644
+--- a/src/inspector/string-util.h
++++ b/src/inspector/string-util.h
+@@ -32,6 +32,7 @@ class StringUtil {
+     return String::fromInteger(number);
+   }
+   static String fromDouble(double number) { return String::fromDouble(number); }
++  static double toDouble(const char* s, size_t len, bool* isOk);
+   static size_t find(const String& s, const char* needle) {
+     return s.find(needle);
+   }
+diff --git a/third_party/inspector_protocol/lib/Parser_cpp.template b/third_party/inspector_protocol/lib/Parser_cpp.template
+index 4bf6bebc46..f3dde5ac21 100644
+--- a/third_party/inspector_protocol/lib/Parser_cpp.template
++++ b/third_party/inspector_protocol/lib/Parser_cpp.template
+@@ -51,19 +51,13 @@ double charactersToDouble(const uint16_t* characters, size_t length, bool* ok)
+         buffer.push_back(static_cast<char>(characters[i]));
+     }
+     buffer.push_back('\0');
+-    char* endptr;
+-    double result = std::strtod(buffer.data(), &endptr);
+-    *ok = !(*endptr);
+-    return result;
++    return StringUtil::toDouble(buffer.data(), length, ok);
+ }
+ 
+ double charactersToDouble(const uint8_t* characters, size_t length, bool* ok)
+ {
+     std::string buffer(reinterpret_cast<const char*>(characters), length);
+-    char* endptr;
+-    double result = std::strtod(buffer.data(), &endptr);
+-    *ok = !(*endptr);
+-    return result;
++    return StringUtil::toDouble(buffer.data(), length, ok);
+ }
+ 
+ template<typename Char>


### PR DESCRIPTION
Backports https://codereview.chromium.org/2866213002 and  https://codereview.chromium.org/2846673005 which have been fixed in Chrome 59.

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=712610
Closes https://github.com/electron/electron/issues/8876