### PR TITLE
Turned off debug mode in shared_library

### DIFF
--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -1,7 +1,7 @@
 root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
 is_electron_build = true
 is_component_build = true
-is_debug = true
+is_debug = false
 symbol_level = 2
 enable_nacl = false
 enable_widevine = true

--- a/patches/build_gn.patch
+++ b/patches/build_gn.patch
@@ -1,8 +1,15 @@
 diff --git a/base/allocator/BUILD.gn b/base/allocator/BUILD.gn
-index 8cdb06161f5c..285461d3381d 100644
+index 8cdb06161f5c..6f938d6be67b 100644
 --- a/base/allocator/BUILD.gn
 +++ b/base/allocator/BUILD.gn
-@@ -16,6 +16,7 @@ declare_args() {
+@@ -10,12 +10,13 @@ declare_args() {
+   # Provide a way to force disable debugallocation in Debug builds,
+   # e.g. for profiling (it's more rare to profile Debug builds,
+   # but people sometimes need to do that).
+-  enable_debugallocation = is_debug
++  enable_debugallocation = false
+ }
+ 
  # The Windows-only allocator shim is only enabled for Release static builds, and
  # is mutually exclusive with the generalized shim.
  win_use_allocator_shim = is_win && !is_component_build && !is_debug &&


### PR DESCRIPTION
This turns off the debug mode for the shared_library build configuration for the time being, as was agreed by the maintainers. There's no need to revert the "dcheck" patches, as they have no effect in non-debug mode.