### PR TITLE
Don't expand shifted keys in accelerators

### DIFF
--- a/patches/001-accelerator.patch
+++ b/patches/001-accelerator.patch
@@ -10,17 +10,72 @@ index f338a95..cde934f 100644
  #include "base/strings/utf_string_conversions.h"
  #include "build/build_config.h"
  #include "ui/base/l10n/l10n_util.h"
-@@ -219,6 +220,9 @@ base::string16 Accelerator::GetShortcutText() const {
-       shortcut +=
-           static_cast<base::string16::value_type>(base::ToUpperASCII(c));
+@@ -22,9 +23,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#if !defined(OS_WIN) && (defined(USE_AURA) || defined(OS_MACOSX))
+ #include "ui/events/keycodes/keyboard_code_conversion.h"
+-#endif
+ 
+ namespace ui {
+ 
+@@ -197,29 +198,36 @@ base::string16 Accelerator::GetShortcutText() const {
+   }
+ 
+   base::string16 shortcut;
++  unsigned int flags = 0;
+   if (!string_id) {
++    if (IsShiftDown())
++        flags = ui::EF_SHIFT_DOWN;
++    const uint16_t c = DomCodeToUsLayoutCharacter(
++        UsLayoutKeyboardCodeToDomCode(key_code_), flags);
++    if (c != 0)
++      shortcut +=
++          static_cast<base::string16::value_type>(
++              base::ToUpperASCII(static_cast<base::char16>(c)));
+ #if defined(OS_WIN)
+     // Our fallback is to try translate the key code to a regular character
+     // unless it is one of digits (VK_0 to VK_9). Some keyboard
+     // layouts have characters other than digits assigned in
+     // an unshifted mode (e.g. French AZERY layout has 'a with grave
+     // accent' for '0'). For display in the menu (e.g. Ctrl-0 for the
+     // default zoom level), we leave VK_[0-9] alone without translation.
+     wchar_t key;
+-    if (base::IsAsciiDigit(key_code_))
++    if (base::IsAsciiDigit(key_code_)) {
+       key = static_cast<wchar_t>(key_code_);
++      shortcut = key;
++    }
+-    else
+-      key = LOWORD(::MapVirtualKeyW(key_code_, MAPVK_VK_TO_CHAR));
+-    shortcut += key;
+-#elif defined(USE_AURA) || defined(OS_MACOSX)
+-    const uint16_t c = DomCodeToUsLayoutCharacter(
+-        UsLayoutKeyboardCodeToDomCode(key_code_), false);
+-    if (c != 0)
+-      shortcut +=
+-          static_cast<base::string16::value_type>(base::ToUpperASCII(c));
  #endif
 +    if (key_code_ > VKEY_F1 && key_code_ <= VKEY_F24)
 +      shortcut += base::UTF8ToUTF16(
 +          base::StringPrintf("F%d", key_code_ - VKEY_F1 + 1));
    } else {
      shortcut = l10n_util::GetStringUTF16(string_id);
++    if (IsShiftDown())
++      shortcut = l10n_util::GetStringFUTF16(IDS_APP_SHIFT_MODIFIER, shortcut);
    }
-@@ -243,7 +247,8 @@ base::string16 Accelerator::GetShortcutText() const {
+ 
+   // Checking whether the character used for the accelerator is alphanumeric.
+@@ -243,15 +247,13 @@ base::string16 Accelerator::GetShortcutText() const {
+     shortcut_rtl.assign(shortcut);
+   }
+ 
+-  if (IsShiftDown())
+-     shortcut = l10n_util::GetStringFUTF16(IDS_APP_SHIFT_MODIFIER, shortcut);
+-
+   // Note that we use 'else-if' in order to avoid using Ctrl+Alt as a shortcut.
+   // See http://blogs.msdn.com/oldnewthing/archive/2004/03/29/101121.aspx for
    // more information.
    if (IsCtrlDown())
      shortcut = l10n_util::GetStringFUTF16(IDS_APP_CONTROL_MODIFIER, shortcut);


### PR DESCRIPTION
Fixes the issue when zoom-in accelerator "Ctrl +" was displayed as "Ctrl Shift =".
This should be fixed for both Win and Lin.

Related issue: electron/electron#6731

<img width="631" alt="2017-08-23 13 39 44" src="https://user-images.githubusercontent.com/872004/29614506-a4d29e1e-880a-11e7-8abd-352b3a8aca93.png">