### PR TITLE
Backport V8 security fixes

### DIFF
--- a/patches/v8/041-backport_a2b91ed.patch
+++ b/patches/v8/041-backport_a2b91ed.patch
@@ -1,0 +1,23 @@
+Fixes security bug
+https://bugs.chromium.org/p/project-zero/issues/detail?id=1446
+
+diff --git a/src/deoptimizer.cc b/src/deoptimizer.cc
+index 93a21a7b3a..641bdb4f1f 100644
+--- a/src/deoptimizer.cc
++++ b/src/deoptimizer.cc
+@@ -3546,6 +3546,7 @@ Handle<Object> TranslatedState::MaterializeCapturedObjectAt(
+     case JS_SET_VALUE_ITERATOR_TYPE: {
+       Handle<JSSetIterator> object = Handle<JSSetIterator>::cast(
+           isolate_->factory()->NewJSObjectFromMap(map, NOT_TENURED));
++      slot->value_ = object;
+       Handle<Object> properties = materializer.FieldAt(value_index);
+       Handle<Object> elements = materializer.FieldAt(value_index);
+       Handle<Object> table = materializer.FieldAt(value_index);
+@@ -3561,6 +3562,7 @@ Handle<Object> TranslatedState::MaterializeCapturedObjectAt(
+     case JS_MAP_VALUE_ITERATOR_TYPE: {
+       Handle<JSMapIterator> object = Handle<JSMapIterator>::cast(
+           isolate_->factory()->NewJSObjectFromMap(map, NOT_TENURED));
++      slot->value_ = object;
+       Handle<Object> properties = materializer.FieldAt(value_index);
+       Handle<Object> elements = materializer.FieldAt(value_index);
+       Handle<Object> table = materializer.FieldAt(value_index);

--- a/patches/v8/042-backport_3ecb047.patch
+++ b/patches/v8/042-backport_3ecb047.patch
@@ -1,0 +1,35 @@
+Fixes security bug
+https://bugs.chromium.org/p/project-zero/issues/detail?id=1445
+
+diff --git a/src/objects.h b/src/objects.h
+index a5acf7c6c4..45811fbaaf 100644
+--- a/src/objects.h
++++ b/src/objects.h
+@@ -2651,6 +2651,8 @@ class JSObject: public JSReceiver {
+   // its size by more than the 1 entry necessary, so sequentially adding fields
+   // to the same object requires fewer allocations and copies.
+   static const int kFieldsAdded = 3;
++  STATIC_ASSERT(kMaxNumberOfDescriptors + kFieldsAdded <=
++                PropertyArray::kMaxLength);
+ 
+   // Layout description.
+   static const int kElementsOffset = JSReceiver::kHeaderSize;
+diff --git a/src/property-details.h b/src/property-details.h
+index d007a0414c..5e0ecc0424 100644
+--- a/src/property-details.h
++++ b/src/property-details.h
+@@ -197,10 +197,10 @@ class Representation {
+ 
+ 
+ static const int kDescriptorIndexBitCount = 10;
+-// The maximum number of descriptors we want in a descriptor array (should
+-// fit in a page).
+-static const int kMaxNumberOfDescriptors =
+-    (1 << kDescriptorIndexBitCount) - 2;
++// The maximum number of descriptors we want in a descriptor array.  It should
++// fit in a page and also the following should hold:
++// kMaxNumberOfDescriptors + kFieldsAdded <= PropertyArray::kMaxLength.
++static const int kMaxNumberOfDescriptors = (1 << kDescriptorIndexBitCount) - 4;
+ static const int kInvalidEnumCacheSentinel =
+     (1 << kDescriptorIndexBitCount) - 1;
+ 


### PR DESCRIPTION
Fixes these publicized security vulnerabilities:

https://bugs.chromium.org/p/project-zero/issues/detail?id=1445
Affects all Chromium versions up to 64
Backport for Cr63: https://github.com/electron/libchromiumcontent/commit/b12be538358e133331a52e3b995273cfedcf929b
Backport for Cr62: this PR
Backport for Cr61 (Electron 2.0): https://github.com/electron/libchromiumcontent/pull/463
Backport for Cr59 (Electron 1.8): https://github.com/electron/libchromiumcontent/pull/462

https://bugs.chromium.org/p/project-zero/issues/detail?id=1446
Affects Chromium 62 and 63 only
Backport for Cr63: https://github.com/electron/libchromiumcontent/commit/03a070f7794a8c0054ee841d57a2fdd30564391d
Backport for Cr62: this PR
