### PR TITLE
[RFC] [WIP] Test Electron after building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,52 @@ jobs:
       - store_artifacts:
           path: libchromiumcontent-static.zip
 
+  libchromiumcontent-linux-x64-test:
+    docker:
+      - image: electronbuilds/electron:0.0.3
+        environment:
+          TARGET_ARCH: x64
+          DISPLAY: ':99.0'
+    resource_class: 2xlarge
+    steps:
+      - run:
+          name: Checkout Electron for testing
+          command: |
+            git clone --depth 1 https://github.com/electron/electron.git
+      - run:
+          name: Setup for headless testing
+          command: sh -e /etc/init.d/xvfb start
+      - run:
+         name: Bootstrap Electron
+         command: |
+            cd electron
+            echo 'export LIBCHROMIUMCONTENT_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
+            echo "Bootstrapping Electron for release build with commit $CIRCLE_SHA1"
+            script/bootstrap.py --target_arch=$TARGET_ARCH
+      - run:
+         name: Build Electron release
+         command: |
+            cd electron
+            script/build.py -c R
+      - run:
+          name: Test Electron
+          environment:
+            MOCHA_FILE: junit/test-results.xml
+            MOCHA_REPORTER: mocha-junit-reporter
+          command: |
+            cd electron
+            mkdir junit
+            script/test.py --ci -c R
+      - run:
+          name: Verify FFmpeg
+          command: |
+             cd electron
+             script/verify-ffmpeg.py
+      - store_test_results:
+          path: electron/junit
+      - store_artifacts:
+          path: electron/junit
+
   libchromiumcontent-linux-ia32-shared:
     docker:
       - image: electronbuilds/libchromiumcontent:0.0.4
@@ -356,6 +402,10 @@ workflows:
     jobs:
       - libchromiumcontent-linux-x64-shared
       - libchromiumcontent-linux-x64-static
+      - libchromiumcontent-linux-x64-test:
+          requires:
+            - libchromiumcontent-linux-x64-shared
+            - libchromiumcontent-linux-x64-static
   build-ia32:
     jobs:
       - libchromiumcontent-linux-ia32-shared

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,5 +131,56 @@ pipeline {
         }
       }
     }
+    stage('Test') {
+      parallel {
+        stage('libchromiumcontent-osx-test') {
+          agent {
+            label 'osx'
+          }
+          steps {
+            script {
+              env.LIBCHROMIUMCONTENT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+            }
+            sh 'git clone --depth 1 https://github.com/electron/electron.git'
+            dir('electron') {
+              sh 'script/bootstrap.py --target_arch=x64'
+              sh 'script/build.py -c R'
+              sh 'script/test.py --ci -c R'
+              sh 'script/verify-ffmpeg.py'
+            }
+          }
+          post {
+            always {
+              cleanWs()
+            }
+          }
+        }
+        stage('libchromiumcontent-mas-test') {
+          agent {
+            label 'osx'
+          }
+          environment {
+            MAS_BUILD = '1'
+          }
+          steps {
+            script {
+              env.LIBCHROMIUMCONTENT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+            }
+            sh 'git clone --depth 1 https://github.com/electron/electron.git'
+            dir('electron') {
+              sh 'script/bootstrap.py --target_arch=x64'
+              sh 'script/build.py -c R'
+              sh 'script/test.py --ci -c R'
+              sh 'script/verify-ffmpeg.py'
+            }
+          }
+          post {
+            always {
+              cleanWs()
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,25 @@ build_script:
       Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
     } else {
       script\cibuild.ps1
+
+      if ($? -ne 'True') {
+        throw "Build failed with exit code $?"
+      } else {
+        "Build succeeded."
+      }
     }
-test: off
+test_script:
+- ps: >-
+    if ($env:COMPONENT -eq 'shared_library') {
+      $env:DISABLE_CRASH_REPORTER_TESTS = 'true'
+      $env:LIBCHROMIUMCONTENT_COMMIT = $env:APPVEYOR_REPO_COMMIT
+      git clone --depth 1 https://github.com/electron/electron.git
+      cd electron
+      Write-Output "Bootstrapping for commit $env:LIBCHROMIUMCONTENT_COMMIT"
+      python script\bootstrap.py -v --dev --libcc_source_path d:\build\dist\main\src --libcc_shared_library_path d:\build\dist\main\shared_library --libcc_static_library_path d:\build\dist\main\static_library
+      python script\build.py -c D
+      python script\test.py --ci
+    }
 artifacts:
 - path: libchromiumcontent.zip
   name: libchromiumcontent.zip


### PR DESCRIPTION
In #360, @alexeykuzmin and I were talking about running Electron tests from a libcc build.  This PR does that, but not everything about it is ideal.  Both CircleCI and Jenkins pipelines allow us to create workflows that wait until both the static and shared builds are done, but for AppVeyor we can't really do that.  So for AppVeyor we build a debug Electron build from master and run tests against that at the end of the shared builds.  CircleCI and Jenkins build a release Electron and run tests against that.