### PR TITLE
Improvements for libcc development

### DIFF
--- a/.gclient
+++ b/.gclient
@@ -1,9 +1,0 @@
-solutions = [
-  {
-    "url": "https://chromium.googlesource.com/chromium/src.git",
-    "managed": False,
-    "name": "src",
-    "deps_file": ".DEPS.git",
-    "custom_deps": {},
-  },
-]

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /libchromiumcontent.zip
 /libchromiumcontent-static.zip
 /vendor/binutils-aarch64
+.gclient
 .gclient_entries
 _gclient_src_*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ dependencies (e.g., Blink, V8, etc.).
 * [Mac](https://chromium.googlesource.com/chromium/src/+/master/docs/mac_build_instructions.md#Prerequisites)
 * [Windows](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md)
 
+Note: Even though it is not mentioned in chromium documentation, pywin32 must
+also be installed for `gclient` to work properly. Before invoking script/update,
+download/install the x64 version from: https://sourceforge.net/projects/pywin32/ 
+
 ### One-time setup
 
     $ script/bootstrap

--- a/script/build
+++ b/script/build
@@ -38,6 +38,8 @@ def main():
     if args.component == 'all' or args.component == component:
       if component == 'shared_library' and args.no_shared_library:
         continue
+      elif component == 'static_library' and args.no_static_library:
+        continue
       out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
       target = 'chromiumcontent:chromiumcontent'
       subprocess.check_call([NINJA, '-C', os.path.relpath(out_dir), target], env=env)
@@ -48,6 +50,8 @@ def parse_args():
   parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
   parser.add_argument('-c', '--component', default='all',
                       help='static_library or shared_library or all')
+  parser.add_argument('-D', '--no_static_library', action='store_true',
+                      help='Do not build static library version')
   parser.add_argument('-R', '--no_shared_library', action='store_true',
                       help='Do not build shared library version')
   return parser.parse_args()

--- a/script/create-dist
+++ b/script/create-dist
@@ -17,12 +17,24 @@ from lib.config import get_output_dir
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
+TOOLS_DIR = os.path.join(SOURCE_ROOT, 'tools')
 DIST_DIR = os.path.join(SOURCE_ROOT, 'dist')
 SRC_DIR = os.path.join(SOURCE_ROOT, 'src')
+
+# import helper module to generate ninja build files
+sys.path.insert(0, os.path.join(SRC_DIR, 'tools', 'gyp', 'pylib', 'gyp'))
+import ninja_syntax
 
 # Almost everything goes into the main zip file...
 MAIN_DIR = os.path.join(DIST_DIR, 'main')
 DIST_SRC_DIR = os.path.join(MAIN_DIR, 'src')
+
+NINJA = os.path.join(VENDOR_DIR, 'depot_tools', 'ninja')
+if sys.platform == 'win32':
+  NINJA = '{0}.exe'.format(NINJA)
+
+COPY_PY = os.path.join(TOOLS_DIR, 'copy.py')
+LICENSES_PY = os.path.join(TOOLS_DIR, 'licenses.py')
 
 TARGET_PLATFORM = {
   'cygwin': 'win32',
@@ -298,34 +310,80 @@ OTHER_DIRS = [
 ]
 
 
+class Ninja(ninja_syntax.Writer):
+  def __init__(self, output):
+    # used to avoid duplicate copy builds
+    self._copies = set()
+    super(Ninja, self).__init__(output=output)
+
+  def __enter__(self):
+    self.variable('python', sys.executable)
+    self.variable('copy_py', COPY_PY)
+    self.variable('licenses_py', LICENSES_PY)
+    self.rule('copy', (
+      '${python} ${copy_py} ${in} ${out}' if TARGET_PLATFORM == 'win32' else 'cp -p ${in} ${out}'
+      ), description='COPY ${in}')
+    self.rule('license', (
+      '${python} ${licenses_py} credits ${out} --file-template '
+      '${file_template} --entry-template ${entry_template}'
+    ), description='LICENSE')
+    return self
+
+  def __exit__(self, t, v, tb):
+    self.output.close()
+
+  def copy(self, src, dest, dest_is_dir=True):
+    dest = os.path.normpath(dest)
+    if dest_is_dir:
+      dest = os.path.join(dest, os.path.basename(src))
+    if (src, dest,) not in self._copies:
+      self.build(dest, 'copy', src)
+      self._copies.add((src, dest,))
+
+
 def main():
   args = parse_args()
+
+  if args.create_debug_archive:
+    check_create_debug_archive(args.target_arch)
+
+  rm_rf(DIST_DIR)
+  os.makedirs(MAIN_DIR)
+  
+  with Ninja(open(os.path.join(MAIN_DIR, 'build.ninja'), 'wb')) as ninja:
+    generate_ninja(args, ninja)
+
+  subprocess.check_call([NINJA, '-C', MAIN_DIR])
+
+  for component in COMPONENTS:
+    if args.component == 'all' or args.component == component:
+      strip_binaries(args.create_debug_archive, args.keep_debug_symbols,
+                     component, os.path.join(MAIN_DIR, component),
+                     args.target_arch)
+
+  if not args.no_zip:
+    create_zip(args.create_debug_archive)
+
+
+def generate_ninja(args, ninja):
   target_arch = args.target_arch
   create_debug_archive = args.create_debug_archive
-
-  if create_debug_archive:
-    check_create_debug_archive(target_arch)
 
   # Some libraries are not available for certain arch.
   for lib in ARCH_BLACKLIST[target_arch]:
     if lib in BINARIES[TARGET_PLATFORM]:
       BINARIES[TARGET_PLATFORM].remove(lib)
 
-  rm_rf(DIST_DIR)
-  os.makedirs(DIST_DIR)
-
   for component in COMPONENTS:
     if args.component == 'all' or args.component == component:
       copy_binaries(target_arch, component, create_debug_archive,
-                    args.keep_debug_symbols)
-      copy_generated_sources(target_arch, component)
-      copy_locales(target_arch, component)
+                    args.keep_debug_symbols, ninja)
+      copy_generated_sources(target_arch, component, ninja)
+      copy_locales(target_arch, component, ninja)
 
-  copy_ffmpeg(target_arch)
-  copy_sources()
-  generate_licenses()
-  if not args.no_zip:
-    create_zip(create_debug_archive)
+  copy_ffmpeg(target_arch, ninja)
+  copy_sources(ninja)
+  generate_licenses(ninja)
 
 
 def parse_args():
@@ -372,61 +430,79 @@ def check_create_debug_archive(target_arch):
       sys.exit(1)
 
 
-def copy_with_blacklist(target_arch, src, dest):
+def copy_with_blacklist(target_arch, src, dest, ninja):
   if os.path.basename(src) in ARCH_BLACKLIST[target_arch]:
     return
-  shutil.copy2(src, dest)
+  ninja.copy(src, dest)
 
 
 def copy_binaries(target_arch, component, create_debug_archive,
-                  keep_debug_symbols):
+                  keep_debug_symbols, ninja):
   output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
