### PR TITLE
Disable Official Build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git
 [submodule "vendor/boto"]
 	path = vendor/boto
-	url = https://github.com/piotrbulinski/boto.git
-  ignore = untracked
+	url = https://github.com/boto/boto

--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -220,13 +220,7 @@ if (is_electron_build && !is_component_build) {
       ":pdfium",
       ":webkit",
       ":webkitbindings",
-      ":webkitcore1",
-      ":webkitcore2",
-      ":webkitcore3",
-      ":webkitcore4",
-      ":webkitcore5",
       ":webkitmodules",
-      ":webkitwtf",
       ":webrtc",
       ":v8",
     ]
@@ -336,59 +330,11 @@ if (is_electron_build && !is_component_build) {
     }
   }
 
-  static_library("webkitcore1") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitcore1)) {
-      sources += obj_webkitcore1
-    }
-  }
-
-  static_library("webkitcore2") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitcore2)) {
-      sources += obj_webkitcore2
-    }
-  }
-
-  static_library("webkitcore3") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitcore3)) {
-      sources += obj_webkitcore3
-    }
-  }
-
-  static_library("webkitcore4") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitcore4)) {
-      sources += obj_webkitcore4
-    }
-  }
-
-  static_library("webkitcore5") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitcore5)) {
-      sources += obj_webkitcore5
-    }
-  }
-
   static_library("webkitmodules") {
     complete_static_lib = true
     sources = []
     if (defined(obj_webkitmodules)) {
       sources += obj_webkitmodules
-    }
-  }
-
-  static_library("webkitwtf") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitwtf)) {
-      sources += obj_webkitwtf
     }
   }
 

--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -6,4 +6,3 @@ enable_widevine = true
 proprietary_codecs = false
 is_component_ffmpeg = true
 ffmpeg_branding = "Chromium"
-is_official_build = true

--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -8,5 +8,4 @@ enable_widevine = true
 proprietary_codecs = true
 is_component_ffmpeg = true
 ffmpeg_branding = "Chrome"
-is_official_build = true
 v8_promise_internal_field_count = 1  # https://github.com/nodejs/node/pull/13242

