### PR TITLE
Build static_library and ffmpeg with is_official_build = true

### DIFF
--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -1,3 +1,5 @@
+import("//build/split_static_library.gni")
+
 group("targets") {
   deps = []
 
@@ -314,8 +316,19 @@ if (is_electron_build && !is_component_build) {
     }
   }
 
-  static_library("webkit") {
+  split_static_library("webkit") {
     complete_static_lib = true
+
+    # Split into multiple static libraries on Windows.
+    # We have hit size limits on Windows official builds.
+    # (We must check if sources actually exist before building
+    # a split library, otherwise build will fail with an error.)
+    if (is_win && defined(obj_webkit)) {
+      split_count = 7
+    } else {
+      split_count = 1
+    }
+
     sources = []
     if (defined(obj_webkit)) {
       sources += obj_webkit

--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -7,6 +7,10 @@ proprietary_codecs = false
 is_component_ffmpeg = true
 ffmpeg_branding = "Chromium"
 
+# Everything that is intended to be shipped to users,
+# should be built with `is_official_build = true`.
+is_official_build = true
+
 # Always use the system provided standard library
 use_custom_libcxx = false
 

--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -9,6 +9,10 @@ proprietary_codecs = true
 is_component_ffmpeg = true
 ffmpeg_branding = "Chrome"
 
+# Everything that is intended to be shipped to users,
+# should be built with `is_official_build = true`.
+is_official_build = true
+
 # Always use the system provided standard library
 use_custom_libcxx = false
 


### PR DESCRIPTION
Fixes #358.

/cc @alespergl, @cifratila 

| Platform  | libcc |Electron |
| ------------- | ------------- | ------------- |
| osx/x64  | ✓  | ✓  |
| mas/x64  | ✓  | ✓  |
| win/ia32  | ✓  | [✘](https://windows-ci.electronjs.org/project/AppVeyor/electron/build/1.0.1279/job/u8wcf4d1hnkobt71)  |
| win/x64  | ✓  | [✘](https://windows-ci.electronjs.org/project/AppVeyor/electron/build/1.0.1279/job/bn23y291jn6yguy6)  |
| linux/ia32  | ✓  | ✓  |
| linux/x64  | ✓  | [✘](https://circleci.com/gh/electron/electron/4694)  |
| linux/arm  | ✓  | ✓  |
| linux/arm64  | ✓  | ✓  |
| linux/mips64el  | N/A  | N/A  |