### PR TITLE
Turn off use_nss_certs for mips64el

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,46 @@
 version: 2.0
 jobs:
-  libchromiumcontent-linux-x64:
+  libchromiumcontent-linux-x64-shared:
     docker:
       - image: electronbuilds/libchromiumcontent:0.0.4
         environment:
           TARGET_ARCH: x64
+          COMPONENT: shared_library
+    resource_class: 2xlarge
+    steps:
+      - checkout
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              echo "Skipping upload to S3"
+            else
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+
+  libchromiumcontent-linux-x64-static:
+    docker:
+      - image: electronbuilds/libchromiumcontent:0.0.4
+        environment:
+          TARGET_ARCH: x64
+          COMPONENT: static_library
     resource_class: 2xlarge
     steps:
       - checkout
@@ -16,16 +52,13 @@ jobs:
           command: script/update --clean -t $TARGET_ARCH
       - run:
           name: Build static library
-          command: script/build -t $TARGET_ARCH -c static_library
-      - run:
-          name: Build shared library
-          command: script/build -t $TARGET_ARCH -c shared_library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Build FFmpeg
           command: script/build -t $TARGET_ARCH -c ffmpeg
       - run:
           name: Create distribution
-          command: script/create-dist -t $TARGET_ARCH
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Upload to S3
           command: |
@@ -35,15 +68,49 @@ jobs:
               script/upload -t $TARGET_ARCH
             fi
       - store_artifacts:
-          path: libchromiumcontent.zip
-      - store_artifacts:
           path: libchromiumcontent-static.zip
 
-  libchromiumcontent-linux-ia32:
+  libchromiumcontent-linux-ia32-shared:
     docker:
       - image: electronbuilds/libchromiumcontent:0.0.4
         environment:
           TARGET_ARCH: ia32
+          COMPONENT: shared_library
+    resource_class: 2xlarge
+    steps:
+      - checkout
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              echo "Skipping upload to S3"
+            else
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+
+  libchromiumcontent-linux-ia32-static:
+    docker:
+      - image: electronbuilds/libchromiumcontent:0.0.4
+        environment:
+          TARGET_ARCH: ia32
+          COMPONENT: static_library
     resource_class: 2xlarge
     steps:
       - checkout
@@ -55,16 +122,13 @@ jobs:
           command: script/update --clean -t $TARGET_ARCH
       - run:
           name: Build static library
-          command: script/build -t $TARGET_ARCH -c static_library
-      - run:
-          name: Build shared library
-          command: script/build -t $TARGET_ARCH -c shared_library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Build FFmpeg
           command: script/build -t $TARGET_ARCH -c ffmpeg
       - run:
           name: Create distribution
-          command: script/create-dist -t $TARGET_ARCH
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Upload to S3
           command: |
@@ -74,15 +138,49 @@ jobs:
               script/upload -t $TARGET_ARCH
             fi
       - store_artifacts:
-          path: libchromiumcontent.zip
-      - store_artifacts:
           path: libchromiumcontent-static.zip
 
-  libchromiumcontent-linux-arm:
+  libchromiumcontent-linux-arm-shared:
     docker:
       - image: electronbuilds/libchromiumcontent:0.0.4
         environment:
           TARGET_ARCH: arm
+          COMPONENT: shared_library
+    resource_class: 2xlarge
+    steps:
+      - checkout
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              echo "Skipping upload to S3"
+            else
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+
+  libchromiumcontent-linux-arm-static:
+    docker:
+      - image: electronbuilds/libchromiumcontent:0.0.4
+        environment:
+          TARGET_ARCH: arm
+          COMPONENT: static_library
     resource_class: 2xlarge
     steps:
       - checkout
@@ -94,16 +192,13 @@ jobs:
           command: script/update --clean -t $TARGET_ARCH
       - run:
           name: Build static library
-          command: script/build -t $TARGET_ARCH -c static_library
-      - run:
-          name: Build shared library
-          command: script/build -t $TARGET_ARCH -c shared_library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Build FFmpeg
           command: script/build -t $TARGET_ARCH -c ffmpeg
       - run:
           name: Create distribution
-          command: script/create-dist -t $TARGET_ARCH
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Upload to S3
           command: |
@@ -113,15 +208,49 @@ jobs:
               script/upload -t $TARGET_ARCH
             fi
       - store_artifacts:
