### PR TITLE
Add patch that removes setting If-Match headers

### DIFF
--- a/patches/resource_multibuffer_data_provider.patch
+++ b/patches/resource_multibuffer_data_provider.patch
@@ -1,0 +1,20 @@
+diff --git a/media/blink/resource_multibuffer_data_provider.cc b/media/blink/resource_multibuffer_data_provider.cc
+index 9ef068447933..f1f80f07823f 100644
+--- a/media/blink/resource_multibuffer_data_provider.cc
++++ b/media/blink/resource_multibuffer_data_provider.cc
+@@ -85,10 +85,11 @@ void ResourceMultiBufferDataProvider::Start() {
+       WebString::fromUTF8(
+           net::HttpByteRange::RightUnbounded(byte_pos()).GetHeaderValue()));
+ 
+-  if (!url_data_->etag().empty()) {
+-    request.setHTTPHeaderField(WebString::fromUTF8("If-Match"),
+-                               WebString::fromUTF8(url_data_->etag()));
+-  }
++  // We would like to send an if-match header with the request to
++  // tell the remote server that we really can't handle files other
++  // than the one we already started playing. Unfortunately, doing
++  // so will disable the http cache, and possibly other proxies
++  // along the way. See crbug/504194 and crbug/689989 for more information.
+ 
+   url_data_->frame()->setReferrerForRequest(request, blink::WebURL());
+ 


### PR DESCRIPTION
Backports https://codereview.chromium.org/2714583002 to Chrome 56.

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=689989

This does not affect Chrome 58 (Electron 1.7.x) so it is only being backported to Chrome 56 (Electron 1.6.x)

/cc @deepak1556 @CharlieHess 