### PR TITLE
add patch to disable base_computed_style_ DCHECK

### DIFF
--- a/patches/common/chromium/disable_base_computed_style_dcheck.patch
+++ b/patches/common/chromium/disable_base_computed_style_dcheck.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/WebKit/Source/core/animation/ElementAnimations.cpp b/third_party/WebKit/Source/core/animation/ElementAnimations.cpp
+index 8b54fa3a9af3..be83456ea6f8 100644
+--- a/third_party/WebKit/Source/core/animation/ElementAnimations.cpp
++++ b/third_party/WebKit/Source/core/animation/ElementAnimations.cpp
+@@ -107,10 +107,6 @@ void ElementAnimations::UpdateBaseComputedStyle(
+     base_computed_style_ = nullptr;
+     return;
+   }
+-#if DCHECK_IS_ON()
+-  if (base_computed_style_ && computed_style)
+-    DCHECK(*base_computed_style_ == *computed_style);
+-#endif
+   base_computed_style_ = ComputedStyle::Clone(*computed_style);
+ }
+


### PR DESCRIPTION
This `DCHECK` is for some reason causing failures in `electron-api-demos` for reasons that i've investigated but can't fully determine; i'm disabling this check for now as a mitigation and will look to more fully investigate and re-add the check in later.

/cc @ckerr 