### PR TITLE
Fix compositor delegate patch

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -104,11 +104,10 @@ patches:
 #  owners: zcbenz
 #  file: can_create_window.patch
 #  description: null
-# TODO(alexeykuzmin): Fix the patch.
-#-
-#  owners: null
-#  file: compositor_delegate.patch
-#  description: null
+-
+  owners: null
+  file: compositor_delegate.patch
+  description: null
 -
   owners: null
   file: desktop_screen_win.patch

--- a/patches/common/chromium/compositor_delegate.patch
+++ b/patches/common/chromium/compositor_delegate.patch
@@ -2,40 +2,49 @@ diff --git a/content/browser/compositor/gpu_process_transport_factory.cc b/conte
 index 45bf6b1b4618..f023beabaa65 100644
 --- a/content/browser/compositor/gpu_process_transport_factory.cc
 +++ b/content/browser/compositor/gpu_process_transport_factory.cc
-@@ -274,6 +274,13 @@ GpuProcessTransportFactory::~GpuProcessTransportFactory() {
- std::unique_ptr<viz::SoftwareOutputDevice>
- GpuProcessTransportFactory::CreateSoftwareOutputDevice(
-     ui::Compositor* compositor) {
-+  if (compositor->delegate()) {
-+    std::unique_ptr<viz::SoftwareOutputDevice> output_device =
-+      compositor->delegate()->CreateSoftwareOutputDevice(compositor);
-+    if (output_device)
-+      return output_device;
-+  }
+@@ -491,9 +491,19 @@ void GpuProcessTransportFactory::EstablishedGpuChannel(
+         // surfaces as they are not following the correct mode.
+         DisableGpuCompositing(compositor.get());
+       }
 +
-   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-   if (command_line->HasSwitch(switches::kHeadless))
-     return base::WrapUnique(new viz::SoftwareOutputDevice);
++      std::unique_ptr<viz::SoftwareOutputDevice> output_device;
++      if (compositor->delegate()) {
++        output_device = compositor->delegate()->CreateSoftwareOutputDevice(
++            compositor.get());
++      }
++      if (!output_device) {
++        output_device = CreateSoftwareOutputDevice(compositor->widget());
++      }
++
+       display_output_surface =
+           std::make_unique<SoftwareBrowserCompositorOutputSurface>(
+-              CreateSoftwareOutputDevice(compositor->widget()), vsync_callback,
++              std::move(output_device), vsync_callback,
+               compositor->task_runner());
+     } else {
+       DCHECK(context_provider);
 diff --git a/ui/compositor/compositor.h b/ui/compositor/compositor.h
 index d842aa55175b..2c2131774b71 100644
 --- a/ui/compositor/compositor.h
 +++ b/ui/compositor/compositor.h
-@@ -23,6 +23,7 @@
+@@ -24,6 +24,7 @@
+ #include "components/viz/common/surfaces/frame_sink_id.h"
  #include "components/viz/common/surfaces/local_surface_id.h"
- #include "components/viz/common/surfaces/surface_sequence.h"
  #include "components/viz/host/host_frame_sink_client.h"
 +#include "components/viz/service/display/software_output_device.h"
  #include "third_party/skia/include/core/SkColor.h"
+ #include "third_party/skia/include/core/SkMatrix44.h"
  #include "ui/compositor/compositor_animation_observer.h"
- #include "ui/compositor/compositor_export.h"
-@@ -179,6 +180,15 @@ class COMPOSITOR_EXPORT ContextFactory {
+@@ -182,6 +183,17 @@ class COMPOSITOR_EXPORT ContextFactory {
    virtual void RemoveObserver(ContextFactoryObserver* observer) = 0;
  };
  
 +class COMPOSITOR_EXPORT CompositorDelegate {
 + public:
 +  virtual std::unique_ptr<viz::SoftwareOutputDevice> CreateSoftwareOutputDevice(
-+      ui::Compositor* compositor) = 0;
++      ui::Compositor* compositor) {
++    return nullptr;
++  }
 +
 + protected:
 +  virtual ~CompositorDelegate() {}
@@ -44,7 +53,7 @@ index d842aa55175b..2c2131774b71 100644
  // Compositor object to take care of GPU painting.
  // A Browser compositor object is responsible for generating the final
  // displayable form of pixels comprising a single widget's contents. It draws an
-@@ -215,6 +225,9 @@ class COMPOSITOR_EXPORT Compositor : public cc::LayerTreeHostClient,
+@@ -221,6 +231,9 @@ class COMPOSITOR_EXPORT Compositor : public cc::LayerTreeHostClient,
    // Schedules a redraw of the layer tree associated with this compositor.
    void ScheduleDraw();
  

--- a/patches/common/chromium/compositor_delegate.patch
+++ b/patches/common/chromium/compositor_delegate.patch
@@ -35,16 +35,14 @@ index d842aa55175b..2c2131774b71 100644
  #include "third_party/skia/include/core/SkColor.h"
  #include "third_party/skia/include/core/SkMatrix44.h"
  #include "ui/compositor/compositor_animation_observer.h"
-@@ -182,6 +183,17 @@ class COMPOSITOR_EXPORT ContextFactory {
+@@ -182,6 +183,15 @@ class COMPOSITOR_EXPORT ContextFactory {
    virtual void RemoveObserver(ContextFactoryObserver* observer) = 0;
  };
  
 +class COMPOSITOR_EXPORT CompositorDelegate {
 + public:
 +  virtual std::unique_ptr<viz::SoftwareOutputDevice> CreateSoftwareOutputDevice(
-+      ui::Compositor* compositor) {
-+    return nullptr;
-+  }
++      ui::Compositor* compositor) {}
 +
 + protected:
 +  virtual ~CompositorDelegate() {}

--- a/patches/common/chromium/compositor_delegate.patch
+++ b/patches/common/chromium/compositor_delegate.patch
@@ -42,7 +42,7 @@ index d842aa55175b..2c2131774b71 100644
 +class COMPOSITOR_EXPORT CompositorDelegate {
 + public:
 +  virtual std::unique_ptr<viz::SoftwareOutputDevice> CreateSoftwareOutputDevice(
-+      ui::Compositor* compositor) {}
++      ui::Compositor* compositor) = 0;
 +
 + protected:
 +  virtual ~CompositorDelegate() {}


### PR DESCRIPTION
Update patch based on [this](https://bitbucket.org/chromiumembedded/cef/src/173d79a417b97aa62216d3c54531a4671aa3ff1f/patch/patches/compositor_1368.patch?at=3359&fileviewer=file-view-default) update for Chromium 66.

Compensates for changes made in [this patchset](https://chromium-review.googlesource.com/c/chromium/src/+/722207).

For https://github.com/electron/libchromiumcontent/pull/499.

/cc @brenca @alexeykuzmin @deepak1556 