### PR TITLE
Fix build issues

### DIFF
--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -185,8 +185,10 @@ if (is_electron_build && !is_component_build) {
   # ninja. Because "objects.gni" is a GN input file, it will cause it
   # to re-generate the targets and produce the static libraries we want.
 
+  is_second_pass = (getenv("CHROMIUMCONTENT_2ND_PASS") != "")
+
   # Make sure the .gni file exists, otherwise it cannot be imported
-  if (getenv("CHROMIUMCONTENT_2ND_PASS") == "") {
+  if (!is_second_pass) {
     write_file("$target_out_dir/objects.gni", "")
   }
 
@@ -208,172 +210,123 @@ if (is_electron_build && !is_component_build) {
   # produce a .lib file bigger than 4 GB, LLVM has a limit on the number of
   # object files on the command line. So we produce multiple libraries.
   group("libs") {
-    deps = [
-      ":libchromiumcontent",
-      ":base",
-      ":cc",
-      ":components",
-      ":ppapi",
-      ":media",
-      ":net",
-      ":services",
-      ":skia",
-      ":angle",
-      ":pdfium",
-      ":webkit",
-      ":webkitcore",
-      ":webkitbindings",
-      ":webkitmodules",
-      ":webrtc",
-      ":v8",
-      ":v8base",
-    ]
-  }
-
-  static_library("libchromiumcontent") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_libchromiumcontent)) {
-      sources += obj_libchromiumcontent
+    if (is_second_pass) {
+      deps = [
+        ":libchromiumcontent",
+        ":base",
+        ":cc",
+        ":components",
+        ":ppapi",
+        ":media",
+        ":net",
+        ":services",
+        ":skia",
+        ":angle",
+        ":pdfium",
+        ":webkit",
+        ":webkitcore",
+        ":webkitbindings",
+        ":webkitmodules",
+        ":webrtc",
+        ":v8",
+        ":v8base",
+      ]
     }
   }
 
-  static_library("base") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_base)) {
-      sources += obj_base
+  if (is_second_pass) {
+    static_library("libchromiumcontent") {
+      complete_static_lib = true
+      sources = obj_libchromiumcontent
     }
-  }
 
-  static_library("cc") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_cc)) {
-      sources += obj_cc
+    static_library("base") {
+      complete_static_lib = true
+      sources = obj_base
     }
-  }
 
-  static_library("components") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_components)) {
-      sources += obj_components
+    static_library("cc") {
+      complete_static_lib = true
+      sources = obj_cc
     }
-  }
 
-  static_library("ppapi") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_ppapi)) {
-      sources += obj_ppapi
+    static_library("components") {
+      complete_static_lib = true
+      sources = obj_components
     }
-  }
 
-  static_library("media") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_media)) {
-      sources += obj_media
+    static_library("ppapi") {
+      complete_static_lib = true
+      sources = obj_ppapi
     }
-  }
 
-  static_library("net") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_net)) {
-      sources += obj_net
+    static_library("media") {
+      complete_static_lib = true
+      sources = obj_media
     }
-  }
 
-  static_library("services") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_services)) {
-      sources += obj_services
+    static_library("net") {
+      complete_static_lib = true
+      sources = obj_net
     }
-  }
 
-  static_library("skia") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_skia)) {
-      sources += obj_skia
+    static_library("services") {
+      complete_static_lib = true
+      sources = obj_services
     }
-  }
 
-  static_library("angle") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_angle)) {
-      sources += obj_angle
+    static_library("skia") {
+      complete_static_lib = true
+      sources = obj_skia
     }
-  }
 
-  static_library("pdfium") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_pdfium)) {
-      sources += obj_pdfium
+    static_library("angle") {
+      complete_static_lib = true
+      sources = obj_angle
     }
-  }
 
-  static_library("webkit") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkit)) {
-      sources += obj_webkit
+    static_library("pdfium") {
+      complete_static_lib = true
+      sources = obj_pdfium
     }
-  }
 
-  static_library("webkitcore") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitcore)) {
-      sources += obj_webkitcore
+    static_library("webkit") {
+      complete_static_lib = true
+      sources = obj_webkit
     }
-  }
 
-  static_library("webkitbindings") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitbindings)) {
-      sources += obj_webkitbindings
+    static_library("webkitbindings") {
+      complete_static_lib = true
+      sources = obj_webkitbindings
     }
-  }
 
-  static_library("webkitmodules") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webkitmodules)) {
-      sources += obj_webkitmodules
+    static_library("webkitcore") {
+      complete_static_lib = true
+      sources = obj_webkitcore
     }
-  }
 
-  static_library("webrtc") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_webrtc)) {
-      sources += obj_webrtc
+    static_library("webkitmodules") {
+      complete_static_lib = true
+      sources = obj_webkitmodules
     }
-  }
 