-          path: libchromiumcontent.zip
-      - store_artifacts:
           path: libchromiumcontent-static.zip
 
-  libchromiumcontent-linux-arm64:
+  libchromiumcontent-linux-arm64-shared:
     docker:
       - image: electronbuilds/libchromiumcontent:0.0.4
         environment:
           TARGET_ARCH: arm64
+          COMPONENT: shared_library
+    resource_class: 2xlarge
+    steps:
+      - checkout
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              echo "Skipping upload to S3"
+            else
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent.zip
+
+  libchromiumcontent-linux-arm64-static:
+    docker:
+      - image: electronbuilds/libchromiumcontent:0.0.4
+        environment:
+          TARGET_ARCH: arm64
+          COMPONENT: static_library
     resource_class: 2xlarge
     steps:
       - checkout
@@ -133,16 +262,48 @@ jobs:
           command: script/update --clean -t $TARGET_ARCH
       - run:
           name: Build static library
-          command: script/build -t $TARGET_ARCH -c static_library
-      - run:
-          name: Build shared library
-          command: script/build -t $TARGET_ARCH -c shared_library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Build FFmpeg
           command: script/build -t $TARGET_ARCH -c ffmpeg
       - run:
           name: Create distribution
-          command: script/create-dist -t $TARGET_ARCH
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              echo "Skipping upload to S3"
+            else
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent-static.zip
+
+  libchromiumcontent-linux-mips64el-shared:
+    docker:
+      - image: electronbuilds/libchromiumcontent:0.0.4
+        environment:
+          TARGET_ARCH: mips64el
+          COMPONENT: shared_library
+    resource_class: 2xlarge
+    steps:
+      - checkout
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build shared library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
       - run:
           name: Upload to S3
           command: |
@@ -153,36 +314,57 @@ jobs:
             fi
       - store_artifacts:
           path: libchromiumcontent.zip
-      - store_artifacts:
-          path: libchromiumcontent-static.zip
 
-  libchromiumcontent-linux-mips64el:
+  libchromiumcontent-linux-mips64el-static:
     docker:
       - image: electronbuilds/libchromiumcontent:0.0.4
         environment:
           TARGET_ARCH: mips64el
+          COMPONENT: static_library
     resource_class: 2xlarge
     steps:
       - checkout
-      - run: script/bootstrap
-      - run: script/update --clean -t $TARGET_ARCH
-      - run: script/build -t $TARGET_ARCH -c static_library
-      - run: script/build -t $TARGET_ARCH -c shared_library
-      - run: script/build -t $TARGET_ARCH -c ffmpeg
-      - run: script/create-dist -t $TARGET_ARCH
-      - run: script/upload -t $TARGET_ARCH
+      - run:
+          name: Bootstrap
+          command: script/bootstrap
+      - run:
+          name: Update
+          command: script/update --clean -t $TARGET_ARCH
+      - run:
+          name: Build static library
+          command: script/build -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Build FFmpeg
+          command: script/build -t $TARGET_ARCH -c ffmpeg
+      - run:
+          name: Create distribution
+          command: script/create-dist -t $TARGET_ARCH -c $COMPONENT
+      - run:
+          name: Upload to S3
+          command: |
+            if [[ -z "${LIBCHROMIUMCONTENT_S3_ACCESS_KEY}" ]]; then
+              echo "Skipping upload to S3"
+            else
+              script/upload -t $TARGET_ARCH
+            fi
+      - store_artifacts:
+          path: libchromiumcontent-static.zip
 
 workflows:
   version: 2
   build-x64:
     jobs:
-      - libchromiumcontent-linux-x64
+      - libchromiumcontent-linux-x64-shared
+      - libchromiumcontent-linux-x64-static
   build-ia32:
     jobs:
-      - libchromiumcontent-linux-ia32
+      - libchromiumcontent-linux-ia32-shared
+      - libchromiumcontent-linux-ia32-static
   build-arm:
     jobs:
-      - libchromiumcontent-linux-arm
+      - libchromiumcontent-linux-arm-shared
+      - libchromiumcontent-linux-arm-static
   build-arm64:
     jobs:
-      - libchromiumcontent-linux-arm64
+      - libchromiumcontent-linux-arm64-shared
+      - libchromiumcontent-linux-arm64-static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,3 +368,7 @@ workflows:
     jobs:
       - libchromiumcontent-linux-arm64-shared
       - libchromiumcontent-linux-arm64-static
