### PR TITLE
WIP: Set _GLIBCXX_USE_CXX11_ABI=0 on Linux

### DIFF
--- a/patches/082-linux-no-cxx11-abi.patch
+++ b/patches/082-linux-no-cxx11-abi.patch
@@ -1,0 +1,14 @@
+diff --git a/build/config/BUILD.gn b/build/config/BUILD.gn
+index 3febe8383b9f..7df1e250a33b 100644
+--- a/build/config/BUILD.gn
++++ b/build/config/BUILD.gn
+@@ -153,6 +153,9 @@ config("feature_flags") {
+   # ==============================================
+   #
+   # See the comment at the top.
++
++  # Electron: Keep backward compatibility with old libstdc++.
++  defines += [ "_GLIBCXX_USE_CXX11_ABI=0" ]
+ }
+ 
+ # Debug/release ----------------------------------------------------------------


### PR DESCRIPTION
According to:
https://gcc.gnu.org/onlinedocs/libstdc++/manual/backwards.html
https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

By defining `_GLIBCXX_USE_CXX11_ABI=0` we should be able to link with new versions of libstdc++ while keeping backward compatibility with the old ones.