-  target_dir = os.path.join(MAIN_DIR, component)
-  mkdir_p(target_dir)
+  target_dir = component
 
   binaries = BINARIES['all'] + BINARIES[TARGET_PLATFORM]
   if component == 'shared_library':
     binaries += BINARIES_SHARED_LIBRARY[TARGET_PLATFORM]
   for binary in binaries:
-    copy_with_blacklist(target_arch, os.path.join(output_dir, binary), target_dir)
+    copy_with_blacklist(target_arch, os.path.join(output_dir, binary), target_dir, ninja)
 
   # Copy all static libraries from chromiumcontent
   for library in glob.glob(os.path.join(output_dir, 'obj', 'chromiumcontent', '*.' + STATIC_LIBRARY_SUFFIX)):
-    shutil.copy2(library, target_dir)
-
-  if component == 'shared_library':
-    match = '*.{0}'.format(SHARED_LIBRARY_SUFFIX)
-  else:
-    match = '*.{0}'.format(STATIC_LIBRARY_SUFFIX)
+    ninja.copy(library, target_dir)
 
   if TARGET_PLATFORM == 'darwin':
     if component == 'shared_library':
       for library in glob.glob(os.path.join(output_dir, '*.dylib')):
-        copy_with_blacklist(target_arch, library, target_dir)
+        copy_with_blacklist(target_arch, library, target_dir, ninja)
 
   if TARGET_PLATFORM == 'win32':
     if component == 'shared_library':
       # out/Release/*.dll(.lib)
       debug_dir = os.path.join(os.path.dirname(target_dir), '.debug')