+  build-mips64el:
+    jobs:
+      - libchromiumcontent-linux-mips64el-shared
+      - libchromiumcontent-linux-mips64el-static

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,38 +3,127 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-        stage('libchromiumcontent-osx') {
+        stage('libchromiumcontent-osx-shared') {
             agent {
               label 'osx-libcc'
             }
             environment {
-              LIBCHROMIUMCONTENT_GIT_CACHE='/Volumes/LIBCC_CACHE'
+              LIBCHROMIUMCONTENT_GIT_CACHE = '/Volumes/LIBCC_CACHE'
+              COMPONENT = 'shared_library'
+              TARGET_ARCH = 'x64'
             }
             steps {
-              sh 'script/cibuild'
+              sh 'script/bootstrap'
+              sh 'script/update --clean -t $TARGET_ARCH'
+              sh 'script/build -t $TARGET_ARCH -c $COMPONENT'
+              sh 'script/build -t $TARGET_ARCH -c ffmpeg'
+              sh 'script/create-dist -t $TARGET_ARCH -c $COMPONENT'
+              script {
+                GIT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+              }
+              withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
+                withAWS(credentials:'libccs3',region:'us-east-1') {
+                  s3Upload(file:'libchromiumcontent.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/osx/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent.zip", acl:'PublicRead')
+                }
+              }
             }
             post {
               always {
                 archive 'libchromiumcontent.zip'
+                cleanWs()
+              }
+            }
+        }
+        stage('libchromiumcontent-osx-static') {
+            agent {
+              label 'osx-libcc'
+            }
+            environment {
+              LIBCHROMIUMCONTENT_GIT_CACHE = '/Volumes/LIBCC_CACHE'
+              COMPONENT = 'static_library'
+              TARGET_ARCH = 'x64'
+            }
+            steps {
+              sh 'script/bootstrap'
+              sh 'script/update --clean -t $TARGET_ARCH'
+              sh 'script/build -t $TARGET_ARCH -c $COMPONENT'
+              sh 'script/build -t $TARGET_ARCH -c ffmpeg'
+              sh 'script/create-dist -t $TARGET_ARCH -c $COMPONENT'
+              script {
+                GIT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+              }
+              withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
+                withAWS(credentials:'libccs3',region:'us-east-1') {
+                  s3Upload(file:'libchromiumcontent-static.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/osx/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent-static.zip", acl:'PublicRead')
+                }
+              }
+            }
+            post {
+              always {
                 archive 'libchromiumcontent-static.zip'
                 cleanWs()
               }
             }
         }
-        stage('libchromiumcontent-mas') {
+        stage('libchromiumcontent-mas-shared') {
           agent {
             label 'osx-libcc'
           }
           environment {
             MAS_BUILD = '1'
-            LIBCHROMIUMCONTENT_GIT_CACHE='/Volumes/LIBCC_CACHE'
+            LIBCHROMIUMCONTENT_GIT_CACHE = '/Volumes/LIBCC_CACHE'
+            COMPONENT = 'shared_library'
+            TARGET_ARCH = 'x64'
           }
           steps {
-            sh 'script/cibuild'
+            sh 'script/bootstrap'
+            sh 'script/update --clean -t $TARGET_ARCH'
+            sh 'script/build -t $TARGET_ARCH -c $COMPONENT'
+            sh 'script/build -t $TARGET_ARCH -c ffmpeg'
+            sh 'script/create-dist -t $TARGET_ARCH -c $COMPONENT'
+            script {
+              GIT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+            }
+            withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
+              withAWS(credentials:'libccs3',region:'us-east-1') {
+                s3Upload(file:'libchromiumcontent.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/mas/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent.zip", acl:'PublicRead')
+              }
+            }
           }
           post {
             always {
               archive 'libchromiumcontent.zip'
+              cleanWs()
+            }
+          }
+        }
+        stage('libchromiumcontent-mas-static') {
+          agent {
+            label 'osx-libcc'
+          }
+          environment {
+            MAS_BUILD = '1'
+            LIBCHROMIUMCONTENT_GIT_CACHE = '/Volumes/LIBCC_CACHE'
+            COMPONENT = 'static_library'
+            TARGET_ARCH = 'x64'
+          }
+          steps {
+            sh 'script/bootstrap'
+            sh 'script/update --clean -t $TARGET_ARCH'
+            sh 'script/build -t $TARGET_ARCH -c $COMPONENT'
+            sh 'script/build -t $TARGET_ARCH -c ffmpeg'
+            sh 'script/create-dist -t $TARGET_ARCH -c $COMPONENT'
+            script {
+              GIT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+            }
+            withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
+              withAWS(credentials:'libccs3',region:'us-east-1') {
+                s3Upload(file:'libchromiumcontent-static.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/mas/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent-static.zip'", acl:'PublicRead')
+              }
+            }
+          }
+          post {
+            always {
               archive 'libchromiumcontent-static.zip'
               cleanWs()
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: 1.0.{build}
+build_cloud: libcc-20
+image: libcc-20core
+clone_folder: d:\build
+environment:
+  matrix:
+  - TARGET_ARCH: ia32
+    COMPONENT: shared_library
+  - TARGET_ARCH: x64
+    COMPONENT: shared_library
+  - TARGET_ARCH: ia32
+    COMPONENT: static_library
+  - TARGET_ARCH: x64
+    COMPONENT: static_library
+build_script:
+- ps: >-
+    if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+      Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
+    } else {
+      script\cibuild.ps1
+    }
+test: off
+artifacts:
+- path: libchromiumcontent.zip
+  name: libchromiumcontent.zip
+- path: libchromiumcontent-static.zip
+  name: libchromiumcontent-static.zip
+deploy: off

--- a/patches-mips64el/011-No-nss.patch
+++ b/patches-mips64el/011-No-nss.patch
@@ -1,0 +1,51 @@
+diff --git a/build/config/crypto.gni b/build/config/crypto.gni
+index 0196e873..cedd75b 100644
+--- a/build/config/crypto.gni
++++ b/build/config/crypto.gni
+@@ -16,8 +16,8 @@
+ # verification. On NaCl, verification isn't supported. On other targets, this
+ # flag also enables OpenSSL for certificate verification, but this configuration
+ # is unsupported.
+-use_openssl_certs = is_android || is_nacl
++use_openssl_certs = true
+ 
+ # True if NSS is used for certificate handling. It is possible to use OpenSSL
+ # for the crypto library, but NSS for the platform certificate library.
+-use_nss_certs = is_linux
++use_nss_certs = false
+diff --git a/content/browser/loader/resource_loader.cc b/content/browser/loader/resource_loader.cc
+index d2a1bb1..9b0b31c 100644
+--- a/content/browser/loader/resource_loader.cc
++++ b/content/browser/loader/resource_loader.cc
+@@ -476,9 +476,13 @@ void ResourceLoader::ContinueWithCertificate(net::X509Certificate* cert) {
+     request_->ContinueWithCertificate(nullptr, nullptr);
+     return;
+   }
++#if defined(USE_OPENSSL_CERTS)
++  request_->ContinueWithCertificate(cert, nullptr);
++#else
+   scoped_refptr<net::SSLPrivateKey> private_key =
+       net::FetchClientCertPrivateKey(cert);
+   request_->ContinueWithCertificate(cert, private_key.get());
++#endif
+ }
+ 
+ void ResourceLoader::CancelCertificateSelection() {
+diff --git a/remoting/host/token_validator_base.cc b/remoting/host/token_validator_base.cc
+index 42cafe1..eef7b5e 100644
+--- a/remoting/host/token_validator_base.cc
++++ b/remoting/host/token_validator_base.cc
+@@ -227,9 +227,13 @@ void TokenValidatorBase::OnCertificatesSelected(
+       !IsCertificateValid(issuer, now, *best_match_position)) {
+     ContinueWithCertificate(nullptr, nullptr);
+   } else {
++#if defined(USE_OPENSSL_CERTS)
++    ContinueWithCertificate(best_match_position->get(), nullptr);
++#else
+     ContinueWithCertificate(
+         best_match_position->get(),
+         net::FetchClientCertPrivateKey(best_match_position->get()).get());
++#endif
+   }
+ }
+ 

--- a/script/build
+++ b/script/build
@@ -41,7 +41,8 @@ def main():
   os.chdir(SOURCE_ROOT)
 
   for component in COMPONENTS:
-    if args.component == 'all' or args.component == component:
+    if args.component == 'all' or args.component == component \
+        or (args.include_ffmpeg and component == 'ffmpeg'):
       if component == 'shared_library' and args.no_shared_library:
         continue
       elif component == 'static_library' and args.no_static_library:
@@ -65,6 +66,8 @@ def parse_args():
                       help='Do not build static library version')
   parser.add_argument('-R', '--no_shared_library', action='store_true',
                       help='Do not build shared library version')
+  parser.add_argument('-F', '--include_ffmpeg', action='store_true',
+                      help='Include ffmpeg in component build')
   return parser.parse_args()
 
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -33,7 +33,8 @@ def main():
   os.environ['CHROME_HEADLESS'] = '1'
 
   if 'TARGET_ARCH' in os.environ:
-    return run_ci(['-t', os.environ['TARGET_ARCH']], skip_upload)
+    args = ['-t', os.environ['TARGET_ARCH']]
+    return run_ci(args, skip_upload, os.environ['COMPONENT'])
 
   if sys.platform in ['win32', 'cygwin']:
     return (run_ci(['-t', 'x64'], skip_upload) or
@@ -71,7 +72,12 @@ def os_version():
     return platform.platform()
 
 
-def run_ci(args, skip_upload):
+def run_ci(args, skip_upload, component=None):
+  build_args = []
+  component_args = []
+  if component is not None:
+    component_args = ['-c', component]
+    build_args += component_args + ['-F']
   if sys.platform in ['win32', 'cygwin']:
     target_arch = args[1]
     # Set build env for VS.
@@ -83,8 +89,8 @@ def run_ci(args, skip_upload):
 
   return (run_script('bootstrap') or
           run_script('update', ['--clean'] + args) or
-          run_script('build', args) or
-          run_script('create-dist', args) or
+          run_script('build', args + build_args) or
+          run_script('create-dist', args + component_args) or
           run_script('upload', args, skip_upload))
 
 

--- a/script/create-dist
+++ b/script/create-dist
@@ -371,7 +371,7 @@ def main():
                      args.target_arch)
 
   if not args.no_zip:
-    create_zip(args.create_debug_archive)
+    create_zip(args.create_debug_archive, args.component)
 
 
 def generate_ninja(args, ninja):
@@ -699,17 +699,19 @@ def generate_licenses(ninja):
       entry_template], variables=data)
 
 
