### PR TITLE
linux appIndicator submenu fix

### DIFF
--- a/patches/app_indicator_icon_menu.patch
+++ b/patches/app_indicator_icon_menu.patch
@@ -1,0 +1,13 @@
+diff --git chrome/browser/ui/libgtkui/app_indicator_icon_menu.cc chrome/browser/ui/libgtkui/app_indicator_icon_menu.cc
+index 91674b9..8a4c391 100644
+--- chrome/browser/ui/libgtkui/app_indicator_icon_menu.cc
++++ chrome/browser/ui/libgtkui/app_indicator_icon_menu.cc
+@@ -116,7 +116,7 @@ void AppIndicatorIconMenu::OnMenuItemActivated(GtkWidget* menu_item) {
+     return;
+ 
+   // The menu item can still be activated by hotkeys even if it is disabled.
+-  if (menu_model_->IsEnabledAt(id))
++  if (model->IsEnabledAt(id))
+     ExecuteCommand(model, id);
+ }
+ 


### PR DESCRIPTION
this fix for issue with disabled submenu if in same position in main menu item disabled
electron/electron#9495
port from 1-6-0