-      mkdir_p(debug_dir)
       for dll in glob.glob(os.path.join(output_dir, '*.dll')):
         lib = dll + '.lib'
         if os.path.exists(lib):
-          copy_with_blacklist(target_arch, dll, target_dir)
-          copy_with_blacklist(target_arch, lib, target_dir)
-          copy_with_blacklist(target_arch, dll + '.pdb', debug_dir)
+          copy_with_blacklist(target_arch, dll, target_dir, ninja)
+          copy_with_blacklist(target_arch, lib, target_dir, ninja)
+          copy_with_blacklist(target_arch, dll + '.pdb', debug_dir, ninja)
     elif component == 'static_library':
       # out/Release/*.pdb
       for root, _, filenames in os.walk(output_dir):
         for pdb in filenames:
           if pdb.endswith('.pdb'):
-            shutil.copy2(os.path.join(root, pdb), target_dir)
+            ninja.copy(os.path.join(root, pdb), target_dir)
 
   if TARGET_PLATFORM == 'linux':
     if component == 'shared_library':
       # out/Release/lib/*.so
       for library in glob.glob(os.path.join(output_dir, '*.so')):
-        copy_with_blacklist(target_arch, library, target_dir)
+        copy_with_blacklist(target_arch, library, target_dir, ninja)
+
+  # Copy chromedriver and mksnapshot
+  # Take them from the "ffmpeg" config, where they are built with all
+  # dependencies statically linked.
+  if component == 'static_library':
+    if TARGET_PLATFORM == "win32":
+      binaries = [ 'chromedriver.exe', 'mksnapshot.exe' ]
+    elif target_arch == 'arm':
+      binaries = [ 'chromedriver', 'clang_x86_v8_arm/mksnapshot' ]
+    elif target_arch == 'arm64':
+      binaries = [ 'chromedriver', 'clang_x64_v8_arm64/mksnapshot' ]
+    else:
+      binaries = [ 'chromedriver', 'mksnapshot' ]
+
+    ffmpeg_output_dir = get_output_dir(SOURCE_ROOT, target_arch, 'ffmpeg')
+    for binary in binaries:
+      ninja.copy(os.path.join(ffmpeg_output_dir, binary), target_dir)
+
+
+def strip_binaries(create_debug_archive, keep_debug_symbols, component,
+                   target_dir, target_arch):
+  if component == 'shared_library':
+    match = '*.{0}'.format(SHARED_LIBRARY_SUFFIX)
+  else:
+    match = '*.{0}'.format(STATIC_LIBRARY_SUFFIX)
 
   if TARGET_PLATFORM in ['linux', 'darwin'] and not keep_debug_symbols:
     if create_debug_archive:
@@ -444,55 +520,38 @@ def copy_binaries(target_arch, component, create_debug_archive,
       for debug_file in glob.glob(os.path.join(target_dir, '*.debug')):
         shutil.move(debug_file, debug_dir)
 
-  # Copy chromedriver and mksnapshot
-  # Take them from the "ffmpeg" config, where they are built with all
-  # dependencies statically linked.
-  if component == 'static_library':
-    if TARGET_PLATFORM == "win32":
-      binaries = [ 'chromedriver.exe', 'mksnapshot.exe' ]
-    elif target_arch == 'arm':
-      binaries = [ 'chromedriver', 'clang_x86_v8_arm/mksnapshot' ]
-    elif target_arch == 'arm64':
-      binaries = [ 'chromedriver', 'clang_x64_v8_arm64/mksnapshot' ]
-    else:
-      binaries = [ 'chromedriver', 'mksnapshot' ]
 
-    ffmpeg_output_dir = get_output_dir(SOURCE_ROOT, target_arch, 'ffmpeg')
-    for binary in binaries:
-      shutil.copy2(os.path.join(ffmpeg_output_dir, binary), target_dir)
-
-
-def copy_generated_sources(target_arch, component):
+def copy_generated_sources(target_arch, component, ninja):
   output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
-  target_dir = os.path.join(MAIN_DIR, component)
+  target_dir = component
   for include_path in GENERATED_INCLUDE_DIRS:
     copy_headers(include_path,
                  relative_to=os.path.join(output_dir, 'gen'),
-                 destination=os.path.join(target_dir, 'gen'))
+                 destination=os.path.join(target_dir, 'gen'),
+                 ninja=ninja)
 