-  static_library("v8") {
-    complete_static_lib = true
-    sources = []
-    if (defined(obj_v8)) {
-      sources += obj_v8
+    static_library("webrtc") {
+      complete_static_lib = true
+      sources = obj_webrtc
     }
-  }
 
-  split_static_library("v8base") {
-    complete_static_lib = true
-    split_count = 1
-    sources = []
-    if (defined(obj_v8base)) {
-      sources += obj_v8base
+    static_library("v8") {
+      complete_static_lib = true
+      sources = obj_v8
+    }
+
+    split_static_library("v8base") {
+      complete_static_lib = true
+      sources = obj_v8base
       if (is_win) {
         split_count = 2
+      } else {
+        split_count = 1
       }
     }
   }
@@ -384,28 +337,4 @@ if (is_electron_build && !is_component_build) {
     deps = [ ":targets" ]
   }
 
-}
-
-# There are some executable targets whose products are ran during build.
-# This config is applied to those targets because we need to give them some
-# special treatment.
-config("build_time_executable") {
-  configs = []
-
-  # The executables which have this config applied are dependent on ICU,
-  # which is always a shared library in an Electron build. However, in the
-  # non-component build, Linux executables don't have rpath set to search for
-  # libraries in the executable's directory, so ICU cannot be found. So let's
-  # make sure rpath is set here.
-  # See '//build/config/gcc/BUILD.gn' for details on the rpath setting.
-  if (is_electron_build && is_linux && !is_component_build) {
-    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
-  }
-}
-
-# For MAS build, we force defining "MAS_BUILD".
-config("mas_build") {
-  if (getenv("MAS_BUILD") != "") {
-    defines = [ "MAS_BUILD" ]
-  }
 }

--- a/chromiumcontent/config/BUILD.gn
+++ b/chromiumcontent/config/BUILD.gn
@@ -1,0 +1,23 @@
+# There are some executable targets whose products are ran during build.
+# This config is applied to those targets because we need to give them some
+# special treatment.
+config("build_time_executable") {
+  configs = []
+
+  # The executables which have this config applied are dependent on ICU,
+  # which is always a shared library in an Electron build. However, in the
+  # non-component build, Linux executables don't have rpath set to search for
+  # libraries in the executable's directory, so ICU cannot be found. So let's
+  # make sure rpath is set here.
+  # See '//build/config/gcc/BUILD.gn' for details on the rpath setting.
+  if (is_electron_build && is_linux && !is_component_build) {
+    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+}
+
+# For MAS build, we force defining "MAS_BUILD".
+config("mas_build") {
+  if (getenv("MAS_BUILD") != "") {
+    defines = [ "MAS_BUILD" ]
+  }
+}

--- a/patches/001-build_gn.patch
+++ b/patches/001-build_gn.patch
@@ -1,5 +1,5 @@
 diff --git a/build/config/BUILDCONFIG.gn b/build/config/BUILDCONFIG.gn
-index de3f35f124aa..eabb988c1711 100644
+index de3f35f124aa..a52003f1b5e1 100644
 --- a/build/config/BUILDCONFIG.gn
 +++ b/build/config/BUILDCONFIG.gn
 @@ -123,6 +123,8 @@ if (current_os == "") {
@@ -15,7 +15,7 @@ index de3f35f124aa..eabb988c1711 100644
    "//build/config/compiler:no_rtti",
    "//build/config/compiler:runtime_library",
    "//build/config/sanitizers:default_sanitizer_flags",
-+  "//chromiumcontent:mas_build",
++  "//chromiumcontent/config:mas_build",
  ]
  if (is_win) {
    default_compiler_configs += [
@@ -59,14 +59,14 @@ index 5e1f7fcc4d83..15723e6b7184 100644
      # exceptions or will give errors about things not matching, so keep
      # exceptions on.
 diff --git a/third_party/WebKit/Source/platform/BUILD.gn b/third_party/WebKit/Source/platform/BUILD.gn
-index 15bf689..9cdc19d 100644
+index 6c86a6454256..2bc8c31396af 100644
 --- a/third_party/WebKit/Source/platform/BUILD.gn
 +++ b/third_party/WebKit/Source/platform/BUILD.gn
-@@ -160,6 +160,7 @@ action("character_data") {
+@@ -160,6 +160,7 @@ action("instrumentation_probes") {
  }
  
  executable("character_data_generator") {
-+  configs += [ "//chromiumcontent:build_time_executable" ]
++  configs += [ "//chromiumcontent/config:build_time_executable" ]
    sources = [
      "text/CharacterPropertyDataGenerator.cpp",
      "text/CharacterPropertyDataGenerator.h",

--- a/patches/v8/001-build_gn.patch
+++ b/patches/v8/001-build_gn.patch
@@ -66,7 +66,7 @@ index 494ba22f29..6071422d7d 100644
  
      configs = [ ":internal_config" ]
  
-+    configs += [ "//chromiumcontent:build_time_executable" ]
++    configs += [ "//chromiumcontent/config:build_time_executable" ]
 +
      deps = [
        ":v8_base",

--- a/script/lib/gn.py
+++ b/script/lib/gn.py
@@ -3,21 +3,12 @@ import subprocess
 import sys
 
 
-def __get_executable_path(chromium_root_dir):
-  platform = sys.platform
-  relative_path = None
+def __get_executable_path(depot_tools_dir):
+  gn_path = os.path.join(depot_tools_dir, 'gn')
+  if sys.platform in ['win32', 'cygwin']:
+    gn_path += '.bat'
 
-  if platform in ['win32', 'cygwin']:
-    relative_path = ['buildtools', 'win', 'gn.exe']
-  elif platform == 'linux2':
-    relative_path = ['buildtools', 'linux64', 'gn']
-  elif platform == 'darwin':
-    relative_path = ['buildtools', 'mac', 'gn']
-
-  assert relative_path is not None, "Platform '{}' is not supported".format(platform)
-
-  absolute_path = os.path.join(chromium_root_dir, *relative_path)
-  return absolute_path
+  return gn_path
 
 
 def create_args(out_dir, raw_config, **kwargs):
@@ -29,8 +20,8 @@ def create_args(out_dir, raw_config, **kwargs):
     f.write(raw_config)
 
 
-def generate(out_dir, chromium_root_dir, env):
-  executable = __get_executable_path(chromium_root_dir)
+def generate(out_dir, chromium_root_dir, depot_tools_dir, env):
+  executable = __get_executable_path(depot_tools_dir)
   out_dir_relative_path = os.path.relpath(out_dir, chromium_root_dir)
   subprocess.check_call([executable, 'gen', out_dir_relative_path],
                         cwd=chromium_root_dir, env=env)

--- a/script/update
+++ b/script/update
@@ -185,9 +185,8 @@ def update_depot_tools():
   # Remove trailing slash from TEMP
   # https://bugs.chromium.org/p/chromium/issues/detail?id=340243
   env['TEMP'] = env['TEMP'].rstrip('\\')
-  env['PATH'] = os.pathsep.join([os.path.join(VENDOR_DIR, 'depot_tools'),
-                                 env['PATH']])
-  update_path = os.path.join(VENDOR_DIR, 'depot_tools', 'update_depot_tools.bat')
+  env['PATH'] = os.pathsep.join([DEPOT_TOOLS, env['PATH']])
+  update_path = os.path.join(DEPOT_TOOLS, 'update_depot_tools.bat')
   subprocess.check_call([update_path], env=env)
 
 
@@ -210,9 +209,8 @@ def gclient_sync(version, force, git_cache, nohooks):
   env = os.environ.copy()
   if sys.platform in ['win32', 'cygwin']:
     env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
-  env['PATH'] = os.pathsep.join([os.path.join(VENDOR_DIR, 'depot_tools'),
-                                 env['PATH']])
-  gclient = os.path.join(VENDOR_DIR, 'depot_tools', 'gclient.py')
+  env['PATH'] = os.pathsep.join([DEPOT_TOOLS, env['PATH']])
+  gclient = os.path.join(DEPOT_TOOLS, 'gclient.py')
   args = [sys.executable, gclient, 'sync', '--jobs', '16',
           '--revision', 'src@{0}'.format(version), '--with_tags',
           '--with_branch_heads', '--reset', '--delete_unversioned_trees']
@@ -233,8 +231,7 @@ def apply_patches(target_arch):
 
 def update_clang():
   env = os.environ.copy()
-  env['PATH'] = os.pathsep.join([os.path.join(VENDOR_DIR, 'depot_tools'),
-                                 env['PATH']])
+  env['PATH'] = os.pathsep.join([DEPOT_TOOLS, env['PATH']])
   env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
   update = os.path.join(SRC_DIR, 'tools', 'clang', 'scripts', 'update.py')
   return subprocess.call([sys.executable, update, '--if-needed'], env=env)
@@ -276,8 +273,7 @@ def setup_mips64el_toolchain(target_arch):
   # Build gn with the patch to support mips64el.
   gn = os.path.join(SRC_DIR, 'out', 'Release', 'gn')
   if not os.path.exists(gn):
-    env['PATH'] = os.pathsep.join([os.path.join(VENDOR_DIR, 'depot_tools'),
-                                   env['PATH']])
+    env['PATH'] = os.pathsep.join([DEPOT_TOOLS, env['PATH']])
     bootstrap = os.path.join(SRC_DIR, 'tools', 'gn', 'bootstrap', 'bootstrap.py')
     subprocess.check_call([bootstrap, '-s'], cwd=SRC_DIR, env=env)
 

--- a/script/update
+++ b/script/update
@@ -313,7 +313,7 @@ def run_gn(target_arch):
           target_cpu=target_cpu)
 
     # Generate Ninja build files.
-    gn.generate(output_dir, chromium_root_dir=SRC_DIR, env=env)
+    gn.generate(output_dir, chromium_root_dir=SRC_DIR, depot_tools_dir=DEPOT_TOOLS, env=env)
 
 
 def is_newer(destination, source):


### PR DESCRIPTION
- For the `static_library` build, the Windows CI jobs take twice the time than necessary because Ninja always rebuilds everything during the second build pass (when it assembles the static libraries). This is due to the fact that the `update` script doesn't run GN via depot_tools, but directly. The second pass runs GN again, but this time from depot_tools and it causes the build command lines to be different from the first pass, which makes Ninja rebuild everything.

- I also cleaned up some syntax