### PR TITLE
CI updates for building forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,67 +8,34 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c shared_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: script/create-dist -t $TARGET_ARCH
-      - run: script/upload -t $TARGET_ARCH
-
-  libchromiumcontent-linux-x64-static-build:
-    docker:
-      - image: electronbuilds/libchromiumcontent:0.0.4
-        environment:
-          TARGET_ARCH: x64
-    resource_class: xlarge
-    steps:
-      - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/static_library"
-      - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/ffmpeg"
-      - run: cp -r "src/out-${TARGET_ARCH}/static_library" "/tmp/workspace/out-${TARGET_ARCH}"
-      - run: cp -r "src/out-${TARGET_ARCH}/ffmpeg" "/tmp/workspace/out-${TARGET_ARCH}"
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - out-x64/static_library
-            - out-x64/ffmpeg
-
-  libchromiumcontent-linux-x64-shared-build:
-      docker:
-        - image: electronbuilds/libchromiumcontent:0.0.4
-          environment:
-            TARGET_ARCH: x64
-      resource_class: xlarge
-      steps:
-        - checkout
-        - run: script/bootstrap
-        - run: script/update --clean -t $TARGET_ARCH
-        - run: script/build -t $TARGET_ARCH -c shared_library
-        - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/shared_library"
-        - run: cp -r "src/out-${TARGET_ARCH}/shared_library" "/tmp/workspace/out-${TARGET_ARCH}"
-        - persist_to_workspace:
-            root: /tmp/workspace
-            paths:
-              - out-x64/shared_library
-
-  libchromiumcontent-linux-x64-upload:
-      docker:
-        - image: electronbuilds/libchromiumcontent:0.0.4
-          environment:
-            TARGET_ARCH: x64
-      resource_class: xlarge
-      steps:
-        - checkout
-        - run: script/bootstrap
-        - attach_workspace:
-            at: /home/builduser/project/src
-        - run: script/create-dist -t $TARGET_ARCH
-        - run: script/upload -t $TARGET_ARCH
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build static library
+          command: script/build -t $TARGET_ARCH -c static_library
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c shared_library
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+      - store_artifacts:
+          path: libchromiumcontent-static.zip
 
   libchromiumcontent-linux-ia32:
     docker:
@@ -78,67 +45,34 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c shared_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: script/create-dist -t $TARGET_ARCH
-      - run: script/upload -t $TARGET_ARCH
-
-  libchromiumcontent-linux-ia32-static-build:
-    docker:
-      - image: electronbuilds/libchromiumcontent:0.0.4
-        environment:
-          TARGET_ARCH: ia32
-    resource_class: xlarge
-    steps:
-      - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/static_library"
-      - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/ffmpeg"
-      - run: cp -r "src/out-${TARGET_ARCH}/static_library" "/tmp/workspace/out-${TARGET_ARCH}"
-      - run: cp -r "src/out-${TARGET_ARCH}/ffmpeg" "/tmp/workspace/out-${TARGET_ARCH}"
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - out-ia32/static_library
-            - out-ia32/ffmpeg
-
-  libchromiumcontent-linux-ia32-shared-build:
-      docker:
-        - image: electronbuilds/libchromiumcontent:0.0.4
-          environment:
-            TARGET_ARCH: ia32
-      resource_class: xlarge
-      steps:
-        - checkout
-        - run: script/bootstrap
-        - run: script/update --clean -t $TARGET_ARCH
-        - run: script/build -t $TARGET_ARCH -c shared_library
-        - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/shared_library"
-        - run: cp -r "src/out-${TARGET_ARCH}/shared_library" "/tmp/workspace/out-${TARGET_ARCH}"
-        - persist_to_workspace:
-            root: /tmp/workspace
-            paths:
-              - out-ia32/shared_library
-
-  libchromiumcontent-linux-ia32-upload:
-      docker:
-        - image: electronbuilds/libchromiumcontent:0.0.4
-          environment:
-            TARGET_ARCH: ia32
-      resource_class: xlarge
-      steps:
-        - checkout
-        - run: script/bootstrap
-        - attach_workspace:
-            at: /home/builduser/project/src
-        - run: script/create-dist -t $TARGET_ARCH
-        - run: script/upload -t $TARGET_ARCH
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build static library
+          command: script/build -t $TARGET_ARCH -c static_library
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c shared_library
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+      - store_artifacts:
+          path: libchromiumcontent-static.zip
 
   libchromiumcontent-linux-arm:
     docker:
@@ -148,67 +82,34 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c shared_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: script/create-dist -t $TARGET_ARCH
-      - run: script/upload -t $TARGET_ARCH
-
-  libchromiumcontent-linux-arm-static-build:
-    docker:
-      - image: electronbuilds/libchromiumcontent:0.0.4
-        environment:
-          TARGET_ARCH: arm
-    resource_class: xlarge
-    steps:
-      - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/static_library"
-      - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/ffmpeg"
-      - run: cp -r "src/out-${TARGET_ARCH}/static_library" "/tmp/workspace/out-${TARGET_ARCH}"
-      - run: cp -r "src/out-${TARGET_ARCH}/ffmpeg" "/tmp/workspace/out-${TARGET_ARCH}"
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - out-arm/static_library
-            - out-arm/ffmpeg
-
-  libchromiumcontent-linux-arm-shared-build:
-      docker:
-        - image: electronbuilds/libchromiumcontent:0.0.4
-          environment:
-            TARGET_ARCH: arm
-      resource_class: xlarge
-      steps:
-        - checkout
-        - run: script/bootstrap
-        - run: script/update --clean -t $TARGET_ARCH
-        - run: script/build -t $TARGET_ARCH -c shared_library
-        - run: mkdir -p "/tmp/workspace/out-${TARGET_ARCH}/shared_library"
-        - run: cp -r "src/out-${TARGET_ARCH}/shared_library" "/tmp/workspace/out-${TARGET_ARCH}"
-        - persist_to_workspace:
-            root: /tmp/workspace
-            paths:
-              - out-arm/shared_library
-
-  libchromiumcontent-linux-arm-upload:
-      docker:
-        - image: electronbuilds/libchromiumcontent:0.0.4
-          environment:
-            TARGET_ARCH: arm
-      resource_class: xlarge
-      steps:
-        - checkout
-        - run: script/bootstrap
-        - attach_workspace:
-            at: /home/builduser/project/src
-        - run: script/create-dist -t $TARGET_ARCH
-        - run: script/upload -t $TARGET_ARCH
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build static library
+          command: script/build -t $TARGET_ARCH -c static_library
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c shared_library
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+      - store_artifacts:
+          path: libchromiumcontent-static.zip
 
   libchromiumcontent-linux-arm64:
     docker:
@@ -218,13 +119,34 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c shared_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: script/create-dist -t $TARGET_ARCH
-      - run: script/upload -t $TARGET_ARCH
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build static library
+          command: script/build -t $TARGET_ARCH -c static_library
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c shared_library
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+      - store_artifacts:
+          path: libchromiumcontent-static.zip
 
 workflows:
   version: 2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,50 @@