-def copy_locales(target_arch, component):
+def copy_locales(target_arch, component, ninja):
   output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
-  target_dir = os.path.join(MAIN_DIR, component, 'locales')
-  mkdir_p(target_dir)
+  target_dir = os.path.join(component, 'locales')
   src_dir = os.path.join(output_dir, 'gen', 'content', 'app', 'strings')
   for src_file in glob.glob(os.path.join(src_dir, 'content_strings_*.pak')):
     filename = os.path.basename(src_file)
     new_name = re.sub('content_strings_', '', filename)
-    shutil.copy2(src_file, os.path.join(target_dir, new_name))
+    ninja.copy(src_file, os.path.join(target_dir, new_name), False)
 
-def copy_sources():
+def copy_sources(ninja):
   for include_path in INCLUDE_DIRS:
-    copy_headers(include_path, relative_to=SRC_DIR, destination=DIST_SRC_DIR)
+    copy_headers(include_path, relative_to=SRC_DIR, destination=DIST_SRC_DIR, ninja=ninja)
 
   for path in OTHER_HEADERS + OTHER_SOURCES:
     copy_source_file(os.path.join(SRC_DIR, path), relative_to=SRC_DIR,
-                     destination=DIST_SRC_DIR)
+                     destination=DIST_SRC_DIR, ninja=ninja)
 
   for path in OTHER_DIRS:
-    copy_dir(path, relative_to=SRC_DIR, destination=DIST_SRC_DIR)
+    copy_dir(path, relative_to=SRC_DIR, destination=DIST_SRC_DIR, ninja=ninja)
 
 
-def copy_ffmpeg(target_arch):
+def copy_ffmpeg(target_arch, ninja):
   output_dir = get_output_dir(SOURCE_ROOT, target_arch, 'ffmpeg')
   if TARGET_PLATFORM == 'darwin':
     binary = 'libffmpeg.dylib'
@@ -501,33 +560,31 @@ def copy_ffmpeg(target_arch):
   elif TARGET_PLATFORM == 'win32':
     binary = 'ffmpeg.dll'
 
-  target_dir = os.path.join(MAIN_DIR, 'ffmpeg')
-  mkdir_p(target_dir)
-  shutil.copy2(os.path.join(output_dir, binary), target_dir)
+  target_dir = 'ffmpeg'
+  ninja.copy(os.path.join(output_dir, binary), target_dir)
 
 
 
-def copy_headers(relative_path, relative_to, destination):
+def copy_headers(relative_path, relative_to, destination, ninja):
   abs_path = os.path.join(relative_to, relative_path)
   for dirpath, dirnames, filenames in os.walk(abs_path):
     for filename in filenames:
       if os.path.splitext(filename)[1] != '.h':
         continue
-      copy_source_file(os.path.join(dirpath, filename), relative_to=relative_to, destination=destination)
+      copy_source_file(os.path.join(dirpath, filename), relative_to=relative_to, destination=destination, ninja=ninja)
 
 
-def copy_source_file(absolute_path, relative_to, destination):
+def copy_source_file(absolute_path, relative_to, destination, ninja):
   relative_path = os.path.relpath(absolute_path, start=relative_to)
   final_path = os.path.join(destination, relative_path)
-  mkdir_p(os.path.dirname(final_path))
-  shutil.copy2(absolute_path, final_path)
+  ninja.copy(absolute_path, final_path, dest_is_dir=False)
 
 
-def copy_dir(relative_path, relative_to, destination):
+def copy_dir(relative_path, relative_to, destination, ninja):
   abs_path = os.path.join(relative_to, relative_path)
   for dirpath, dirnames, filenames in os.walk(abs_path):
     for filename in filenames:
-      copy_source_file(os.path.join(dirpath, filename), relative_to=relative_to, destination=destination)
+      copy_source_file(os.path.join(dirpath, filename), relative_to=relative_to, destination=destination, ninja=ninja)
 
 
 def add_gdb_index_section(gdb, objcopy, symfile, dirname, env):
