### PR TITLE
Surface boto process errors

### DIFF
--- a/script/upload
+++ b/script/upload
@@ -76,7 +76,7 @@ def run_boto_script(access_key, secret_key, script_name, *args):
       [env.get('PYTHONPATH', '')] + boto_path_dirs())
 
   boto = os.path.join(BOTO_DIR, 'bin', script_name)
-  subprocess.call([sys.executable, boto] + list(args), env=env)
+  subprocess.check_call([sys.executable, boto] + list(args), env=env)
 
 
 def s3put(bucket, access_key, secret_key, prefix, key_prefix, files):


### PR DESCRIPTION
Looks like a couple recent builds were marked as passing even though the upload script failed.

This pull request update the boto call to use `check_call` to surface errors.

http://208.52.191.140:8080/job/libchromiumcontent-osx/420/console