### PR TITLE
fix mime type error for es6 modules

### DIFF
--- a/patches/077_fix_mime_type_error.patch
+++ b/patches/077_fix_mime_type_error.patch
@@ -1,0 +1,28 @@
+Include mime type in served extension files
+
+Modules enforce strict mime type requirements, but files served through
+extension protocols don't specify a mime type. Include it in the
+response headers. This enables modules for chrome extensions.
+---
+
+diff --git a/extensions/browser/extension_protocols.cc b/extensions/browser/extension_protocols.cc
+index 10cc848..9a3e73a 100644
+--- a/extensions/browser/extension_protocols.cc
++++ b/extensions/browser/extension_protocols.cc
+@@ -199,6 +199,16 @@
+   }
+
+   void GetResponseInfo(net::HttpResponseInfo* info) override {
++    // Set the mime type for the request. We do this here (rather than when we
++    // build the rest of the headers) because the mime type is retrieved only
++    // after URLRequestFileJob::Start() is called. Using an accurate mime type
++    // is necessary at least for modules, which enforce strict mime type
++    // requirements.
++    std::string mime_type;
++    bool found_mime_type = GetMimeType(&mime_type);
++    if (found_mime_type)
++      response_info_.headers->AddHeader("Content-Type: " + mime_type);
++
+     *info = response_info_;
+   }
+


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/12011.

Patch [chromium commit](https://chromium.googlesource.com/chromium/src.git/+/6449de840aec46116c234a5865c4ba120a0e38d9) to fix es6 loading bug that caused
> Failed to load module script: The server responded with a non-JavaScript MIME type of "". Strict MIME type checking is enforced for module scripts per HTML spec.

to be thrown when es6 modules attempted to be loaded. 

/cc @MarshallOfSound 