@@ -602,15 +659,15 @@ def run_ar_combine(filename, target_dir):
   subprocess.check_call([ar_combine, '-o', target, filename])
 
 
-def generate_licenses():
+def generate_licenses(ninja):
   file_template = os.path.join(SOURCE_ROOT, 'resources', 'about_credits.tmpl')
   entry_template = os.path.join(SOURCE_ROOT, 'resources',
                                 'about_credits_entry.tmpl')
-  licenses_py = os.path.join(SOURCE_ROOT, 'tools', 'licenses.py')
-  target = os.path.join(MAIN_DIR, 'LICENSES.chromium.html')
-  subprocess.check_call([sys.executable, licenses_py, 'credits', target,
-                         '--file-template', file_template,
-                         '--entry-template', entry_template])
+  target = 'LICENSES.chromium.html'
+  data = dict(target=target, file_template=file_template,
+              entry_template=entry_template)
+  ninja.build(target, 'license', ['${licenses_py}', file_template,
+      entry_template], variables=data)
 
 
 def create_zip(create_debug_archive):

--- a/script/create-dist
+++ b/script/create-dist
@@ -316,7 +316,8 @@ def main():
 
   for component in COMPONENTS:
     if args.component == 'all' or args.component == component:
-      copy_binaries(target_arch, component, create_debug_archive)
+      copy_binaries(target_arch, component, create_debug_archive,
+                    args.keep_debug_symbols)
       copy_generated_sources(target_arch, component)
       copy_locales(target_arch, component)
 
@@ -330,11 +331,18 @@ def main():
 def parse_args():
   parser = argparse.ArgumentParser(description='Create distribution')
   parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