+pipeline {
+  agent none
+  stages {
+    stage('Build') {
+      parallel {
+        stage('libchromiumcontent-osx') {
+            agent {
+              label 'osx-libcc'
+            }
+            environment {
+              LIBCHROMIUMCONTENT_GIT_CACHE='/Volumes/LIBCC_CACHE'
+            }
+            steps {
+              sh 'script/cibuild'
+            }
+            post {
+              always {
+                cleanWs()
+              }
+              success {
+                 archive 'libchromiumcontent.zip'
+                 archive 'libchromiumcontent-static.zip'
+              }
+            }
+        }
+        stage('libchromiumcontent-mas') {
+          agent {
+            label 'osx-libcc'
+          }
+          environment {
+            MAS_BUILD = '1'
+            LIBCHROMIUMCONTENT_GIT_CACHE='/Volumes/LIBCC_CACHE'
+          }
+          steps {
+            sh 'script/cibuild'
+          }
+          post {
+            always {
+              cleanWs()
+            }
+            success {
+               archive 'libchromiumcontent.zip'
+               archive 'libchromiumcontent-static.zip'
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,11 +15,9 @@ pipeline {
             }
             post {
               always {
+                archive 'libchromiumcontent.zip'
+                archive 'libchromiumcontent-static.zip'
                 cleanWs()
-              }
-              success {
-                 archive 'libchromiumcontent.zip'
-                 archive 'libchromiumcontent-static.zip'
               }
             }
         }
@@ -36,11 +34,9 @@ pipeline {
           }
           post {
             always {
+              archive 'libchromiumcontent.zip'
+              archive 'libchromiumcontent-static.zip'
               cleanWs()
-            }
-            success {
-               archive 'libchromiumcontent.zip'
-               archive 'libchromiumcontent-static.zip'
             }
           }
         }

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import platform
 import subprocess
@@ -15,31 +16,41 @@ S3_CREDENTIALS_FILE = os.path.join(JENKINS_ROOT, 'config', 's3credentials')
 
 
 def main():
+  args = parse_args()
+  skip_upload = args.skip_upload
 
-  if (not 'LIBCHROMIUMCONTENT_S3_ACCESS_KEY' in os.environ and
+  if (not skip_upload and
+     not 'LIBCHROMIUMCONTENT_S3_ACCESS_KEY' in os.environ and
      not 'LIBCHROMIUMCONTENT_S3_BUCKET' in os.environ and
      not 'LIBCHROMIUMCONTENT_S3_SECRET_KEY' in os.environ):
-     if not os.path.isfile(S3_CREDENTIALS_FILE):
-       return 'Error: Can\'t find {0}'.format(S3_CREDENTIALS_FILE)
-     copy_to_environment(S3_CREDENTIALS_FILE)
-
+     if os.path.isfile(S3_CREDENTIALS_FILE):
+       copy_to_environment(S3_CREDENTIALS_FILE)
+     else:
+       skip_upload = True
+  if (skip_upload):
+    print 'WARNING: Upload to S3 will be skipped.'
   # Use by gclient to distinguish bot builds
   os.environ['CHROME_HEADLESS'] = '1'
 
   if 'TARGET_ARCH' in os.environ:
-    return run_ci(['-t', os.environ['TARGET_ARCH']])
+    return run_ci(['-t', os.environ['TARGET_ARCH']], skip_upload)
 
   if sys.platform in ['win32', 'cygwin']:
-    return (run_ci(['-t', 'x64']) or
-            run_ci(['-t', 'ia32']))
+    return (run_ci(['-t', 'x64'], skip_upload) or
+            run_ci(['-t', 'ia32'], skip_upload))
   elif sys.platform == 'linux2':
-    return (run_ci(['-t', 'x64']) or
-            run_ci(['-t', 'ia32']) or
-            run_ci(['-t', 'arm']) or
-            run_ci(['-t', 'arm64']))
+    return (run_ci(['-t', 'x64'], skip_upload) or
+            run_ci(['-t', 'ia32'], skip_upload) or
+            run_ci(['-t', 'arm'], skip_upload) or
+            run_ci(['-t', 'arm64'], skip_upload))
   else:
-    return run_ci([])
+    return run_ci([], skip_upload)
 
+def parse_args():
+  parser = argparse.ArgumentParser(description='Run CI build')
+  parser.add_argument('-s', '--skip_upload', action='store_true',
+                      help='Skip uploading to S3')
+  return parser.parse_args()
 
 def copy_to_environment(credentials_file):
     with open(credentials_file, 'r') as f:
@@ -60,7 +71,7 @@ def os_version():
     return platform.platform()
 
 
-def run_ci(args):
+def run_ci(args, skip_upload):
   if sys.platform in ['win32', 'cygwin']:
     target_arch = args[1]
     # Set build env for VS.
@@ -74,10 +85,12 @@ def run_ci(args):
           run_script('update', ['--clean'] + args) or
           run_script('build', args) or
           run_script('create-dist', args) or
-          run_script('upload', args))
+          run_script('upload', args, skip_upload))
 
 
-def run_script(script, args=[]):
+def run_script(script, args=[], skip_run=False):
+  if skip_run:
+    return True
   script = os.path.join('script', script)
   sys.stderr.write('+ {0}\n'.format(script))
   sys.stderr.flush()

--- a/script/cibuild
+++ b/script/cibuild
@@ -90,7 +90,7 @@ def run_ci(args, skip_upload):
 
 def run_script(script, args=[], skip_run=False):
   if skip_run:
-    return True
+    return 0
   script = os.path.join('script', script)
   sys.stderr.write('+ {0}\n'.format(script))
   sys.stderr.flush()

--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -1,3 +1,4 @@
+param([switch]$skipUpload)
 function Run-Command([scriptblock]$Command, [switch]$Fatal, [switch]$Quiet) {
   $output = ""
   try {
@@ -32,4 +33,8 @@ function Run-Command([scriptblock]$Command, [switch]$Fatal, [switch]$Quiet) {
 }
 
 Write-Output ""
-Run-Command -Fatal { python .\script\cibuild }
+if ($skipUpload) {
+  Run-Command -Fatal { python .\script\cibuild --skip_upload }
+} else {
+  Run-Command -Fatal { python .\script\cibuild }
+}


### PR DESCRIPTION
This PR does a couple of things:
1. Allows builds of forked PRs.  Forked PRs were not properly building because AppVeyor and CircleCI don't pass the S3 credentials to PRs that come from forks, and this is a good thing because **security**.  This change will allow those prs to build, but they won't upload to S3.  Eventually once we introduce tests to libchromiumcontent we can run those test for these type of PRs.
2. Storage of libchromiumcontent.zip and libchromiumcontent-static.zip as artifacts on the CI build.  This is particularly useful for PRs that come from forks because those builds don't get uploaded to S3 (see 1.)
3. Adds a Jenkins pipeline build for libcc.  These builds can be specifically restarted unlike our current Jenkins setup where you can only re-run the last build that was run.
