### PR TITLE
Enable unittests and browsertests

### DIFF
--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -351,4 +351,62 @@ if (is_electron_build && !is_component_build) {
     deps = [ ":targets" ]
   }
 
+  group("chromiumcontent_tests") {
+    testonly = true
+
+    deps = [
+      "//base:base_unittests",
+      "//cc:cc_unittests",
+      "//cc/blink:cc_blink_unittests",
+      "//content/test:content_browsertests",
+      "//content/test:content_unittests",
+      "//crypto:crypto_unittests",
+      "//device:device_unittests",
+      "//gin:gin_unittests",
+      "//gpu:gpu_unittests",
+      "//gpu/ipc/service:gpu_ipc_service_unittests",
+      "//ipc:ipc_tests",
+      "//media:media_unittests",
+      "//media/midi:midi_unittests",
+      "//media/mojo:media_mojo_unittests",
+      "//media/capture:capture_unittests",
+      "//mojo/common:mojo_common_unittests",
+      "//mojo/edk/system:mojo_system_unittests",
+      "//mojo/edk/test:mojo_public_bindings_unittests",
+      "//mojo/edk/test:mojo_public_system_unittests",
+      "//net:net_unittests",
+      "//ppapi:ppapi_unittests",
+      "//printing:printing_unittests",
+      "//skia:skia_unittests",
+      "//storage:storage_unittests",
+      "//sql:sql_unittests",
+      "//third_party/angle/src/tests:angle_unittests",
+      "//third_party/leveldatabase:env_chromium_unittests",
+      "//third_party/WebKit/public:test_support",
+      "//third_party/WebKit/public:all_blink",
+      "//tools/gn:gn_unittests",
+      "//ui/base:ui_base_unittests",
+      "//ui/compositor:compositor_unittests",
+      "//ui/display:display_unittests",
+      "//ui/events:events_unittests",
+      "//ui/gl:gl_unittests",
+      "//url:url_unittests",
+      "//url/ipc:url_ipc_unittests",
+      "//v8/test/unittests:unittests",
+    ]
+
+    if (is_linux) {
+      deps += [
+        "//net:disk_cache_memory_test",
+        "//sandbox/linux:sandbox_linux_unittests",
+      ]
+
+      if (use_dbus) {
+        deps += [
+          "//dbus:dbus_unittests",
+        ]
+      }
+    }
+  }
+
 }

--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -1,4 +1,5 @@
 import("//build/config/c++/c++.gni")
+import("//build/config/features.gni")
 import("//build/split_static_library.gni")
 
 group("targets") {

--- a/chromiumcontent/args/tests.gn
+++ b/chromiumcontent/args/tests.gn
@@ -1,0 +1,12 @@
+root_extra_deps = [ "//chromiumcontent:chromiumcontent_tests" ]
+is_debug = false
+is_electron_build = true
+is_component_build = true
+dcheck_always_on = true
+symbol_level = 1
+enable_nacl = false
+
+# Jumbo build should improve compilation times.
+# https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
+use_jumbo_build = true
+

--- a/script/build
+++ b/script/build
@@ -11,7 +11,7 @@ from lib.config import MIPS64EL_GCC, set_mips64el_env, get_output_dir
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
-COMPONENTS = ['static_library', 'shared_library', 'ffmpeg']
+COMPONENTS = ['static_library', 'shared_library', 'ffmpeg', 'tests']
 
 NINJA = os.path.join(VENDOR_DIR, 'depot_tools', 'ninja')
 if sys.platform == 'win32':
@@ -49,6 +49,8 @@ def main():
   for component in components_to_build:
     out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
     target = 'chromiumcontent:chromiumcontent'
+    if component == 'tests':
+      target = 'chromiumcontent:chromiumcontent_tests'
     subprocess.check_call([NINJA, '-C', os.path.relpath(out_dir), target], env=env)
     if component == 'static_library':
       subenv = env.copy()

--- a/script/run_tests
+++ b/script/run_tests
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import platform
+import re
+import sys
+import subprocess
+
+from lib.config import get_output_dir
+
+SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+if sys.platform in ['win32', 'cygwin']:
+  BINARY_TEST_REGEX = re.compile(r'_(unit|browser)?tests(\.exe)?$', re.IGNORECASE)
+else:
+  BINARY_TEST_REGEX = re.compile(r'_(unit|browser)?tests$')
+
+def GetTestsToRun(args):
+  build_dir = get_output_dir(SOURCE_ROOT, args.target_arch, 'tests')
+  tests = []
+  for file_name in os.listdir(build_dir):
+    if re.search(BINARY_TEST_REGEX, file_name):
+      tests.append(os.path.join(build_dir, file_name))
+  return tests
+
+def RunTests(binary_tests):
+  if binary_tests:
+    results = []
+    for test in binary_tests:
+      results.append((os.path.basename(test),
+                      subprocess.call([test]) == 0))
+    failed = [test
+              for (test, success) in results
+              if not success]
+    print '%d tests run.' % len(results)
+    if failed:
+      print 'The following %d tests failed:' % len(failed)
+      for test in failed:
+        print test
+      return 1
+    else:
+      print 'All tests passed!'
+  else:
+    print 'Nothing to test - no tests found!'
+  return 0
+
+def main():
+  parser = argparse.ArgumentParser(description='Run Chromium tests')
+  parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  tests = GetTestsToRun(parser.parse_args())
+  if not tests:
+    return 1
+  return RunTests(tests)
+
+if __name__ == '__main__':
+  sys.exit(main())
+

--- a/script/update
+++ b/script/update
@@ -22,7 +22,7 @@ VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
 SRC_DIR = os.path.join(SOURCE_ROOT, 'src')
 CHROMIUMCONTENT_SOURCE_DIR = os.path.join(SOURCE_ROOT, 'chromiumcontent')
 CHROMIUMCONTENT_DESTINATION_DIR = os.path.join(SRC_DIR, 'chromiumcontent')
-COMPONENTS = ['static_library', 'shared_library', 'ffmpeg']
+COMPONENTS = ['static_library', 'shared_library', 'ffmpeg', 'tests']
 DEPOT_TOOLS = os.path.join(VENDOR_DIR, 'depot_tools')
 
 DEBIAN_MIRROR = 'http://ftp.jp.debian.org/debian/pool/main/'


### PR DESCRIPTION
This PR tries to accomplish the first three action items in https://github.com/electron/libchromiumcontent/issues/360

```
$ ./script/run_tests

40 tests run.
The following 7 tests failed:
gpu_unittests
blink_platform_unittests
base_unittests
content_unittests
net_unittests
compositor_unittests
content_browsertests
```

- [ ] Build test target on all platforms
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- [ ] Fix failing tests
  - [ ] gpu_unittests
  - [ ] blink_platform_unittests
  - [ ] base_unittests
  - [ ] content_unittests
  - [ ] net_unittests
  - [ ] compositor_unittests
  - [ ] content_browsertests

/cc @alexeykuzmin 