-  parser.add_argument('--create-debug-archive',
+  group = parser.add_mutually_exclusive_group()
+  group.add_argument('--create-debug-archive',
                       default=False,
                       required=False,
                       action='store_true',
-                      help='Create archive with debug symbols and source code')
+                      help='Create archive with debug symbols and source code '
+                           'for the shared library build')
+  group.add_argument('--keep-debug-symbols',
+                      default=False,
+                      required=False,
+                      action='store_true',
+                      help='Keep debug symbols in shared library build')
   parser.add_argument('-c', '--component', default='all',
                       help='static_library or shared_library or all')
   parser.add_argument('--no_zip', action='store_true',
@@ -370,7 +378,8 @@ def copy_with_blacklist(target_arch, src, dest):
   shutil.copy2(src, dest)
 
 
-def copy_binaries(target_arch, component, create_debug_archive):
+def copy_binaries(target_arch, component, create_debug_archive,
+                  keep_debug_symbols):
   output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
   target_dir = os.path.join(MAIN_DIR, component)
   mkdir_p(target_dir)
@@ -419,7 +428,7 @@ def copy_binaries(target_arch, component, create_debug_archive):
       for library in glob.glob(os.path.join(output_dir, '*.so')):
         copy_with_blacklist(target_arch, library, target_dir)
 
-  if TARGET_PLATFORM in ['linux', 'darwin']:
+  if TARGET_PLATFORM in ['linux', 'darwin'] and not keep_debug_symbols:
     if create_debug_archive:
       print 'Extracting debug symbols...'
     for binary in BINARIES[TARGET_PLATFORM]:

--- a/script/update
+++ b/script/update
@@ -26,6 +26,19 @@ if sys.platform == 'win32':
 
 DEBIAN_MIRROR = 'http://ftp.jp.debian.org/debian/pool/main/'
 BINTOOLS_NAME = 'c/cross-binutils/binutils-aarch64-linux-gnu_2.25-5_amd64.deb'
+GCLIENT_CONFIG_PATH = os.path.join(SOURCE_ROOT, '.gclient')
+GCLIENT_CONFIG_TEMPLATE = '''
+solutions = [
+  {{
+    "url": "https://chromium.googlesource.com/chromium/src.git",
+    "managed": False,
+    "name": "src",
+    "deps_file": ".DEPS.git",
+    "custom_deps": {{}},
+  }},
+]
+{cache_dir_line}
+'''
 
 def main():
   args = parse_args()
@@ -36,7 +49,14 @@ def main():
   if args.clean and os.path.isdir(SRC_DIR):
     git_clean_recursive(SRC_DIR)
 
-  gclient_sync(chromium_version(), args.clean)
+  # Warning about using a network share as git cache from Windows 7+: The
+  # gclient script may experience errors unless you disable SMBv2 cache by
+  # setting the registry key
+  # HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Lanmanworkstation\Parameters\DirectoryCacheLifetime
+  # to 0.
+  # More information: https://stackoverflow.com/a/9935126
+  git_cache = args.git_cache or os.getenv('LIBCHROMIUMCONTENT_GIT_CACHE', '')
+  gclient_sync(chromium_version(), args.clean, git_cache)
 
   if sys.platform == 'linux2':
     install_sysroot()
@@ -58,6 +78,8 @@ def parse_args():
   parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
   parser.add_argument('--defines', default='',
                       help='The definitions passed to gyp')
+  parser.add_argument('--git-cache', default='',
+                      help='Global git object cache for chromium+ deps')
   parser.add_argument('--clean', action='store_true',
                       help='Cleans the working directory for full rebuild')
   return parser.parse_args()
@@ -138,7 +160,17 @@ def update_depot_tools():
   subprocess.check_call([cmd_path, '/c', update_path], env=env)
 
 
-def gclient_sync(version, force):
+def ensure_gclient_config(git_cache):
+  # escape backslashes to avoid escaping the cache_dir assignment quote
+  git_cache = git_cache.replace('\\', '\\\\')
+  with open(GCLIENT_CONFIG_PATH, 'wb') as f:
+    f.write(GCLIENT_CONFIG_TEMPLATE.format(
+      cache_dir_line="cache_dir = '{0}'".format(git_cache) if git_cache else ''
+      ))
+
+
+def gclient_sync(version, force, git_cache):
+  ensure_gclient_config(git_cache)
   env = os.environ.copy()
   if sys.platform in ['win32', 'cygwin']:
     env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
@@ -148,6 +180,8 @@ def gclient_sync(version, force):
   args = [sys.executable, gclient, 'sync', '--jobs', '16',
           '--revision', 'src@{0}'.format(version), '--with_tags',
           '--with_branch_heads', '--reset', '--delete_unversioned_trees']
+  if git_cache:
+    args += ['--lock_timeout=15']
   if force:
     args += ['--force']
   subprocess.check_call(args, env=env)

--- a/tools/copy.py
+++ b/tools/copy.py
@@ -1,0 +1,18 @@
+import argparse
+import shutil
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Copy file')
+  parser.add_argument('source')
+  parser.add_argument('destination')
+  return parser.parse_args()
+
+
+def main():
+  args = parse_args()
+  shutil.copy2(args.source, args.destination)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Goal of this PR is to make libchromiumcontent build system more friendly for development with electron by speeding up the modify/compile/debug cycles.

The biggest change is a modification to `create-dist`, which instead of copying all compiled libraries to `dist/main`, it generates a ninja file that does the copy and persists after the script exits.

The reason for this change is to allow incremental copying, which is good when developing libchromiumcontent inside electron tree. For example, right now we need to do something like this when making changes to chromium files and bootstrapping electron with `./bootstrap.py --build_libchromiumcontent`:

    $ ninja -C vendor/libchromiumcontent/src/out-x64/shared_library
    $ ./vendor/libchromiumcontent/script/create-dist -t x64 -c shared_library --no_zip
    $ ./script/build.py -c D  # will relink electron with the updated libraries.

The second step is a problem, because every time a change is made in any of the chromium files, the create dist script has to be re-executed, unnecessarily copying a lot of files.

With this PR, the following is now possible:

    $ ninja -C vendor/libchromiumcontent/src/out-x64/shared_library
    $ ninja -C vendor/libchromiumcontent/dist/main
    $ ./script/build.py -c D

Which should be much faster.

Other changes are:

- Generate .gclient dynamically to allow optional use of the `cache_dir` option(store git objects for chromium + deps in a shared directory)
- Add `-D` option to build script, equivalent to `-R` but for shared library build

This PR will have a corresponding electron PR that uses the new options