### PR TITLE
Enable debug mode for "shared_library"

### DIFF
--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -1,7 +1,7 @@
 root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
 is_electron_build = true
 is_component_build = true
-is_debug = false
+is_debug = true
 symbol_level = 2
 enable_nacl = false
 enable_widevine = true

--- a/patches/dcheck.patch
+++ b/patches/dcheck.patch
@@ -1,0 +1,13 @@
+diff --git a/base/logging.h b/base/logging.h
+index c67b937e5b08..e61a35859450 100644
+--- a/base/logging.h
++++ b/base/logging.h
+@@ -718,7 +718,7 @@ DEFINE_CHECK_OP_IMPL(GT, > )
+ #if defined(NDEBUG) && !defined(DCHECK_ALWAYS_ON)
+ #define DCHECK_IS_ON() 0
+ #else
+-#define DCHECK_IS_ON() 1
++#define DCHECK_IS_ON() 0
+ #endif
+ 
+ // Definitions for DLOG et al.

--- a/patches/v8/dcheck.patch
+++ b/patches/v8/dcheck.patch
@@ -1,0 +1,13 @@
+diff --git a/src/base/logging.h b/src/base/logging.h
+index e852dde8dd..a57ddf5404 100644
+--- a/src/base/logging.h
++++ b/src/base/logging.h
+@@ -214,7 +214,7 @@ DEFINE_CHECK_OP_IMPL(GT, > )
+ // The DCHECK macro is equivalent to CHECK except that it only
+ // generates code in debug builds.
+ #ifdef DEBUG
+-#define DCHECK(condition)      CHECK(condition)
++#define DCHECK(condition)      CHECK((condition) || true)
+ #define DCHECK_EQ(v1, v2)      CHECK_EQ(v1, v2)
+ #define DCHECK_NE(v1, v2)      CHECK_NE(v1, v2)
+ #define DCHECK_GT(v1, v2)      CHECK_GT(v1, v2)


### PR DESCRIPTION
This PR enables debug mode in the shared_library build configuration, which is consumed by the debug ("D") configuration of Electron. It will allow contributors to catch some bugs before they slip through to released binaries. It will also reveal existing bugs!

There are currently known bugs which are flagged by the DCHECK macro in runtime which prevents Electron to even launch. Some of these bugs are not trivial to fix, so there needs to be some transition to fully checked debug builds. This transition is enabled by temporarily disabling the DCHECK macro.

The goal of this is to have a better, safer Electron. 🌻 🌞 