### PR TITLE
Re-enabled debug mode, and disabled tcmalloc for shared_library build

### DIFF
--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -1,8 +1,9 @@
 root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
 is_electron_build = true
 is_component_build = true
-is_debug = false
+is_debug = true
 symbol_level = 2
+use_allocator = "none"    # on Linux this defaults to "tcmalloc", but tcmalloc deadlocks when Electron CI tests are run inside Docker
 enable_nacl = false
 enable_widevine = true
 proprietary_codecs = true

--- a/patches/010-build_gn.patch
+++ b/patches/010-build_gn.patch
@@ -1,15 +1,8 @@
 diff --git a/base/allocator/BUILD.gn b/base/allocator/BUILD.gn
-index 8cdb06161f5c..6f938d6be67b 100644
+index 8cdb06161f5c..285461d3381d 100644
 --- a/base/allocator/BUILD.gn
 +++ b/base/allocator/BUILD.gn
-@@ -10,12 +10,13 @@ declare_args() {
-   # Provide a way to force disable debugallocation in Debug builds,
-   # e.g. for profiling (it's more rare to profile Debug builds,
-   # but people sometimes need to do that).
--  enable_debugallocation = is_debug
-+  enable_debugallocation = false
- }
- 
+@@ -16,6 +16,7 @@ declare_args() {
  # The Windows-only allocator shim is only enabled for Release static builds, and
  # is mutually exclusive with the generalized shim.
  win_use_allocator_shim = is_win && !is_component_build && !is_debug &&


### PR DESCRIPTION
This PR re-introduces debug mode for the shared_library configuration.

It was disabled because there were issues with it when Electron tests were executed as part of the Linux CI build - the tests hung inexplicably. It turns out that the thing that causes the hangs is the tcmalloc allocator library, which (when run inside Docker) deadlocks while trying to allocate memory.

The way tcmalloc works is by replacing the `malloc` family of APIs normally provided by the C runtime library. Supposedly on Linux, tcmalloc has better performance compared to the default, which is why Chromium uses it. It's not used on other platforms.

I was unable to explain why the deadlock condition occurs in Docker and not elsewhere. Nevertheless, I decided to just disable tcmalloc for the shared_library build, since it is only used on Linux, and it shouldn't be a problem to use the built in glibc `malloc` for shared_library, which is Electron's debug configuration.