### PR TITLE
Do not use system freetype for arm64

### DIFF
--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -19,12 +19,10 @@ if (target_cpu == "arm64") {
   # Temporary disable on arm64 due to "error: '__' macro redefined".
   # Should be enabled back eventually.
   use_jumbo_build = false
-}
 
-# On ARM64 Linux, use system provided freetype library to prevent this build failure:
-# warning: libfreetype.so.6, needed by ../../build/linux/debian_jessie_arm64-sysroot/usr/lib/aarch64-linux-gnu/libfontconfig.so, may conflict with libfreetype.so.6
-if (target_cpu == "arm64") {
-  use_system_freetype = true
+  # Suppress the linking warning for arm64:
+  # warning: libfreetype.so.6, needed by ../../build/linux/debian_jessie_arm64-sysroot/usr/lib/aarch64-linux-gnu/libfontconfig.so, may conflict with libfreetype.so.6
+  fatal_linker_warnings = false
 }
 
 # Configuration for mips64el

--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -28,10 +28,10 @@ if (target_cpu == "arm64") {
 # See https://github.com/nodejs/node/pull/13242
 v8_promise_internal_field_count = 1
 
-# On ARM64 Linux, use system provided freetype library to prevent this build failure:
+# Suppress the linking warning for arm64:
 # warning: libfreetype.so.6, needed by ../../build/linux/debian_jessie_arm64-sysroot/usr/lib/aarch64-linux-gnu/libfontconfig.so, may conflict with libfreetype.so.6
 if (target_cpu == "arm64") {
-  use_system_freetype = true
+  fatal_linker_warnings = false
 }
 
 # Configuration for mips64el

--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -32,10 +32,10 @@ if (target_cpu == "arm64") {
 # See https://github.com/nodejs/node/pull/13242
 v8_promise_internal_field_count = 1
 
-# On ARM64 Linux, use system provided freetype library to prevent this build failure:
+# Suppress the linking warning for arm64:
 # warning: libfreetype.so.6, needed by ../../build/linux/debian_jessie_arm64-sysroot/usr/lib/aarch64-linux-gnu/libfontconfig.so, may conflict with libfreetype.so.6
 if (target_cpu == "arm64") {
-  use_system_freetype = true
+  fatal_linker_warnings = false
 }
 
 # On Windows, we cannot use allocator shim because even though this is

--- a/patches/082-fix-arm64-linking-error.patch
+++ b/patches/082-fix-arm64-linking-error.patch
@@ -1,0 +1,13 @@
+diff --git a/skia/BUILD.gn b/skia/BUILD.gn
+index beb166ef89b4..f7aa3875c441 100644
+--- a/skia/BUILD.gn
++++ b/skia/BUILD.gn
+@@ -129,7 +129,7 @@ config("skia_library_config") {
+ 
+   defines = []
+ 
+-  if (!use_system_freetype) {
++  if (is_win || is_mac) {
+     defines += [ "SK_FREETYPE_MINIMUM_RUNTIME_VERSION=(((FREETYPE_MAJOR) * 0x01000000) | ((FREETYPE_MINOR) * 0x00010000) | ((FREETYPE_PATCH) * 0x00000100))" ]
+   }
+ 


### PR DESCRIPTION
Might be responsible for https://github.com/electron/electron/issues/12057, even if it does not fix the crash, it is still a good thing to align the config of arm64 with other architectures.