### PR TITLE
Fix bootstrap install error

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,7 +28,7 @@ def main():
 
   # Install PyYAML.
   with util.scoped_cwd(os.path.join('vendor', 'pyyaml')):
-    subprocess.call([sys.executable, 'setup.py', 'install', '--user'])
+    subprocess.call([sys.executable, 'setup.py', 'install', '--user', '--prefix', ''])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I was seeing the following error on macOS when running the bootstrap script.
`error: can't combine user with prefix, exec_prefix/home, or install_(plat)base`
This fixes it.