### PR TITLE
Add patch for pdf support in sub frames

### DIFF
--- a/patches/042-webui_in_subframes.patch
+++ b/patches/042-webui_in_subframes.patch
@@ -79,7 +79,7 @@ index 4fa796b38b3f..376e8e143770 100644
 +	}
 +
 +	size_t child_count = parent_frame_host->frame_tree_node()->child_count();
-+	for (int i = 0; i < child_count; ++i) {
++	for (size_t i = 0; i < child_count; ++i) {
 +		RenderFrameHostImpl *sub_frame_host =
 +			parent_frame_host->frame_tree_node()->child_at(i)->current_frame_host();
 +		SenMessageToFrameTreeWebUIs(sub_frame_host, message, dispatch_count);

--- a/patches/042-webui_in_subframes.patch
+++ b/patches/042-webui_in_subframes.patch
@@ -9,9 +9,9 @@ index 4d0a8ea553c5..0fac0b22ff2f 100644
 -RenderFrameHostDelegate::CreateWebUIForRenderFrameHost(const GURL& url) {
 -  return nullptr;
 +RenderFrameHostDelegate::CreateWebUIForRenderFrameHost(
-+	const GURL& url,
-+	const std::string& frame_name) {
-+	return nullptr;
++    const GURL& url,
++    const std::string& frame_name) {
++  return nullptr;
  }
  
  bool RenderFrameHostDelegate::ShouldAllowRunningInsecureContent(
@@ -24,8 +24,8 @@ index 197b64b49fd6..2e94b03c4f44 100644
    // applies, returns null.
    virtual std::unique_ptr<WebUIImpl> CreateWebUIForRenderFrameHost(
 -      const GURL& url);
-+	  const GURL& url,
-+	  const std::string& frame_name);
++      const GURL& url,
++      const std::string& frame_name);
  
    // Called by |frame| to notify that it has received an update on focused
    // element. |bounds_in_root_view| is the rectangle containing the element that
@@ -39,21 +39,21 @@ index 585a523bff87..2fa10398813d 100644
      } else {
 -      // Otherwise create a new pending WebUI.
 -      pending_web_ui_ = delegate_->CreateWebUIForRenderFrameHost(dest_url);
-+	  //Give the frame a name if it does not already have one
-+	  //The reason is web ui code base the frame look up on the frame name
++      // Give the frame a name if it does not already have one.
++      // The reason is web ui code base the frame look up on the frame name.
 +      std::string frame_name = GetFrameName();
-+	  if (frame_name.empty() && !frame_tree_node_->IsMainFrame()) {
-+	      frame_name = base::StringPrintf("frame_%i", frame_tree_node_->frame_tree_node_id());
-+		  frame_tree_node_->SetFrameName(frame_name, "");
++      if (frame_name.empty() && !frame_tree_node_->IsMainFrame()) {
++        frame_name = base::StringPrintf("frame_%i", frame_tree_node_->frame_tree_node_id());
++        frame_tree_node_->SetFrameName(frame_name, "");
 +      }
 +
-+	  //if the web ui is in subframes, the parent frame bindings does not have the web ui binding
-+      //So, we reset the bindings for the subframes.
++      // If the web ui is in subframes, the parent frame bindings does not have the web ui binding,
++      // so we reset the bindings for the subframes.
 +      if (!frame_tree_node_->IsMainFrame() && new_web_ui_type != WebUI::kNoWebUI) {
-+	      entry_bindings = NavigationEntryImpl::kInvalidBindings;
-+	  }
-+		
-+	  // Otherwise create a new pending WebUI.
++        entry_bindings = NavigationEntryImpl::kInvalidBindings;
++      }
++
++      // Otherwise create a new pending WebUI.
 +      pending_web_ui_ = delegate_->CreateWebUIForRenderFrameHost(dest_url, frame_name);
        DCHECK(pending_web_ui_);
        pending_web_ui_type_ = new_web_ui_type;
@@ -62,68 +62,52 @@ diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser
 index 4fa796b38b3f..376e8e143770 100644
 --- a/content/browser/web_contents/web_contents_impl.cc
 +++ b/content/browser/web_contents/web_contents_impl.cc
-@@ -685,13 +685,38 @@ RenderFrameHostManager* WebContentsImpl::GetRenderManagerForTesting() {
+@@ -685,12 +685,34 @@ RenderFrameHostManager* WebContentsImpl::GetRenderManagerForTesting() {
    return GetRenderManager();
  }
  
-+void SenMessageToFrameTreeWebUIs(RenderFrameHostImpl *parent_frame_host,
-+	const IPC::Message &message,
-+	int &dispatch_count) {
++void SendMessageToFrameTreeWebUIs(RenderFrameHostImpl* parent_frame_host,
++                                  const IPC::Message& message,
++                                  int& dispatch_count) {
++  // Get the web ui or the pending one if it's not yet commited.
++  WebUIImpl* web_ui = parent_frame_host->web_ui()
++      ? parent_frame_host->web_ui()
++      : parent_frame_host->pending_web_ui();
++  if (web_ui && web_ui->OnMessageReceived(message)) {
++    ++dispatch_count;
++  }
 +
-+	// Get the web ui or the pending one if it's not yet commited
-+	WebUIImpl *web_ui = parent_frame_host->web_ui()
-+		? parent_frame_host->web_ui()
-+		: parent_frame_host->pending_web_ui();
-+	if (web_ui && web_ui->OnMessageReceived(message)) {
-+		++dispatch_count;
-+	}
-+
-+	size_t child_count = parent_frame_host->frame_tree_node()->child_count();
-+	for (size_t i = 0; i < child_count; ++i) {
-+		RenderFrameHostImpl *sub_frame_host =
-+			parent_frame_host->frame_tree_node()->child_at(i)->current_frame_host();
-+		SenMessageToFrameTreeWebUIs(sub_frame_host, message, dispatch_count);
-+	}
++  size_t child_count = parent_frame_host->frame_tree_node()->child_count();
++  for (size_t i = 0; i < child_count; ++i) {
++    RenderFrameHostImpl* sub_frame_host =
++        parent_frame_host->frame_tree_node()->child_at(i)->current_frame_host();
++    SendMessageToFrameTreeWebUIs(sub_frame_host, message, dispatch_count);
++  }
 +}
-+
 +
  bool WebContentsImpl::OnMessageReceived(RenderViewHostImpl* render_view_host,
                                          const IPC::Message& message) {
--  RenderFrameHost* main_frame = render_view_host->GetMainFrame();
--  if (main_frame) {
+   RenderFrameHost* main_frame = render_view_host->GetMainFrame();
++  int dispatch_count = 0;
+   if (main_frame) {
 -    WebUIImpl* web_ui = static_cast<RenderFrameHostImpl*>(main_frame)->web_ui();
 -    if (web_ui && web_ui->OnMessageReceived(message))
--      return true;
-+   RenderFrameHost *main_frame = render_view_host->GetMainFrame();
-+  int dispatch_count = 0;
-+  if (main_frame) {
-+    RenderFrameHostImpl *main_frame_host =
-+        static_cast<RenderFrameHostImpl *>(main_frame);
-+    SenMessageToFrameTreeWebUIs(main_frame_host, message, dispatch_count);
-+    if (dispatch_count > 0) {
-+      return true;
-+    }
++    RenderFrameHostImpl* main_frame_host =
++        static_cast<RenderFrameHostImpl*>(main_frame);
++    SendMessageToFrameTreeWebUIs(main_frame_host, message, dispatch_count);
++    if (dispatch_count > 0)
+       return true;
    }
  
-   for (auto& observer : observers_) {
-@@ -732,6 +757,7 @@ bool WebContentsImpl::OnMessageReceived(RenderViewHostImpl* render_view_host,
-   return handled;
+@@ -5021,8 +5043,9 @@ NavigationControllerImpl& WebContentsImpl::GetControllerForRenderManager() {
  }
  
-+
- bool WebContentsImpl::OnMessageReceived(RenderFrameHostImpl* render_frame_host,
-                                         const IPC::Message& message) {
-   for (auto& observer : observers_) {
-@@ -5013,9 +5039,9 @@ NavigationControllerImpl& WebContentsImpl::GetControllerForRenderManager() {
-   return GetController();
- }
- 
--std::unique_ptr<WebUIImpl> WebContentsImpl::CreateWebUIForRenderFrameHost(
+ std::unique_ptr<WebUIImpl> WebContentsImpl::CreateWebUIForRenderFrameHost(
 -    const GURL& url) {
 -  return CreateWebUI(url, std::string());
-+std::unique_ptr<WebUIImpl>
-+WebContentsImpl::CreateWebUIForRenderFrameHost(const GURL &url, const std::string& frame_name) {
-+	return CreateWebUI(url, frame_name);
++    const GURL &url,
++    const std::string& frame_name) {
++  return CreateWebUI(url, frame_name);
  }
  
  NavigationEntry*
@@ -136,8 +120,8 @@ index 5a621c32adb4..21de4d65efe3 100644
    void EnsureOpenerProxiesExist(RenderFrameHost* source_rfh) override;
    std::unique_ptr<WebUIImpl> CreateWebUIForRenderFrameHost(
 -      const GURL& url) override;
-+	  const GURL& url,
-+	  const std::string& frame_name) override;
++    const GURL& url,
++    const std::string& frame_name) override;
    void SetFocusedFrame(FrameTreeNode* node, SiteInstance* source) override;
    void OnFocusedElementChangedInFrame(
        RenderFrameHostImpl* frame,

--- a/patches/042-webui_in_subframes.patch
+++ b/patches/042-webui_in_subframes.patch
@@ -1,0 +1,143 @@
+diff --git a/content/browser/frame_host/render_frame_host_delegate.cc b/content/browser/frame_host/render_frame_host_delegate.cc
+index 4d0a8ea553c5..0fac0b22ff2f 100644
+--- a/content/browser/frame_host/render_frame_host_delegate.cc
++++ b/content/browser/frame_host/render_frame_host_delegate.cc
+@@ -89,8 +89,10 @@ bool RenderFrameHostDelegate::ShouldRouteMessageEvent(
+ }
+ 
+ std::unique_ptr<WebUIImpl>
+-RenderFrameHostDelegate::CreateWebUIForRenderFrameHost(const GURL& url) {
+-  return nullptr;
++RenderFrameHostDelegate::CreateWebUIForRenderFrameHost(
++	const GURL& url,
++	const std::string& frame_name) {
++	return nullptr;
+ }
+ 
+ bool RenderFrameHostDelegate::ShouldAllowRunningInsecureContent(
+diff --git a/content/browser/frame_host/render_frame_host_delegate.h b/content/browser/frame_host/render_frame_host_delegate.h
+index 197b64b49fd6..2e94b03c4f44 100644
+--- a/content/browser/frame_host/render_frame_host_delegate.h
++++ b/content/browser/frame_host/render_frame_host_delegate.h
+@@ -234,7 +234,8 @@ class CONTENT_EXPORT RenderFrameHostDelegate {
+   // Creates a WebUI object for a frame navigating to |url|. If no WebUI
+   // applies, returns null.
+   virtual std::unique_ptr<WebUIImpl> CreateWebUIForRenderFrameHost(
+-      const GURL& url);
++	  const GURL& url,
++	  const std::string& frame_name);
+ 
+   // Called by |frame| to notify that it has received an update on focused
+   // element. |bounds_in_root_view| is the rectangle containing the element that
+diff --git a/content/browser/frame_host/render_frame_host_impl.cc b/content/browser/frame_host/render_frame_host_impl.cc
+index 585a523bff87..2fa10398813d 100644
+--- a/content/browser/frame_host/render_frame_host_impl.cc
++++ b/content/browser/frame_host/render_frame_host_impl.cc
+@@ -2961,8 +2961,22 @@ bool RenderFrameHostImpl::UpdatePendingWebUI(const GURL& dest_url,
+       DCHECK(web_ui_);
+       should_reuse_web_ui_ = true;
+     } else {
+-      // Otherwise create a new pending WebUI.
+-      pending_web_ui_ = delegate_->CreateWebUIForRenderFrameHost(dest_url);
++	  //Give the frame a name if it does not already have one
++	  //The reason is web ui code base the frame look up on the frame name
++      std::string frame_name = GetFrameName();
++	  if (frame_name.empty() && !frame_tree_node_->IsMainFrame()) {
++	      frame_name = base::StringPrintf("frame_%i", frame_tree_node_->frame_tree_node_id());
++		  frame_tree_node_->SetFrameName(frame_name, "");
++      }
++
++	  //if the web ui is in subframes, the parent frame bindings does not have the web ui binding
++      //So, we reset the bindings for the subframes.
++      if (!frame_tree_node_->IsMainFrame() && new_web_ui_type != WebUI::kNoWebUI) {
++	      entry_bindings = NavigationEntryImpl::kInvalidBindings;
++	  }
++		
++	  // Otherwise create a new pending WebUI.
++      pending_web_ui_ = delegate_->CreateWebUIForRenderFrameHost(dest_url, frame_name);
+       DCHECK(pending_web_ui_);
+       pending_web_ui_type_ = new_web_ui_type;
+ 
+diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
+index 4fa796b38b3f..376e8e143770 100644
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -685,13 +685,38 @@ RenderFrameHostManager* WebContentsImpl::GetRenderManagerForTesting() {
+   return GetRenderManager();
+ }
+ 
++void SenMessageToFrameTreeWebUIs(RenderFrameHostImpl *parent_frame_host,
++	const IPC::Message &message,
++	int &dispatch_count) {
++
++	// Get the web ui or the pending one if it's not yet commited
++	WebUIImpl *web_ui = parent_frame_host->web_ui()
++		? parent_frame_host->web_ui()
++		: parent_frame_host->pending_web_ui();
++	if (web_ui && web_ui->OnMessageReceived(message)) {
++		++dispatch_count;
++	}
++
++	size_t child_count = parent_frame_host->frame_tree_node()->child_count();
++	for (int i = 0; i < child_count; ++i) {
++		RenderFrameHostImpl *sub_frame_host =
++			parent_frame_host->frame_tree_node()->child_at(i)->current_frame_host();
++		SenMessageToFrameTreeWebUIs(sub_frame_host, message, dispatch_count);
++	}
++}
++
++
+ bool WebContentsImpl::OnMessageReceived(RenderViewHostImpl* render_view_host,
+                                         const IPC::Message& message) {
+-  RenderFrameHost* main_frame = render_view_host->GetMainFrame();
+-  if (main_frame) {
+-    WebUIImpl* web_ui = static_cast<RenderFrameHostImpl*>(main_frame)->web_ui();
+-    if (web_ui && web_ui->OnMessageReceived(message))
+-      return true;
++   RenderFrameHost *main_frame = render_view_host->GetMainFrame();
++  int dispatch_count = 0;
++  if (main_frame) {
++    RenderFrameHostImpl *main_frame_host =
++        static_cast<RenderFrameHostImpl *>(main_frame);
++    SenMessageToFrameTreeWebUIs(main_frame_host, message, dispatch_count);
++    if (dispatch_count > 0) {
++      return true;
++    }
+   }
+ 
+   for (auto& observer : observers_) {
+@@ -732,6 +757,7 @@ bool WebContentsImpl::OnMessageReceived(RenderViewHostImpl* render_view_host,
+   return handled;
+ }
+ 
++
+ bool WebContentsImpl::OnMessageReceived(RenderFrameHostImpl* render_frame_host,
+                                         const IPC::Message& message) {
+   for (auto& observer : observers_) {
+@@ -5013,9 +5039,9 @@ NavigationControllerImpl& WebContentsImpl::GetControllerForRenderManager() {
+   return GetController();
+ }
+ 
+-std::unique_ptr<WebUIImpl> WebContentsImpl::CreateWebUIForRenderFrameHost(
+-    const GURL& url) {
+-  return CreateWebUI(url, std::string());
++std::unique_ptr<WebUIImpl>
++WebContentsImpl::CreateWebUIForRenderFrameHost(const GURL &url, const std::string& frame_name) {
++	return CreateWebUI(url, frame_name);
+ }
+ 
+ NavigationEntry*
+diff --git a/content/browser/web_contents/web_contents_impl.h b/content/browser/web_contents/web_contents_impl.h
+index 5a621c32adb4..21de4d65efe3 100644
+--- a/content/browser/web_contents/web_contents_impl.h
++++ b/content/browser/web_contents/web_contents_impl.h
+@@ -497,7 +497,8 @@ class CONTENT_EXPORT WebContentsImpl
+       SiteInstance* source_site_instance) const override;
+   void EnsureOpenerProxiesExist(RenderFrameHost* source_rfh) override;
+   std::unique_ptr<WebUIImpl> CreateWebUIForRenderFrameHost(
+-      const GURL& url) override;
++	  const GURL& url,
++	  const std::string& frame_name) override;
+   void SetFocusedFrame(FrameTreeNode* node, SiteInstance* source) override;
+   void OnFocusedElementChangedInFrame(
+       RenderFrameHostImpl* frame,


### PR DESCRIPTION
This PR is a proposal to fix the issue https://github.com/electron/electron/issues/9192
The patch is fixing the following issues:

1) The  sub frame inherit the bindings from the main frame which does not have the web ui bindings.
Th fix is to reset the bindings fro the sub frame during the navigation

2) The user needs to set a name for the sub frame otherwise the web ui will be displayed in the main frame.  This limitation is removed by generating a name from the id for the sub frame when it hosts a web ui. A better approach would be to use the frame node id but this need a change in the chromium design for web ui which is based on the frame name.

3)  Messages are passed only to the web ui in the main frame. The fix is to iterate recursively the child frames and pass the message.
