### PR TITLE
Disable DCHECK in program_binding.h

### DIFF
--- a/patches/002-dcheck.patch
+++ b/patches/002-dcheck.patch
@@ -28,6 +28,7 @@ These files have debug checks explicitly commented out:
   content/browser/frame_host/render_frame_host_impl.cc
   content/browser/renderer_host/render_widget_host_view_mac.mm
   ppapi/host/ppapi_host.cc
+  third_party/WebKit/Source/core/dom/Node.cpp
   third_party/WebKit/Source/platform/wtf/text/StringImpl.h
   ui/base/clipboard/clipboard_win.cc
 
@@ -173,6 +174,19 @@ index 1e08519e1410..eceb046eb309 100644
 +    defines += [ "ELECTRON_NO_DCHECK" ]
 +  }
  }
+diff --git a/third_party/WebKit/Source/core/dom/Node.cpp b/third_party/WebKit/Source/core/dom/Node.cpp
+index 922a2561bcef..e31fa34f98ea 100644
+--- a/third_party/WebKit/Source/core/dom/Node.cpp
++++ b/third_party/WebKit/Source/core/dom/Node.cpp
+@@ -2435,7 +2435,7 @@ StaticNodeList* Node::getDestinationInsertionPoints() {
+ 
+ HTMLSlotElement* Node::AssignedSlot() const {
+   // assignedSlot doesn't need to call updateDistribution().
+-  DCHECK(!IsPseudoElement());
++  // DCHECK(!IsPseudoElement());
+   if (ShadowRoot* root = V1ShadowRootOfParent())
+     return root->AssignedSlotFor(*this);
+   return nullptr;
 diff --git a/third_party/WebKit/Source/platform/wtf/text/StringImpl.h b/third_party/WebKit/Source/platform/wtf/text/StringImpl.h
 index 9a02085a635e..1f4de626ee1b 100644
 --- a/third_party/WebKit/Source/platform/wtf/text/StringImpl.h

--- a/patches/002-dcheck.patch
+++ b/patches/002-dcheck.patch
@@ -23,6 +23,7 @@ These files have debug checks explicitly commented out:
 
   base/memory/weak_ptr.cc
   base/process/kill_win.cc
+  components/viz/service/display/program_binding.h
   content/browser/frame_host/navigation_controller_impl.cc
   content/browser/frame_host/render_frame_host_impl.cc
   content/browser/renderer_host/render_widget_host_view_mac.mm
@@ -72,6 +73,28 @@ index 6a0038e2c00d..dd00dfb3e5d0 100644
  
      // This really is a random number.  We haven't received any
      // information about the exit code, presumably because this
+diff --git a/components/viz/service/display/program_binding.h b/components/viz/service/display/program_binding.h
+index 70f1ff97b1ac..d1abd804e988 100644
+--- a/components/viz/service/display/program_binding.h
++++ b/components/viz/service/display/program_binding.h
+@@ -416,7 +416,7 @@ class VIZ_SERVICE_EXPORT Program : public ProgramBindingBase {
+     if (!ProgramBindingBase::Init(context_provider->ContextGL(),
+                                   vertex_shader_.GetShaderString(),
+                                   fragment_shader_.GetShaderString())) {
+-      DCHECK(IsContextLost(context_provider->ContextGL()));
++      // DCHECK(IsContextLost(context_provider->ContextGL()));
+       return;
+     }
+ 
+@@ -428,7 +428,7 @@ class VIZ_SERVICE_EXPORT Program : public ProgramBindingBase {
+ 
+     // Link after binding uniforms
+     if (!Link(context_provider->ContextGL())) {
+-      DCHECK(IsContextLost(context_provider->ContextGL()));
++      // DCHECK(IsContextLost(context_provider->ContextGL()));
+       return;
+     }
+ 
 diff --git a/content/browser/frame_host/navigation_controller_impl.cc b/content/browser/frame_host/navigation_controller_impl.cc
 index 4eb65b14dd49..8fd5d9ec9a1d 100644
 --- a/content/browser/frame_host/navigation_controller_impl.cc


### PR DESCRIPTION
Saw crash when running tests on Linux:

```
[4499:0307/103701.363973:FATAL:program_binding.h(419)] Check failed: IsContextLost(context_provider->ContextGL()).
0 0x7f4eb77c318d base::debug::StackTrace::StackTrace()
1 0x7f4eb77c155c base::debug::StackTrace::StackTrace()
2 0x7f4eb7851caa logging::LogMessage::~LogMessage()
3 0x7f4ec03b850a <unknown>
4 0x7f4ec03b38e7 <unknown>
5 0x7f4ec039ff4d viz::GLRenderer::SetUseProgram()
6 0x7f4ec03959f3 viz::GLRenderer::SetUseProgram()
7 0x7f4ec0391a64 viz::GLRenderer::DrawSolidColorQuad()
8 0x7f4ec03905db viz::GLRenderer::DoDrawQuad()
9 0x7f4eb6f15bc8 cc::DirectRenderer::DrawRenderPass()
10 0x7f4eb6f14316 cc::DirectRenderer::DrawRenderPassAndExecuteCopyRequests()
11 0x7f4eb6f13d24 cc::DirectRenderer::DrawFrame()
12 0x7f4ec0371f8d viz::Display::DrawAndSwap()
13 0x7f4ec037fcfe viz::DisplayScheduler::DrawAndSwap()
14 0x7f4ec037ec16 viz::DisplayScheduler::AttemptDrawAndSwap()
15 0x7f4ec037e50f viz::DisplayScheduler::OnBeginFrameDeadline()
```