### PR TITLE
Upgrade Node to v9.3.0 for Chromium 62

### DIFF
--- a/patches/v8/026-cherry_pick_c690f54d95802.patch
+++ b/patches/v8/026-cherry_pick_c690f54d95802.patch
@@ -1,0 +1,85 @@
+diff --git a/include/v8-platform.h b/include/v8-platform.h
+index 3df78a81c0..01b9231103 100644
+--- a/include/v8-platform.h
++++ b/include/v8-platform.h
+@@ -36,6 +36,51 @@ class IdleTask {
+   virtual void Run(double deadline_in_seconds) = 0;
+ };
+ 
++/**
++ * A TaskRunner allows scheduling of tasks. The TaskRunner may still be used to
++ * post tasks after the isolate gets destructed, but these tasks may not get
++ * executed anymore. All tasks posted to a given TaskRunner will be invoked in
++ * sequence. Tasks can be posted from any thread.
++ */
++class TaskRunner {
++ public:
++  /**
++   * Schedules a task to be invoked by this TaskRunner. The TaskRunner
++   * implementation takes ownership of |task|.
++   */
++  virtual void PostTask(std::unique_ptr<Task> task) = 0;
++
++  /**
++   * Schedules a task to be invoked by this TaskRunner. The task is scheduled
++   * after the given number of seconds |delay_in_seconds|. The TaskRunner
++   * implementation takes ownership of |task|.
++   */
++  virtual void PostDelayedTask(std::unique_ptr<Task> task,
++                               double delay_in_seconds) = 0;
++
++  /**
++   * Schedules an idle task to be invoked by this TaskRunner. The task is
++   * scheduled when the embedder is idle. Requires that
++   * TaskRunner::SupportsIdleTasks(isolate) is true. Idle tasks may be reordered
++   * relative to other task types and may be starved for an arbitrarily long
++   * time if no idle time is available. The TaskRunner implementation takes
++   * ownership of |task|.
++   */
++  virtual void PostIdleTask(std::unique_ptr<IdleTask> task) = 0;
++
++  /**
++   * Returns true if idle tasks are enabled for this TaskRunner.
++   */
++  virtual bool IdleTasksEnabled() = 0;
++
++  TaskRunner() = default;
++  virtual ~TaskRunner() = default;
++
++ private:
++  TaskRunner(const TaskRunner&) = delete;
++  TaskRunner& operator=(const TaskRunner&) = delete;
++};
++
+ /**
+  * The interface represents complex arguments to trace events.
+  */
+@@ -141,6 +186,28 @@ class Platform {
+    */
+   virtual size_t NumberOfAvailableBackgroundThreads() { return 0; }
+ 
++  /**
++   * Returns a TaskRunner which can be used to post a task on the foreground.
++   * This function should only be called from a foreground thread.
++   */
++  virtual std::unique_ptr<v8::TaskRunner> GetForegroundTaskRunner(
++      Isolate* isolate) {
++    // TODO(ahaas): Make this function abstract after it got implemented on all
++    // platforms.
++    return {};
++  }
++
++  /**
++   * Returns a TaskRunner which can be used to post a task on a background.
++   * This function should only be called from a foreground thread.
++   */
++  virtual std::unique_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
++      Isolate* isolate) {
++    // TODO(ahaas): Make this function abstract after it got implemented on all
++    // platforms.
++    return {};
++  }
++
+   /**
+    * Schedules a task to be invoked on a background thread. |expected_runtime|
+    * indicates that the task will run a long time. The Platform implementation

--- a/patches/v8/027-cherry_pick_98c40a4bae915.patch
+++ b/patches/v8/027-cherry_pick_98c40a4bae915.patch
@@ -1,0 +1,22 @@
+diff --git a/include/v8-platform.h b/include/v8-platform.h
+index 01b9231103..d4df9c01d3 100644
+--- a/include/v8-platform.h
++++ b/include/v8-platform.h
+@@ -190,7 +190,7 @@ class Platform {
+    * Returns a TaskRunner which can be used to post a task on the foreground.
+    * This function should only be called from a foreground thread.
+    */
+-  virtual std::unique_ptr<v8::TaskRunner> GetForegroundTaskRunner(
++  virtual std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(
+       Isolate* isolate) {
+     // TODO(ahaas): Make this function abstract after it got implemented on all
+     // platforms.
+@@ -201,7 +201,7 @@ class Platform {
+    * Returns a TaskRunner which can be used to post a task on a background.
+    * This function should only be called from a foreground thread.
+    */
+-  virtual std::unique_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
++  virtual std::shared_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
+       Isolate* isolate) {
+     // TODO(ahaas): Make this function abstract after it got implemented on all
+     // platforms.

--- a/patches/v8/029-backport_14ac02c.patch
+++ b/patches/v8/029-backport_14ac02c.patch
@@ -1,0 +1,107 @@
+diff --git a/src/profiler/profiler-listener.cc b/src/profiler/profiler-listener.cc
+index 169b12da07..540d930024 100644
+--- a/src/profiler/profiler-listener.cc
++++ b/src/profiler/profiler-listener.cc
+@@ -16,11 +16,7 @@ namespace internal {
+ ProfilerListener::ProfilerListener(Isolate* isolate)
+     : function_and_resource_names_(isolate->heap()) {}
+
+-ProfilerListener::~ProfilerListener() {
+-  for (auto code_entry : code_entries_) {
+-    delete code_entry;
+-  }
+-}
++ProfilerListener::~ProfilerListener() = default;
+
+ void ProfilerListener::CallbackEvent(Name* name, Address entry_point) {
+   CodeEventsContainer evt_rec(CodeEventRecord::CODE_CREATION);
+@@ -286,19 +282,23 @@ CodeEntry* ProfilerListener::NewCodeEntry(
+     CodeEventListener::LogEventsAndTags tag, const char* name,
+     const char* name_prefix, const char* resource_name, int line_number,
+     int column_number, JITLineInfoTable* line_info, Address instruction_start) {
+-  CodeEntry* code_entry =
+-      new CodeEntry(tag, name, name_prefix, resource_name, line_number,
+-                    column_number, line_info, instruction_start);
+-  code_entries_.push_back(code_entry);
+-  return code_entry;
++  std::unique_ptr<CodeEntry> code_entry = base::make_unique<CodeEntry>(
++      tag, name, name_prefix, resource_name, line_number, column_number,
++      line_info, instruction_start);
++  CodeEntry* raw_code_entry = code_entry.get();
++  code_entries_.push_back(std::move(code_entry));
++  return raw_code_entry;
+ }
+
+ void ProfilerListener::AddObserver(CodeEventObserver* observer) {
+   base::LockGuard<base::Mutex> guard(&mutex_);
+-  if (std::find(observers_.begin(), observers_.end(), observer) !=
+-      observers_.end())
+-    return;
+-  observers_.push_back(observer);
++  if (observers_.empty()) {
++    code_entries_.clear();
++  }
++  if (std::find(observers_.begin(), observers_.end(), observer) ==
++      observers_.end()) {
++    observers_.push_back(observer);
++  }
+ }
+
+ void ProfilerListener::RemoveObserver(CodeEventObserver* observer) {
+diff --git a/src/profiler/profiler-listener.h b/src/profiler/profiler-listener.h
+index f4a9e24c7d..440afd87a2 100644
+--- a/src/profiler/profiler-listener.h
++++ b/src/profiler/profiler-listener.h
+@@ -74,6 +74,7 @@ class ProfilerListener : public CodeEventListener {
+   const char* GetFunctionName(const char* name) {
+     return function_and_resource_names_.GetFunctionName(name);
+   }
++  size_t entries_count_for_test() const { return code_entries_.size(); }
+
+  private:
+   void RecordInliningInfo(CodeEntry* entry, AbstractCode* abstract_code);
+@@ -87,7 +88,7 @@ class ProfilerListener : public CodeEventListener {
+   }
+
+   StringsStorage function_and_resource_names_;
+-  std::vector<CodeEntry*> code_entries_;
++  std::vector<std::unique_ptr<CodeEntry>> code_entries_;
+   std::vector<CodeEventObserver*> observers_;
+   base::Mutex mutex_;
+
+diff --git a/test/cctest/test-cpu-profiler.cc b/test/cctest/test-cpu-profiler.cc
+index 1ffb5dfcaf..733a602cfc 100644
+--- a/test/cctest/test-cpu-profiler.cc
++++ b/test/cctest/test-cpu-profiler.cc
+@@ -2192,3 +2192,31 @@ TEST(TracingCpuProfiler) {
+
+   i::V8::SetPlatformForTesting(old_platform);
+ }
++
++TEST(CodeEntriesMemoryLeak) {
++  v8::HandleScope scope(CcTest::isolate());
++  v8::Local<v8::Context> env = CcTest::NewContext(PROFILER_EXTENSION);
++  v8::Context::Scope context_scope(env);
++
++  std::string source = "function start() {}\n";
++  for (int i = 0; i < 1000; ++i) {
++    source += "function foo" + std::to_string(i) + "() { return " +
++              std::to_string(i) +
++              "; }\n"
++              "foo" +
++              std::to_string(i) + "();\n";
++  }
++  CompileRun(source.c_str());
++  v8::Local<v8::Function> function = GetFunction(env, "start");
++
++  ProfilerHelper helper(env);
++
++  for (int j = 0; j < 100; ++j) {
++    v8::CpuProfile* profile = helper.Run(function, nullptr, 0);
++    profile->Delete();
++  }
++  ProfilerListener* profiler_listener =
++      CcTest::i_isolate()->logger()->profiler_listener();
++
++  CHECK_GE(10000ul, profiler_listener->entries_count_for_test());
++}


### PR DESCRIPTION
- [ ] 9f282ddaf7 deps: cherry-pick 1420e44db0 from upstream V8
- [ ] 49d23a3021 deps: V8: backport 14ac02c from upstream
- [ ] 7c2a9bba64 deps: patch V8 to 6.2.414.46
- [x] 04115724dc deps: cherry-pick 98c40a4bae915 from V8 upstream
- [x] 7812c93a41 deps: cherry-pick c690f54d95802 from V8 upstream

I'm fairly certain we don't need to apply either of these since the first is reverted by the second:
- 47cd49a8cb deps: backport 3c8195d from V8 upstream
- 465a32a087 Revert "deps: cherry-pick 3c8195d from V8 upstream"

/cc @alexeykuzmin 
