### PR TITLE
Add RenderWidget patch for macOS IME backspace fix

### DIFF
--- a/patches/render_widget_mac_ime.patch
+++ b/patches/render_widget_mac_ime.patch
@@ -1,0 +1,18 @@
+diff --git a/content/renderer/render_widget.cc b/content/renderer/render_widget.cc
+index 9aabb0ab876a..7c7e22572e1d 100644
+--- a/content/renderer/render_widget.cc
++++ b/content/renderer/render_widget.cc
+@@ -1749,8 +1749,13 @@ ui::TextInputType RenderWidget::GetTextInputType() {
+ }
+ 
+ void RenderWidget::UpdateCompositionInfo(bool immediate_request) {
++#if !defined(OS_MACOSX)
++  // On Mac, we always perform update regardless of |monitor_composition_info_|
++  // to workaround IME malfunctions.
++  // TODO(crbug.com/714771): Remove this platform-specific guard.
+   if (!monitor_composition_info_ && !immediate_request)
+     return;  // Do not calculate composition info if not requested.
++#endif
+ 
+   TRACE_EVENT0("renderer", "RenderWidget::UpdateCompositionInfo");
+   gfx::Range range;


### PR DESCRIPTION
Backports #300 to Chrome 56 (Electron 1.6.x).

/cc @CharlieHess @deepak1556 