### PR TITLE
Switch to `tar.bz2` for distribution package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,14 +24,14 @@ pipeline {
                 }
                 withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
                   withAWS(credentials:'libccs3',region:'us-east-1') {
-                    s3Upload(file:'libchromiumcontent.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/osx/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent.zip", acl:'PublicRead')
+                    s3Upload(includePathPattern:'libchromiumcontent.*', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/osx/${env.TARGET_ARCH}/${GIT_COMMIT}/", acl:'PublicRead')
                   }
                 }
               }
             }
             post {
               always {
-                archive 'libchromiumcontent.zip'
+                archive 'libchromiumcontent.*'
                 cleanWs()
               }
             }
@@ -57,14 +57,14 @@ pipeline {
                 }
                 withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
                   withAWS(credentials:'libccs3',region:'us-east-1') {
-                    s3Upload(file:'libchromiumcontent-static.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/osx/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent-static.zip", acl:'PublicRead')
+                    s3Upload(includePathPattern:'libchromiumcontent-static.*', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/osx/${env.TARGET_ARCH}/${GIT_COMMIT}/", acl:'PublicRead')
                   }
                 }
               }
             }
             post {
               always {
-                archive 'libchromiumcontent-static.zip'
+                archive 'libchromiumcontent-static.*'
                 cleanWs()
               }
             }
@@ -91,14 +91,14 @@ pipeline {
               }
               withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
                 withAWS(credentials:'libccs3',region:'us-east-1') {
-                  s3Upload(file:'libchromiumcontent.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/mas/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent.zip", acl:'PublicRead')
+                  s3Upload(includePathPattern:'libchromiumcontent.*', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/mas/${env.TARGET_ARCH}/${GIT_COMMIT}/", acl:'PublicRead')
                 }
               }
             }
           }
           post {
             always {
-              archive 'libchromiumcontent.zip'
+              archive 'libchromiumcontent.*'
               cleanWs()
             }
           }
@@ -125,14 +125,14 @@ pipeline {
               }
               withCredentials([string(credentialsId: 'libccbucket', variable: 'LIBCC_BUCKET')]) {
                 withAWS(credentials:'libccs3',region:'us-east-1') {
-                  s3Upload(file:'libchromiumcontent-static.zip', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/mas/${env.TARGET_ARCH}/${GIT_COMMIT}/libchromiumcontent-static.zip", acl:'PublicRead')
+                  s3Upload(includePathPattern:'libchromiumcontent-static.*', bucket:"${LIBCC_BUCKET}", path:"libchromiumcontent/mas/${env.TARGET_ARCH}/${GIT_COMMIT}/", acl:'PublicRead')
                 }
               }
             }
           }
           post {
             always {
-              archive 'libchromiumcontent-static.zip'
+              archive 'libchromiumcontent-static.*'
               cleanWs()
             }
           }

--- a/script/cibuild-libchromiumcontent-linux
+++ b/script/cibuild-libchromiumcontent-linux
@@ -4,7 +4,9 @@ set -e
 set -o pipefail
 
 rm -rf dist
+rm -rf libchromiumcontent.tar.bz2
 rm -rf libchromiumcontent.zip
+rm -rf libchromiumcontent-static.tar.bz2
 rm -rf libchromiumcontent-static.zip
 
 docker build \

--- a/script/create-dist
+++ b/script/create-dist
@@ -8,7 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
-import zipfile
+import tarfile
 import platform
 
 from lib.config import get_output_dir
@@ -26,7 +26,7 @@ SRC_DIR = os.path.join(SOURCE_ROOT, 'src')
 sys.path.insert(0, os.path.join(SRC_DIR, 'tools', 'gyp', 'pylib', 'gyp'))
 import ninja_syntax
 
-# Almost everything goes into the main zip file...
+# Almost everything goes into the main tar file...
 MAIN_DIR = os.path.join(DIST_DIR, 'main')
 DIST_SRC_DIR = os.path.join(MAIN_DIR, 'src')
 
@@ -392,7 +392,7 @@ def main():
                      args.target_arch)
 
   if not args.no_zip:
-    create_zip(args.create_debug_archive, args.component)
+    create_tar(args.create_debug_archive, args.component)
 
 
 def generate_ninja(args, ninja):
@@ -434,7 +434,7 @@ def parse_args():
   parser.add_argument('-c', '--component', default='all',
                       help='static_library or shared_library or all')
   parser.add_argument('--no_zip', action='store_true',
-                      help='Do not create zip distribution')
+                      help='Do not create distribution archive')
   return parser.parse_args()
 
 
@@ -729,33 +729,32 @@ def generate_licenses(ninja):
       entry_template], variables=data)
 
 
-def create_zip(create_debug_archive, component):
+def create_tar(create_debug_archive, component):
   if component == 'all' or component == 'shared_library':
-    print 'Zipping shared_library builds...'
-    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent.zip')
-    make_zip(MAIN_DIR, ['src', 'ffmpeg', 'shared_library'], ['LICENSES.chromium.html'], p)
+    print 'Packing shared_library builds...'
+    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent.tar.bz2')
+    make_tar(MAIN_DIR, ['src', 'ffmpeg', 'shared_library'], ['LICENSES.chromium.html'], p)
   if create_debug_archive:
-    print 'Zipping shared library debug files...'
-    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-dbg.zip')
-    make_zip(MAIN_DIR, ['.debug'], [], p)
+    print 'Packing shared library debug files...'
+    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-dbg.tar.bz2')
+    make_tar(MAIN_DIR, ['.debug'], [], p)
   if component == 'all' or component == 'static_library':