-def create_zip(create_debug_archive):
-  print 'Zipping shared_library builds...'
-  p = os.path.join(SOURCE_ROOT, 'libchromiumcontent.zip')
-  make_zip(MAIN_DIR, ['src', 'ffmpeg', 'shared_library'], ['LICENSES.chromium.html'], p)
+def create_zip(create_debug_archive, component):
+  if component == 'all' or component == 'shared_library':
+    print 'Zipping shared_library builds...'
+    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent.zip')
+    make_zip(MAIN_DIR, ['src', 'ffmpeg', 'shared_library'], ['LICENSES.chromium.html'], p)
   if create_debug_archive:
     print 'Zipping shared library debug files...'
     p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-dbg.zip')
     make_zip(MAIN_DIR, ['.debug'], [], p)
-  print 'Zipping static_library builds...'
-  p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-static.zip')
-  make_zip(MAIN_DIR, ['static_library'], [], p)
+  if component == 'all' or component == 'static_library':
+    print 'Zipping static_library builds...'
+    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-static.zip')
+    make_zip(MAIN_DIR, ['static_library'], [], p)
 
 
 def make_zip(src, dirs, files, target):


### PR DESCRIPTION
Linking with nss was causing crashes on mips64el platforms, the crash was coming from the system libsqlite3 which seemed to conflict with the forked libsqlite3 version inside Chromium:

```
(gdb) bt
#0  0x0000000000000000 in  ()
#1  0x000000ffe84e5bfc in sqlite3Malloc () at /lib64/libsqlite3.so.0
#2  0x000000ffe85d2cac in openDatabase () at /lib64/libsqlite3.so.0
#3  0x000000ffea8a8c84 in sdb_init () at /lib64/libsoftokn3.so
```

Turning off `use_nss_certs` can temporarily solve this problem, with the downside of making Electron's certificate related APIs not work.

We can probably solve this cleanly once Chromium [supports building with system sqlite](https://bugs.chromium.org/p/chromium/issues/detail?id=22208), but before that we are going to use this workaround while still exploring other possible solutions.

This patch is only applied for mips64el, other targets are not affected at all.

This PR also backports the commit to split out static and shared builds, so compilation would be faster.