### PR TITLE
Add patch to allow disabling gin's V8 platform

### DIFF
--- a/patches/073-gin_enable_disable_v8_platform.patch
+++ b/patches/073-gin_enable_disable_v8_platform.patch
@@ -1,0 +1,66 @@
+diff --git a/gin/isolate_holder.cc b/gin/isolate_holder.cc
+index 6df4689e0ec5..689a9809561a 100644
+--- a/gin/isolate_holder.cc
++++ b/gin/isolate_holder.cc
+@@ -106,9 +106,10 @@ IsolateHolder::~IsolateHolder() {
+ // static
+ void IsolateHolder::Initialize(ScriptMode mode,
+                                V8ExtrasMode v8_extras_mode,
+-                               v8::ArrayBuffer::Allocator* allocator) {
++                               v8::ArrayBuffer::Allocator* allocator,
++                               bool create_v8_platform) {
+   CHECK(allocator);
+-  V8Initializer::Initialize(mode, v8_extras_mode);
++  V8Initializer::Initialize(mode, v8_extras_mode, create_v8_platform);
+   g_array_buffer_allocator = allocator;
+ }
+ 
+diff --git a/gin/public/isolate_holder.h b/gin/public/isolate_holder.h
+index fb7ffe0880f0..44851f21e94f 100644
+--- a/gin/public/isolate_holder.h
++++ b/gin/public/isolate_holder.h
+@@ -79,7 +79,8 @@ class GIN_EXPORT IsolateHolder {
+   // V8Initializer::LoadV8Snapshot) before calling this method.
+   static void Initialize(ScriptMode mode,
+                          V8ExtrasMode v8_extras_mode,
+-                         v8::ArrayBuffer::Allocator* allocator);
++                         v8::ArrayBuffer::Allocator* allocator,
++                         bool create_v8_platform = true);
+ 
+   v8::Isolate* isolate() { return isolate_; }
+ 
+diff --git a/gin/v8_initializer.cc b/gin/v8_initializer.cc
+index e03635f4378f..d6274f66da1a 100644
+--- a/gin/v8_initializer.cc
++++ b/gin/v8_initializer.cc
+@@ -321,12 +321,14 @@ base::FilePath V8Initializer::GetSnapshotFilePath(bool abi_32_bit) {
+ 
+ // static
+ void V8Initializer::Initialize(IsolateHolder::ScriptMode mode,
+-                               IsolateHolder::V8ExtrasMode v8_extras_mode) {
++                               IsolateHolder::V8ExtrasMode v8_extras_mode,
++                               bool create_v8_platform) {
+   static bool v8_is_initialized = false;
+   if (v8_is_initialized)
+     return;
+ 
+-  v8::V8::InitializePlatform(V8Platform::Get());
++  if (create_v8_platform)
++    v8::V8::InitializePlatform(V8Platform::Get());
+ 
+   if (IsolateHolder::kStrictMode == mode) {
+     static const char use_strict[] = "--use_strict";
+diff --git a/gin/v8_initializer.h b/gin/v8_initializer.h
+index f0a7c5e0fb68..df4ab4f3e4b9 100644
+--- a/gin/v8_initializer.h
++++ b/gin/v8_initializer.h
+@@ -21,7 +21,8 @@ class GIN_EXPORT V8Initializer {
+  public:
+   // This should be called by IsolateHolder::Initialize().
+   static void Initialize(IsolateHolder::ScriptMode mode,
+-                         IsolateHolder::V8ExtrasMode v8_extras_mode);
++                         IsolateHolder::V8ExtrasMode v8_extras_mode,
++                         bool create_v8_platform = true);
+ 
+   // Get address and size information for currently loaded snapshot.
+   // If no snapshot is loaded, the return values are null for addresses


### PR DESCRIPTION
This is part of the fix for the V8 startup dead lock problem on Chrome61. The same patch has already been applied on the Chrome62 branch.

/cc @alexeykuzmin The patch is identical and you may encounter conflicts when rebasing.