### PR TITLE
Fix unpacking of downloaded artefacts

### DIFF
--- a/script/download
+++ b/script/download
@@ -150,7 +150,7 @@ def download_and_extract(destination, url):
         t.write(chunk)
     sys.stderr.write('\nExtracting...\n')
     sys.stderr.flush()
-    with tarfile.open(t, 'r:bz2') as z:
+    with tarfile.open(fileobj=t, mode='r:bz2') as z:
       z.extractall(destination)
 
 


### PR DESCRIPTION
The `t` is a file object, not a filename, so it must be passed to `tarfile.open` as a named argument.