### PR TITLE
Backport WebRTC fix for connection failures with restrictive firewalls (master).

### DIFF
--- a/patches/third_party/webrtc/003-connect_using_hostname_on_dns_failure_over_tls.patch
+++ b/patches/third_party/webrtc/003-connect_using_hostname_on_dns_failure_over_tls.patch
@@ -1,0 +1,24 @@
+diff --git a/p2p/base/turnport.cc b/p2p/base/turnport.cc
+index 901516922..52280c4a3 100644
+--- a/p2p/base/turnport.cc
++++ b/p2p/base/turnport.cc
+@@ -686,7 +686,8 @@ void TurnPort::OnResolveResult(rtc::AsyncResolverInterface* resolver) {
+   // one of the reason could be due to DNS queries blocked by firewall.
+   // In such cases we will try to connect to the server with hostname, assuming
+   // socket layer will resolve the hostname through a HTTP proxy (if any).
+-  if (resolver_->GetError() != 0 && server_address_.proto == PROTO_TCP) {
++  if (resolver_->GetError() != 0 && (server_address_.proto == PROTO_TCP ||
++                                     server_address_.proto == PROTO_TLS)) {
+     if (!CreateTurnClientSocket()) {
+       OnAllocateError();
+     }
+@@ -805,7 +806,8 @@ void TurnPort::OnMessage(rtc::Message* message) {
+         // Since it's TCP, we have to delete the connected socket and reconnect
+         // with the alternate server. PrepareAddress will send stun binding once
+         // the new socket is connected.
+-        RTC_DCHECK(server_address().proto == PROTO_TCP);
++        RTC_DCHECK(server_address().proto == PROTO_TCP ||
++                   server_address().proto == PROTO_TLS);
+         RTC_DCHECK(!SharedSocket());
+         delete socket_;
+         socket_ = NULL;


### PR DESCRIPTION
Addresses the problem described here:
https://bugs.chromium.org/p/webrtc/issues/detail?id=8102

where, after DNS resolution fails with a restrictive firewall, TLS
connections fail immediately.

As pointed out here in the bug:
https://bugs.chromium.org/p/webrtc/issues/detail?id=8102#c7

the problem is fixed with this change:
https://chromium-review.googlesource.com/c/external/webrtc/+/611520/9/webrtc/p2p/base/turnport.cc

which allows the connection attempt to proceed using the hostname as intended.