### PR TITLE
Temporarily turn off escape analysis in V8's Turbofan

### DIFF
--- a/patches/v8/turn_off_escape_analysis.patch
+++ b/patches/v8/turn_off_escape_analysis.patch
@@ -1,0 +1,13 @@
+diff --git a/src/flag-definitions.h b/src/flag-definitions.h
+index e6e9b7eb7a..a304326143 100644
+--- a/src/flag-definitions.h
++++ b/src/flag-definitions.h
+@@ -490,7 +490,7 @@ DEFINE_BOOL(turbo_loop_peeling, true, "Turbofan loop peeling")
+ DEFINE_BOOL(turbo_loop_variable, true, "Turbofan loop variable optimization")
+ DEFINE_BOOL(turbo_cf_optimization, true, "optimize control flow in TurboFan")
+ DEFINE_BOOL(turbo_frame_elision, true, "elide frames in TurboFan")
+-DEFINE_BOOL(turbo_escape, true, "enable escape analysis")
++DEFINE_BOOL(turbo_escape, false, "enable escape analysis")
+ DEFINE_BOOL(turbo_instruction_scheduling, false,
+             "enable instruction scheduling in TurboFan")
+ DEFINE_BOOL(turbo_stress_instruction_scheduling, false,


### PR DESCRIPTION
Fixes a security vulnerability in V8's Turbofan engine.
For detailed description see
https://blogs.technet.microsoft.com/mmpc/2017/10/18/browser-security-beyond-sandboxing/

https://crbug.com/765433
https://chromium-review.googlesource.com/670563