### PR TITLE
Disable the mips64el job on electron-1-8-x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,3 @@ workflows:
   build-arm64:
     jobs:
       - libchromiumcontent-linux-arm64
-  build-mips64el:
-    jobs:
-      - libchromiumcontent-linux-mips64el


### PR DESCRIPTION
The fix for Intel bugs are slowing down our CI machine, making the mips64el job timeout. Will look into this in future.