### PR TITLE
Apply patches fix for cases when src is not a git repo

### DIFF
--- a/script/apply-patches
+++ b/script/apply-patches
@@ -8,7 +8,8 @@ import sys
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 PATCHES_DIR = os.path.join(SOURCE_ROOT, 'patches')
 PATCHES_MAS_DIR = os.path.join(SOURCE_ROOT, 'patches-mas')
-SRC_DIR = os.path.join(SOURCE_ROOT, 'src')
+SRC = 'src'
+SRC_DIR = os.path.join(SOURCE_ROOT, SRC)
 
 
 def main():
@@ -27,16 +28,17 @@ def main():
 def apply_patches_for_dir(directory):
   for root, dirs, files in os.walk(directory):
     prefix = os.path.relpath(root, directory)
-    repo = SRC_DIR
     if prefix != '.':
-      repo = os.path.join(repo, prefix)
+      cwd = os.path.join(SRC, prefix)
+    else:
+      cwd = SRC
     args = ['git', 'apply', '--ignore-whitespace', '--ignore-space-change',
-            '--whitespace', 'fix']
+            '--whitespace', 'fix', '--directory', cwd, '--verbose']
     for name in sorted(files):
       if not name.endswith('.patch'):
         continue
       patch = os.path.join(root, name)
-      if subprocess.call(args + [patch], cwd=repo):
+      if subprocess.call(args + [patch]):
         return '{0} failed to apply'.format(os.path.basename(patch))
 
 

--- a/script/apply-patches
+++ b/script/apply-patches
@@ -33,7 +33,7 @@ def apply_patches_for_dir(directory):
     else:
       cwd = SRC
     args = ['git', 'apply', '--ignore-whitespace', '--ignore-space-change',
-            '--whitespace', 'fix', '--directory', cwd, '--verbose']
+            '--whitespace', 'fix', '--directory', cwd]
     for name in sorted(files):
       if not name.endswith('.patch'):
         continue


### PR DESCRIPTION
This fix is compatible to any setup you choose for your LIBCC build. 

If you don't want to use `gclient`, then the `src` folder will not be a git repo and the current approach will fail applying patches (actually skipping them). The reason for this might be that you are not allowed to fetch dependencies from outside of your network and everything needs to be "cooked" in house.