### PR TITLE
Collect objects from third_party/libdrm

### DIFF
--- a/chromiumcontent/build_libs.py
+++ b/chromiumcontent/build_libs.py
@@ -59,6 +59,7 @@ with open(args.out, 'w') as out:
             "third_party/iccjpeg",
             "third_party/isimpledom",
             "third_party/leveldatabase",
+            "third_party/libdrm",
             "third_party/libXNVCtrl",
             "third_party/libjingle",
             "third_party/libjpeg_turbo",


### PR DESCRIPTION
The `third_party/libdrm` is build and used by some code of content module, but the linker could build electron without it since electron is not using related code. However the linker of mips64el is not so advanced to optimize the dependency out and we have to ship it as part of libcc.