-    print 'Zipping static_library builds...'
-    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-static.zip')
-    make_zip(MAIN_DIR, ['static_library'], [], p)
+    print 'Packing static_library builds...'
+    p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-static.tar.bz2')
+    make_tar(MAIN_DIR, ['static_library'], [], p)
 
 
-def make_zip(src, dirs, files, target):
+def make_tar(src, dirs, files, target):
   filesystem.safe_unlink(target)
   with util.scoped_cwd(src):
-    zip_file = zipfile.ZipFile(target, 'w', zipfile.ZIP_DEFLATED,
-                               allowZip64=True)
+    tar_file = tarfile.open(target, 'w:bz2')
     for dirname in dirs:
       for root, _, filenames in os.walk(dirname):
         for f in filenames:
-          zip_file.write(os.path.join(root, f))
+          tar_file.add(os.path.join(root, f))
     for f in files:
-      zip_file.write(f)
-    zip_file.close();
+      tar_file.add(f)
+    tar_file.close();
 
 
 def is_newer(destination, source):

--- a/script/create-dist
+++ b/script/create-dist
@@ -26,7 +26,7 @@ SRC_DIR = os.path.join(SOURCE_ROOT, 'src')
 sys.path.insert(0, os.path.join(SRC_DIR, 'tools', 'gyp', 'pylib', 'gyp'))
 import ninja_syntax
 
-# Almost everything goes into the main tar file...
+# Almost everything goes into the main archive
 MAIN_DIR = os.path.join(DIST_DIR, 'main')
 DIST_SRC_DIR = os.path.join(MAIN_DIR, 'src')
 
@@ -392,7 +392,7 @@ def main():
                      args.target_arch)
 
   if not args.no_zip:
-    create_tar(args.create_debug_archive, args.component)
+    create_archive(args.create_debug_archive, args.component)
 
 
 def generate_ninja(args, ninja):
@@ -729,22 +729,22 @@ def generate_licenses(ninja):
       entry_template], variables=data)
 
 
-def create_tar(create_debug_archive, component):
+def create_archive(create_debug_archive, component):
   if component == 'all' or component == 'shared_library':
     print 'Packing shared_library builds...'
     p = os.path.join(SOURCE_ROOT, 'libchromiumcontent.tar.bz2')
-    make_tar(MAIN_DIR, ['src', 'ffmpeg', 'shared_library'], ['LICENSES.chromium.html'], p)
+    make_archive(MAIN_DIR, ['src', 'ffmpeg', 'shared_library'], ['LICENSES.chromium.html'], p)
   if create_debug_archive:
     print 'Packing shared library debug files...'
     p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-dbg.tar.bz2')
-    make_tar(MAIN_DIR, ['.debug'], [], p)
+    make_archive(MAIN_DIR, ['.debug'], [], p)
   if component == 'all' or component == 'static_library':
     print 'Packing static_library builds...'
     p = os.path.join(SOURCE_ROOT, 'libchromiumcontent-static.tar.bz2')
-    make_tar(MAIN_DIR, ['static_library'], [], p)
+    make_archive(MAIN_DIR, ['static_library'], [], p)
 
 
-def make_tar(src, dirs, files, target):
+def make_archive(src, dirs, files, target):
   filesystem.safe_unlink(target)
   with util.scoped_cwd(src):
     tar_file = tarfile.open(target, 'w:bz2')

--- a/script/download
+++ b/script/download
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 import urllib2
-import zipfile
+import tarfile
 
 import lib.filesystem as filesystem
 
@@ -22,8 +22,8 @@ PLATFORM_KEY = {
   'win32': 'win',
 }[sys.platform]
 
-SHARED_LIBRARY_FILENAME = 'libchromiumcontent.zip'
-STATIC_LIBRARY_FILENAME = 'libchromiumcontent-static.zip'
+SHARED_LIBRARY_FILENAME = 'libchromiumcontent.tar.bz2'
+STATIC_LIBRARY_FILENAME = 'libchromiumcontent-static.tar.bz2'
 
 
 class ProgramError(Exception):
@@ -137,13 +137,6 @@ def download(destination, base_url, commit, filename):
   download_and_extract(destination, url)
 
 
-def download_static_libraries(destination, base_url, commit):
-  sys.stderr.write('Downloading static_library build of libchromiumcontent...')
-  sys.stderr.flush()
-  url = '{0}/{1}/libchromiumcontent-static.zip'.format(base_url, commit)
-  download_and_extract(destination, url)
-
-
 def download_and_extract(destination, url):
   print url
   with tempfile.TemporaryFile() as t:
@@ -157,7 +150,7 @@ def download_and_extract(destination, url):
         t.write(chunk)
     sys.stderr.write('\nExtracting...\n')
     sys.stderr.flush()
-    with zipfile.ZipFile(t) as z:
+    with tarfile.open(t, 'r:bz2') as z:
       z.extractall(destination)
 
 

--- a/script/upload
+++ b/script/upload
@@ -46,7 +46,7 @@ def upload(target_arch):
 
   s3put(bucket, access_key, secret_key, SOURCE_ROOT,
         'libchromiumcontent/{0}/{1}/{2}'.format(platform, target_arch, commit),
-        glob.glob('libchromiumcontent*.zip'))
+        glob.glob('libchromiumcontent*.tar.bz2'))
 
 
 def s3_config():


### PR DESCRIPTION
The distribution packages are getting ever bigger. Especially after we switch to "official" builds, the static package can approach 3 GB due to bigger object files containing intermediate language code. Downloading such big files is tedious on slower connections and also Amazon intermittently closes long connections, making developer's life unbearable.

`tar.bz2` seems to be the best compression method readily available in Python 2.