### PR TITLE
Set pipefail to catch cibuild errors

### DIFF
--- a/script/cibuild-libchromiumcontent-linux
+++ b/script/cibuild-libchromiumcontent-linux
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 # Workaround for massive amounts of the following being logged in binutils 2.22:
 # /usr/bin/arm-linux-gnueabihf-ld: BFD (GNU Binutils for Ubuntu) 2.22 assertion fail ../../bfd/elf32-arm.c:12049


### PR DESCRIPTION
Linux builds are still green when failing without since `grep` is used to filter out thousands of ignored warnings.