### PR TITLE
Backported fix for V8 security issue (2.0)

### DIFF
--- a/patches/v8/026-backport_3ecb047.patch
+++ b/patches/v8/026-backport_3ecb047.patch
@@ -1,0 +1,17 @@
+Fixes security bug
+https://bugs.chromium.org/p/project-zero/issues/detail?id=1445
+
+diff --git a/src/property-details.h b/src/property-details.h
+index d007a0414c..6badf25766 100644
+--- a/src/property-details.h
++++ b/src/property-details.h
+@@ -199,8 +199,7 @@ class Representation {
+ static const int kDescriptorIndexBitCount = 10;
+ // The maximum number of descriptors we want in a descriptor array (should
+ // fit in a page).
+-static const int kMaxNumberOfDescriptors =
+-    (1 << kDescriptorIndexBitCount) - 2;
++static const int kMaxNumberOfDescriptors = (1 << kDescriptorIndexBitCount) - 4;
+ static const int kInvalidEnumCacheSentinel =
+     (1 << kDescriptorIndexBitCount) - 1;
+ 


### PR DESCRIPTION
Bug report: https://bugs.chromium.org/p/project-zero/issues/detail?id=1445
Original change: https://chromium.googlesource.com/v8/v8/+/3ecb047abae69064052f268896afd3fe0824e0ce