### PR TITLE
Add a patch to fix window repainting issues when DWM is disabled on Windows

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -274,10 +274,6 @@ patches:
   file: disable-recursive-surface-sync.patch
   description: null
 -
-  owners: brenca
-  file: disable-redraw-lock.patch
-  description: null
--
   owners: alexeykuzmin
   file: backport_a6977980088b.patch
   description: null
@@ -335,3 +331,17 @@ patches:
   owners: zcbenz
   file: fix-arm64-linking-error.patch
   description: Do not use system freetype for arm64
+-
+  owners: brenca
+  file: disable-redraw-lock.patch
+  description:  |
+    Chromium uses a custom window titlebar implementation on Windows when DWM
+    is disabled (Windows 7 and earlier, non Aero theme). The native titlebar
+    sometimes painted over this custom titlebar, so a workaround was put in
+    place to lock redraws in reaction to certain events if DWM is disabled,
+    since the code assumes that in that case, the custom titlebar is painted.
+    Electron forces the use of the native titlebar, which the workaround doesn't
+    take into account, and still locks redraws, causing weird repainting issues
+    in electron (and other applications). This patch provides a way to disable
+    the redraw locking mechanism, which fixes these issues. The electron issue
+    can be found at https://github.com/electron/electron/issues/1821

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -14,23 +14,23 @@ patches:
     build Electron (debug configuration) and make sure all tests pass on the CI
     systems. Unfortunately the tests don't always cover the check failures, so it's
     good to also run some non-trivial Electron app to verify.
-    
+
     Apart from getting rid of a whole diff, you may also be able to replace one diff
     with another which enables at least some of the previously disabled checks. For
     example, the checks might be disabled for a whole build target, but actually
     only one or two specific checks fail. Then it's better to simply comment out the
     failing checks and allow the rest of the target to have them enabled.
-    
+
     Please keep the following lists updated.
-    
+
     The ELECTRON_NO_DCHECK build flag disables debug checks universally.
     This patch applies the flag to the following GN targets:
-    
+
       third_party/WebKit/Source/core/loader:loader
       url:url
-    
+
     These files have debug checks explicitly commented out:
-    
+
       base/memory/weak_ptr.cc
       base/process/kill_win.cc
       components/viz/service/display/program_binding.h
@@ -64,11 +64,11 @@ patches:
     According to electron/electron#3699, it is unreliable to use |unload|
     event for process.exit('exit'), so we have to do that in
     willReleaseScriptContext.
-    
+
     However Chromium then disallowed scripting in willReleaseScriptContext
     in https://codereview.chromium.org/1657583002, and crash will happen
     when there is code doing that.
-    
+
     This patch reverts the change to fix the crash in Electron.
 -
   owners: null
@@ -179,7 +179,7 @@ patches:
     Linux, which may cause issues in a context like Electron, where the main
     and renderer threads are supposed to keep inherited permissions over the
     system.
-    
+
     See https://github.com/atom/electron/issues/3666
 -
   owners: zcbenz
@@ -274,6 +274,10 @@ patches:
   file: disable-recursive-surface-sync.patch
   description: null
 -
+  owners: brenca
+  file: disable-redraw-lock.patch
+  description: null
+-
   owners: alexeykuzmin
   file: backport_a6977980088b.patch
   description: null
@@ -293,7 +297,7 @@ patches:
     (wildcard), which is in itself probably a Bad Thing; but it's
     especially bad now because the catalog service exposes module
     directory access through its app capability.
-    
+
     This changes the catalog manifest to move the capability to a
     different more specific capability, and updates two of its
     consumers.

--- a/patches/common/chromium/disable-redraw-lock.patch
+++ b/patches/common/chromium/disable-redraw-lock.patch
@@ -1,0 +1,49 @@
+diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
+index 9776325defc8..570fb6330f48 100644
+--- a/ui/views/win/hwnd_message_handler.cc
++++ b/ui/views/win/hwnd_message_handler.cc
+@@ -305,6 +305,7 @@ class HWNDMessageHandler::ScopedRedrawLock {
+         cancel_unlock_(false),
+         should_lock_(owner_->IsVisible() && !owner->HasChildRenderingWindow() &&
+                      ::IsWindow(hwnd_) &&
++                     !owner_->HasNativeFrame() &&
+                      (!(GetWindowLong(hwnd_, GWL_STYLE) & WS_CAPTION) ||
+                       !ui::win::IsAeroGlassEnabled())) {
+     if (should_lock_)
+@@ -905,6 +906,10 @@ bool HWNDMessageHandler::HasChildRenderingWindow() {
+       hwnd());
+ }
+
++bool HWNDMessageHandler::HasNativeFrame() {
++  return delegate_->HasNativeFrame();
++}
++
+ ////////////////////////////////////////////////////////////////////////////////
+ // HWNDMessageHandler, gfx::WindowImpl overrides:
+
+diff --git a/ui/views/win/hwnd_message_handler.h b/ui/views/win/hwnd_message_handler.h
+index ad432b4d9ac6..9c22521f2bfb 100644
+--- a/ui/views/win/hwnd_message_handler.h
++++ b/ui/views/win/hwnd_message_handler.h
+@@ -227,6 +227,8 @@ class VIEWS_EXPORT HWNDMessageHandler : public gfx::WindowImpl,
+   typedef std::set<DWORD> TouchIDs;
+   enum class DwmFrameState { OFF, ON };
+
++  bool HasNativeFrame();
++
+   // Overridden from WindowImpl:
+   HICON GetDefaultWindowIcon() const override;
+   HICON GetSmallWindowIcon() const override;
+diff --git a/ui/views/win/hwnd_message_handler_delegate.h b/ui/views/win/hwnd_message_handler_delegate.h
+index 2168aedea4bb..1615c65f18d8 100644
+--- a/ui/views/win/hwnd_message_handler_delegate.h
++++ b/ui/views/win/hwnd_message_handler_delegate.h
+@@ -40,6 +40,8 @@ class VIEWS_EXPORT HWNDMessageHandlerDelegate {
+   // True if the widget associated with this window has a non-client view.
+   virtual bool HasNonClientView() const = 0;
+
++  virtual bool HasNativeFrame() const { return false; }
++
+   // Returns who we want to be drawing the frame. Either the system (Windows)
+   // will handle it or Chrome will custom draw it.
+   virtual FrameMode GetFrameMode() const = 0;


### PR DESCRIPTION
Fixes electron/electron#1821, sister PR coming up on that repo

When DWM is disabled, chromium uses a custom window title implementation (this can be observed by running Chrome on Windows7 with the aero theme disabled). The code is written to assume that that's what's happening, but electron is forcing a native titlebar, and that causes problems, since chromium does [some hacky stuff](https://cs.chromium.org/chromium/src/ui/views/win/hwnd_message_handler.cc?l=253) to ensure that the custom titlebar always works perfectly. That hacky stuff blocks the native titlebar (and the whole window in fact) from rendering correctly. This patch adds a way to disable the lock.