### PR TITLE
Add patch for nvidia GPU's on High Sierra (redo #377)

### DIFF
--- a/patches/042-high-sierra-nvidia-gpu.patch
+++ b/patches/042-high-sierra-nvidia-gpu.patch
@@ -1,0 +1,29 @@
+diff --git a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
+index ebdfca0..bcbcb4a 100644
+--- a/gpu/config/software_rendering_list.json
++++ b/gpu/config/software_rendering_list.json
+@@ -1460,6 +1460,24 @@
+       "features": [
+         "webgl2"
+       ]
++    },
++    {
++      "id": 150,
++      "description": "Macs with NVidia GPUs experience rendering issues on High Sierra",
++      "cr_bugs": [773705],
++      "os": {
++        "type": "macosx",
++        "version": {
++          "op": ">=",
++          "value": "10.13"
++        }
++      },
++      "vendor_id": "0x10de",
++      "multi_gpu_category": "any",
++      "features": [
++        "accelerated_2d_canvas",
++        "gpu_rasterization"
++      ]
+     }
+   ],
+   "comment": [


### PR DESCRIPTION
This is a redo of @MarshallOfSound's PR #377 that was merged into master a bit prematurely by myself.  This needs to be tested against a 1.8 Electron build before merging.