### PR TITLE
Patch the Windows build toolchain to generate unique PDB names

### DIFF
--- a/patches/build_toolchain_win_patch.patch
+++ b/patches/build_toolchain_win_patch.patch
@@ -1,0 +1,82 @@
+diff --git a/build/toolchain/win/BUILD.gn b/build/toolchain/win/BUILD.gn
+index dd1017f..d15706b 100644
+--- a/build/toolchain/win/BUILD.gn
++++ b/build/toolchain/win/BUILD.gn
+@@ -129,12 +129,19 @@ template("msvc_toolchain") {
+     tool("cc") {
+       rspfile = "{{output}}.rsp"
+       precompiled_header_type = "msvc"
+-      pdbname = "{{target_out_dir}}/{{label_name}}_c.pdb"
++      if (is_electron_build && !is_component_build) {
++        pdbdir = "{{target_out_dir}}"
++        pdbname = "{{label_name}}_c.pdb"
++        command = "$python_path $tool_wrapper_path cl-wrapper $env_wrapper$cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} $pdbdir \"$pdbname\""
++      } else {
++        pdbname = "{{target_out_dir}}/{{label_name}}_c.pdb"
++
++        # Label names may have spaces in them so the pdbname must be quoted. The
++        # source and output don't need to be quoted because GN knows they're a
++        # full file name and will quote automatically when necessary.
++        command = "$env_wrapper$cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
++      }
+ 
+-      # Label names may have spaces in them so the pdbname must be quoted. The
+-      # source and output don't need to be quoted because GN knows they're a
+-      # full file name and will quote automatically when necessary.
+-      command = "$env_wrapper$cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
+       depsformat = "msvc"
+       description = "CC {{output}}"
+       outputs = [
+@@ -147,11 +154,18 @@ template("msvc_toolchain") {
+       rspfile = "{{output}}.rsp"
+       precompiled_header_type = "msvc"
+ 
+-      # The PDB name needs to be different between C and C++ compiled files.
+-      pdbname = "{{target_out_dir}}/{{label_name}}_cc.pdb"
++      if (is_electron_build && !is_component_build) {
++        pdbdir = "{{target_out_dir}}"
++        pdbname = "{{label_name}}_cc.pdb"
++        command = "$python_path $tool_wrapper_path cl-wrapper $env_wrapper$cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} $pdbdir \"$pdbname\""
++      } else {
++        # The PDB name needs to be different between C and C++ compiled files.
++        pdbname = "{{target_out_dir}}/{{label_name}}_cc.pdb"
++
++        # See comment in CC tool about quoting.
++        command = "$env_wrapper$cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
++      }
+ 
+-      # See comment in CC tool about quoting.
+-      command = "$env_wrapper$cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
+       depsformat = "msvc"
+       description = "CXX {{output}}"
+       outputs = [
+diff --git a/build/toolchain/win/tool_wrapper.py b/build/toolchain/win/tool_wrapper.py
+index 4e69dea..c70408c 100644
+--- a/build/toolchain/win/tool_wrapper.py
++++ b/build/toolchain/win/tool_wrapper.py
+@@ -326,5 +326,25 @@ class WinTool(object):
+     cmd.extend(ninja_targets)
+     return subprocess.call(cmd, shell=True, cwd=BASE_DIR)
+ 
++  def ExecClWrapper(self, *args):
++    """Invokes cl.exe to compile a C/C++ source file."""
++    args = list(args)
++    # Incorporate the PDB output dir into the PDB name to ensure the PDB name
++    # is unique (see https://github.com/electron/libchromiumcontent/issues/287)
++    pdb_name = args.pop()
++    pdb_dir = args.pop()
++    pdb_filename = '%s/%s_%s' % (pdb_dir, pdb_dir.replace('/', '_'), pdb_name)
++    # On Windows when args is a sequence instead of a single string
++    # subprocess.call() will use subprocess.list2cmdline() to convert the
++    # sequence to a string. Unfortunately the double-quote escaping done by
++    # subprocess.list2cmdline() mangles the /Fd"path/to/some.pdb" arg to
++    # /Fd\"path/to/some.pdb\", and cl.exe then fails to parse the PDB filename
++    # correctly. To work around this we use subprocess.list2cmdline()
++    # (even though it's not part of the public API) to construct most of the
++    # command line, and then append the /Fd flag.
++    pdb_flag = '/Fd"%s"' % pdb_filename
++    cmdline = '%s %s' % (subprocess.list2cmdline(args), pdb_flag)
++    return subprocess.call(cmdline, shell=False)
++
+ if __name__ == '__main__':
+   sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
When the PDB files generated by the static_library build are packaged for distribution they are all copied to a single folder, some of the PDB files have identical names so they end up overwriting each other. The missing PDB files cause linker warnings when building Electron in Release mode, and make it more difficult
to debug release builds.

This patch modifies the PDB naming convention for the static_library build configuration to ensure PDB names are unique. For example, instead of generating obj/ui/base/base_cc.pdb the build will now generate obj/ui/base/obj_ui_base_base_cc.pdb.