### PR TITLE
[2-0-x]: Re-enable accelerated 2D Canvas on NVidia High Sierra

### DIFF
--- a/patches/043-fix_rendering_glitches_on_high_sierra.patch
+++ b/patches/043-fix_rendering_glitches_on_high_sierra.patch
@@ -1,8 +1,8 @@
 diff --git a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
-index ed5c6d6c0e3c..ffec922b199d 100644
+index ed5c6d6c0e3c..da2053366a07 100644
 --- a/gpu/config/software_rendering_list.json
 +++ b/gpu/config/software_rendering_list.json
-@@ -1532,6 +1532,24 @@
+@@ -1532,6 +1532,23 @@
        "features": [
          "gpu_rasterization"
        ]
@@ -21,7 +21,6 @@ index ed5c6d6c0e3c..ffec922b199d 100644
 +      "vendor_id": "0x10de",
 +      "multi_gpu_category": "any",
 +      "features": [
-+        "accelerated_2d_canvas",
 +        "gpu_rasterization"
 +      ]
      }

--- a/patches/083-vs_toolchain.patch
+++ b/patches/083-vs_toolchain.patch
@@ -1,0 +1,47 @@
+Force building with *spring* Creators Update SDK
+
+The Fall Creators Update SDK has various bugs/incompatibilities that
+cause errors when building Chromium. This will not affect Google
+employees who use a packaged toolchain but good affect anybody who set
+DEPOT_TOOLS_WIN_TOOLCHAIN=0 and is therefore using the system install
+of VS 2017. This change forces vcvarsall.bat to use the 15063 SDK
+instead of the latest-installed.
+
+This should be a temporary measure that can be undone as we land
+workarounds for the incompatibilities or get fixed SDK versions.
+
+diff --git a/build/toolchain/win/setup_toolchain.py b/build/toolchain/win/setup_toolchain.py
+index 8150d3a4e4ac..bb599d62968f 100644
+--- a/build/toolchain/win/setup_toolchain.py
++++ b/build/toolchain/win/setup_toolchain.py
+@@ -139,9 +139,11 @@ def _LoadToolchainEnv(cpu, sdk_dir):
+         raise Exception('%s is missing - make sure VC++ tools are installed.' %
+                         script_path)
+       script_path = other_path
+-    # Chromium requires the 10.0.14393.0 SDK or higher - previous versions don't
+-    # have all of the required declarations.
+-    args = [script_path, 'amd64_x86' if cpu == 'x86' else 'amd64']
++    # Chromium requires the 10.0.15063.468 SDK - previous versions don't have
++    # all of the required declarations and 10.0.16299.0 has some
++    # incompatibilities (crbug.com/773476).
++    args = [script_path, 'amd64_x86' if cpu == 'x86' else 'amd64',
++            '10.0.15063.0']
+     variables = _LoadEnvFromBat(args)
+   return _ExtractImportantEnvironment(variables)
+ 
+diff --git a/build/vs_toolchain.py b/build/vs_toolchain.py
+index 3b2c727f51d5..9b005fcc5d57 100755
+--- a/build/vs_toolchain.py
++++ b/build/vs_toolchain.py
+@@ -346,8 +346,9 @@ def _GetDesiredVsToolchainHashes():
+     # Update 3 final with 10.0.15063.468 SDK and no vctip.exe.
+     return ['f53e4598951162bad6330f7a167486c7ae5db1e5']
+   if env_version == '2017':
+-    # VS 2017 Update 3 Preview 4 with 10.0.15063.468 SDK.
+-    return ['1f52d730755ac72dddaf121b73c9d6fd5c24ddf8']
++    # VS 2017 Update 3.2 with 10.0.15063.468 SDK, patched setenv.cmd, and
++    # 10.0.16299.15 debuggers.
++    return ['1180cb75833ea365097e279efb2d5d7a42dee4b0']
+   raise Exception('Unsupported VS version %s' % env_version)
+ 
+ 


### PR DESCRIPTION
As per https://bugs.chromium.org/p/chromium/issues/detail?id=773705#c141, I am aligning the patch with upstream. Might improve the state of https://github.com/electron/electron/issues/12042

```
Re-enabling accelerated 2D Canvas, as without acceleration performance
was bad enough that Canvas2D became unusable in common cases. If
deciding between occasional visual corruption and unusable performance,
visual corruption seems to be the lesser issue.

Note that this keeps GPU Raster blacklisted. This is unfortunate, but
was only enabled 1yr ago, so should have less sites with a hard
dependency.
```

CL: https://chromium-review.googlesource.com/c/chromium/src/+/759236

/cc @bpasero @Tyriar 