### PR TITLE
Backport a WebRTC patch for video cropping to prevent freezes.

### DIFF
--- a/patches/third_party/webrtc/002-crop_video_to_prevent_freezes.patch
+++ b/patches/third_party/webrtc/002-crop_video_to_prevent_freezes.patch
@@ -1,0 +1,75 @@
+diff --git a/video/vie_encoder.cc b/video/vie_encoder.cc
+index 3a848f852..825451084 100644
+--- a/video/vie_encoder.cc
++++ b/video/vie_encoder.cc
+@@ -494,6 +494,20 @@ void ViEEncoder::ReconfigureEncoder() {
+       encoder_config_.video_stream_factory->CreateEncoderStreams(
+           last_frame_info_->width, last_frame_info_->height, encoder_config_);
+ 
++  // TODO(ilnik): If configured resolution is significantly less than provided,
++  // e.g. because there are not enough SSRCs for all simulcast streams,
++  // signal new resolutions via SinkWants to video source.
++
++  // Stream dimensions may be not equal to given because of a simulcast
++  // restrictions.
++  int highest_stream_width = static_cast<int>(streams.back().width);
++  int highest_stream_height = static_cast<int>(streams.back().height);
++  // Dimension may be reduced to be, e.g. divisible by 4.
++  RTC_CHECK_GE(last_frame_info_->width, highest_stream_width);
++  RTC_CHECK_GE(last_frame_info_->height, highest_stream_height);
++  crop_width_ = last_frame_info_->width - highest_stream_width;
++  crop_height_ = last_frame_info_->height - highest_stream_height;
++
+   VideoCodec codec;
+   if (!VideoCodecInitializer::SetupCodec(encoder_config_, settings_, streams,
+                                          nack_enabled_, &codec,
+@@ -690,12 +704,34 @@ void ViEEncoder::EncodeVideoFrame(const VideoFrame& video_frame,
+   }
+   TraceFrameDropEnd();
+ 
++  VideoFrame out_frame(video_frame);
++  // Crop frame if needed.
++  if (crop_width_ > 0 || crop_height_ > 0) {
++    int cropped_width = video_frame.width() - crop_width_;
++    int cropped_height = video_frame.height() - crop_height_;
++    rtc::scoped_refptr<I420Buffer> cropped_buffer =
++        I420Buffer::Create(cropped_width, cropped_height);
++    // TODO(ilnik): Remove scaling if cropping is too big, as it should never
++    // happen after SinkWants signaled correctly from ReconfigureEncoder.
++    if (crop_width_ < 4 && crop_height_ < 4) {
++      cropped_buffer->CropAndScaleFrom(
++          *video_frame.video_frame_buffer(), crop_width_ / 2, crop_height_ / 2,
++          cropped_width, cropped_height);
++    } else {
++      cropped_buffer->ScaleFrom(*video_frame.video_frame_buffer());
++    }
++    out_frame =
++        VideoFrame(cropped_buffer, video_frame.timestamp(),
++                   video_frame.render_time_ms(), video_frame.rotation());
++    out_frame.set_ntp_time_ms(video_frame.ntp_time_ms());
++  }
++
+   TRACE_EVENT_ASYNC_STEP0("webrtc", "Video", video_frame.render_time_ms(),
+                           "Encode");
+ 
+-  overuse_detector_.FrameCaptured(video_frame, time_when_posted_us);
++  overuse_detector_.FrameCaptured(out_frame, time_when_posted_us);
+ 
+-  video_sender_.AddVideoFrame(video_frame, nullptr);
++  video_sender_.AddVideoFrame(out_frame, nullptr);
+ }
+ 
+ void ViEEncoder::SendKeyFrame() {
+diff --git a/video/vie_encoder.h b/video/vie_encoder.h
+index 213ff6d0a..b0a9b077e 100644
+--- a/video/vie_encoder.h
++++ b/video/vie_encoder.h
+@@ -211,6 +211,8 @@ class ViEEncoder : public rtc::VideoSinkInterface<VideoFrame>,
+   // encoder on the next frame.
+   bool pending_encoder_reconfiguration_ ACCESS_ON(&encoder_queue_);
+   rtc::Optional<VideoFrameInfo> last_frame_info_ ACCESS_ON(&encoder_queue_);
++  int crop_width_ ACCESS_ON(&encoder_queue_);
++  int crop_height_ ACCESS_ON(&encoder_queue_);
+   uint32_t encoder_start_bitrate_bps_ ACCESS_ON(&encoder_queue_);
+   size_t max_data_payload_length_ ACCESS_ON(&encoder_queue_);
+   bool nack_enabled_ ACCESS_ON(&encoder_queue_);


### PR DESCRIPTION
Fixes the problem documented in this bug:
https://bugs.chromium.org/p/webrtc/issues/detail?id=6958

where the encoder receives frame sizes it's not expecting and errors
out. The fix landed in M61:
https://codereview.webrtc.org/2936393002

This applies the critical pieces of that change to crop and scale poorly
sized frames before they hit the encoder.

Verified the fix with Slack video calling. It's easy to reproduce by
requesting a 641x480 getUserMedia stream from the camera. The logs will
be filled with this error:
```
Incoming frame doesn't match set resolution. Dropping.
```