### PR TITLE
Disable official build for mips64el (1.8.x)

### DIFF
--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -1,7 +1,6 @@
 root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
 is_electron_build = true
 is_component_build = false
-is_official_build = true
 symbol_level = 2
 enable_nacl = false
 enable_widevine = true

--- a/script/update
+++ b/script/update
@@ -317,6 +317,12 @@ def run_gn(target_arch, defines):
         if IS_MIPS64EL_HOST:
           args += ' use_sysroot=false'
 
+    if component == 'static_library':
+      if target_arch == 'mips64el':
+        args += ' is_debug=false'
+      else:
+        args += ' is_official_build=true'
+
     output_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
     subprocess.call([gn, 'gen', os.path.relpath(output_dir, SRC_DIR), '--args=' + args],
                     cwd=SRC_DIR, env=env)


### PR DESCRIPTION
Due to problems in mips64el toolchain, the `--as-needed` linker flag crashes the compiler when we have official build enabled. Binary generated without the flag would potentially have symbols conflict between certain system libraries and Chromium's forked versions.

This PR is required for making Release build of mips64el work.

/cc @jkleinsc 