### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Order is important. The LAST matching pattern has the MOST precedence.
+# gitignore style patterns are used, not globs.
+# https://help.github.com/articles/about-codeowners
+# https://git-scm.com/docs/gitignore
+
+* @electron/libcc
+/.github/ @electron/hubbers


### PR DESCRIPTION
The new @electron/libcc team consists of folks who regularly contribute to this repo, and their review will be required for any changes made here, with the exception of `/.github/*` which will require sign-off from a GitHub person.

If you'd like to be added to the libcc reviewer team, you can request to join at https://github.com/orgs/electron/teams/libcc/members