--- a/chromiumcontent/build_libs.py
+++ b/chromiumcontent/build_libs.py
@@ -252,6 +252,7 @@ with open(args.out, 'w') as out:
         "obj_webkit",
         [
             "third_party/WebKit/public",
+            "third_party/WebKit/Source/core",
             "third_party/WebKit/Source/platform/heap",
             "third_party/WebKit/Source/platform/blink_common",
             "third_party/WebKit/Source/platform/loader",
@@ -259,67 +260,7 @@ with open(args.out, 'w') as out:
             "third_party/WebKit/Source/platform/platform",
             "third_party/WebKit/Source/platform/wtf/platform_wtf",
             "third_party/WebKit/Source/web",
-        ])
-
-    gen_list(
-        out,
-        "obj_webkitcore1",
-        [
-	    "third_party/WebKit/Source/core/animation",
-	    "third_party/WebKit/Source/core/clipboard",
-	    "third_party/WebKit/Source/core/core",
-	    "third_party/WebKit/Source/core/core_generated",
-        ])
-
-    gen_list(
-        out,
-        "obj_webkitcore2",
-        [
-	    "third_party/WebKit/Source/core/css",
-	    "third_party/WebKit/Source/core/dom",
-	    "third_party/WebKit/Source/core/editing",
-	    "third_party/WebKit/Source/core/events",
-	    "third_party/WebKit/Source/core/fileapi",
-	    "third_party/WebKit/Source/core/frame",
-	    "third_party/WebKit/Source/core/geometry",
-        ])
-
-    gen_list(
-        out,
-        "obj_webkitcore3",
-        [
-	    "third_party/WebKit/Source/core/html",
-	    "third_party/WebKit/Source/core/imagebitmap",
-	    "third_party/WebKit/Source/core/input",
-	    "third_party/WebKit/Source/core/inspector",
-        ])
-
-    gen_list(
-        out,
-        "obj_webkitcore4",
-        [
-	    "third_party/WebKit/Source/core/layout",
-	    "third_party/WebKit/Source/core/loader",
-	    "third_party/WebKit/Source/core/mojo",
-	    "third_party/WebKit/Source/core/offscreencanvas",
-	    "third_party/WebKit/Source/core/origin_trials",
-	    "third_party/WebKit/Source/core/page",
-        ])
-
-    gen_list(
-        out,
-        "obj_webkitcore5",
-        [
-	    "third_party/WebKit/Source/core/paint",
-	    "third_party/WebKit/Source/core/plugins",
-	    "third_party/WebKit/Source/core/probe",
-	    "third_party/WebKit/Source/core/streams",
-	    "third_party/WebKit/Source/core/style",
-	    "third_party/WebKit/Source/core/svg",
-	    "third_party/WebKit/Source/core/timing",
-	    "third_party/WebKit/Source/core/workers",
-	    "third_party/WebKit/Source/core/xml",
-	    "third_party/WebKit/Source/core/xmlhttprequest",
+            "third_party/WebKit/Source/wtf",
         ])
 
     gen_list(
@@ -334,13 +275,6 @@ with open(args.out, 'w') as out:
         "obj_webkitmodules",
         [
             "third_party/WebKit/Source/modules",
-        ])
-
-    gen_list(
-        out,
-        "obj_webkitwtf",
-        [
-            "third_party/WebKit/Source/wtf",
         ])
 
     gen_list(

--- a/patches/025-no_stack_dumping.patch
+++ b/patches/025-no_stack_dumping.patch
@@ -1,0 +1,13 @@
+diff --git a/content/app/content_main_runner.cc b/content/app/content_main_runner.cc
+index c283922..397ba80 100644
+--- a/content/app/content_main_runner.cc
++++ b/content/app/content_main_runner.cc
+@@ -657,7 +657,7 @@ class ContentMainRunnerImpl : public ContentMainRunner {
+ 
+     InitializeV8IfNeeded(command_line, process_type);
+ 
+-#if !defined(OFFICIAL_BUILD)
++#if 0
+ #if defined(OS_WIN)
+     bool should_enable_stack_dump = !process_type.empty();
+ #else

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,6 @@
 
 import contextlib
 import os
-import shutil
 import subprocess
 import sys
 
@@ -21,9 +20,6 @@ def main():
   # Setup boto.
   with scoped_cwd(os.path.join('vendor', 'boto')):
     subprocess.call([sys.executable, 'setup.py', 'build'])
-    # On windows python assumes all script names end with .py, if we don't
-    # do so some modules like multiprocessing would break.
-    shutil.copy(os.path.join('bin', 's3put'), os.path.join('bin', 's3put.py'))
 
 
 @contextlib.contextmanager

--- a/script/update
+++ b/script/update
@@ -218,8 +218,7 @@ def update_clang():
   update = os.path.join(SRC_DIR, 'tools', 'clang', 'scripts', 'update.py')
   download_gold = os.path.join(SRC_DIR, 'build', 'download_gold_plugin.py')
   return (subprocess.call([sys.executable, update, '--if-needed'], env=env) or
-          (0 if sys.platform != 'linux2'
-                else subprocess.call([sys.executable, download_gold], env=env)))
+          subprocess.call([sys.executable, download_gold], env=env))
 
 
 def run_gn(target_arch, defines):

--- a/script/update
+++ b/script/update
@@ -216,9 +216,7 @@ def update_clang():
                                  env['PATH']])
   env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
   update = os.path.join(SRC_DIR, 'tools', 'clang', 'scripts', 'update.py')
-  download_gold = os.path.join(SRC_DIR, 'build', 'download_gold_plugin.py')
-  return (subprocess.call([sys.executable, update, '--if-needed'], env=env) or
-          subprocess.call([sys.executable, download_gold], env=env))
+  return subprocess.call([sys.executable, update, '--if-needed'], env=env)
 
 
 def run_gn(target_arch, defines):

--- a/script/upload
+++ b/script/upload
@@ -84,7 +84,6 @@ def s3put(bucket, access_key, secret_key, prefix, key_prefix, files):
     '--bucket', bucket,
     '--prefix', prefix,
     '--key_prefix', key_prefix,
-    '--multipart',
     '--grant', 'public-read'
   ] + files
 


### PR DESCRIPTION
**UPD** Electron Release builds on Windows and Linux x64 fail electron/electron#10726 after the `is_official_build=true` was added.

```
Revert "Merge pull request #361 from electron/use-official-build-for-static-library"

    This reverts commit 628f0d99441016270750fda6b0781107c8d9cd76, reversing
    changes made to c073406bd0256846e1074bb74e9b6265bd80d2fa.

Revert "Merge pull request #367 from electron/cifratila/download_llvm_gold_fix"

    This reverts commit d6df80e20748f35373f15c2bfbd70befb4bb6221, reversing
    changes made to 628f0d99441016270750fda6b0781107c8d9cd76.
```