### PR TITLE
Don't download llvm gold on windows and mac

### DIFF
--- a/script/update
+++ b/script/update
@@ -218,7 +218,8 @@ def update_clang():
   update = os.path.join(SRC_DIR, 'tools', 'clang', 'scripts', 'update.py')
   download_gold = os.path.join(SRC_DIR, 'build', 'download_gold_plugin.py')
   return (subprocess.call([sys.executable, update, '--if-needed'], env=env) or
-          subprocess.call([sys.executable, download_gold], env=env))
+          (0 if sys.platform != 'linux2'
+                else subprocess.call([sys.executable, download_gold], env=env)))
 
 
 def run_gn(target_arch, defines):


### PR DESCRIPTION
Found during our internal builds that the update script is trying to download this on Windows and Mac, which is not needed for the `is_official` libchromiumcontent build.