### PR TITLE
[webrtc][mac] cherry-pick fix for laggy mouse during desktop capture

### DIFF
--- a/patches/third_party/webrtc/001-fix_laggy_mouse_during_desktop_capture.patch
+++ b/patches/third_party/webrtc/001-fix_laggy_mouse_during_desktop_capture.patch
@@ -1,0 +1,27 @@
+diff --git a/modules/desktop_capture/screen_capturer_mac.mm b/modules/desktop_capture/screen_capturer_mac.mm
+index f48b30774..0fcdfc61f 100644
+--- a/modules/desktop_capture/screen_capturer_mac.mm
++++ b/modules/desktop_capture/screen_capturer_mac.mm
+@@ -966,8 +966,21 @@ void ScreenRefresh(CGRectCount count,
+             ScreenRefresh(count, rects, display_origin);
+           }
+         };
++
++    CFDictionaryRef properties_dict = CFDictionaryCreate(kCFAllocatorDefault,
++                                                         (const void* []){kCGDisplayStreamShowCursor},
++                                                         (const void* []){kCFBooleanFalse},
++                                                         1,
++                                                         &kCFTypeDictionaryKeyCallBacks,
++                                                         &kCFTypeDictionaryValueCallBacks);
++
+     CGDisplayStreamRef display_stream = CGDisplayStreamCreate(
+-        display_id, pixel_width, pixel_height, 'BGRA', nullptr, handler);
++        display_id, pixel_width, pixel_height, 'BGRA', properties_dict, handler);
++
++    if (properties_dict) {
++      CFRelease(properties_dict);
++      properties_dict = nullptr;
++    }
+ 
+     if (display_stream) {
+       CGError error = CGDisplayStreamStart(display_stream);


### PR DESCRIPTION
The mouse is being capture twice, one time with a custom way
and one time with a built-in Mac API. The later was not known
so the mouse was wrongly captured twice.
Also the later way causes the cursor to move slowly on the
machine that is being captured.

The solution is just to disable this build-in way to just
keep the former way.

https://webrtc-review.googlesource.com/c/src/+/30902