### PR TITLE
Enable OpenH264 in the non-proprietary ffmpeg builds

### DIFF
--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -5,5 +5,6 @@ enable_nacl = false
 enable_widevine = true
 proprietary_codecs = false
 is_component_ffmpeg = true
-ffmpeg_branding = "Chromium"
+rtc_use_h264 = true
+ffmpeg_branding = "Chrome"
 use_gold = false


### PR DESCRIPTION
Based on the following Chromium merges

https://codereview.webrtc.org/1306813009/#ps730001
https://codereview.chromium.org/1601813005/
https://chromiumcodereview.appspot.com/1675143003/

It looks like we can enable the OpenH264 codec without enabling proprietary codecs.  I am not 100% sure on what exactly changing the branding from Chromium to Chrome does but it seems to be required to enable the OpenH264 codec.

OpenH264 is [free to use](http://www.openh264.org/) so I think it's perfectly safe to include in this build of ffmpeg

/cc @zcbenz Can you clarify what changes when I change the branding to Chrome