### PR TITLE
Backport a couple of IndexedDB fixes

### DIFF
--- a/patches/046-backport_72d995cf.patch
+++ b/patches/046-backport_72d995cf.patch
@@ -1,0 +1,89 @@
+Backport of "[IndexedDB] Added wrapper to cursor to avoid use-after-free on shutdown."
+See https://codereview.chromium.org/2892223003
+
+diff --git a/content/browser/indexed_db/indexed_db_callbacks.cc b/content/browser/indexed_db/indexed_db_callbacks.cc
+index 3cd348c5a5a6..052eb61df016 100644
+--- a/content/browser/indexed_db/indexed_db_callbacks.cc
++++ b/content/browser/indexed_db/indexed_db_callbacks.cc
+@@ -44,10 +44,8 @@ namespace content {
+ 
+ namespace {
+ 
+-// If this is destructed with the connection still living inside it, we assume
+-// we have been killed due to IO thread shutdown, and we need to safely schedule
+-// the destruction of the connection on the IDB thread, as we should still be in
+-// a transaction's operation queue, where we cannot destroy the transaction.
++// The following two objects protect the given objects from being destructed on
++// the IO thread if we have a shutdown or an error.
+ struct SafeIOThreadConnectionWrapper {
+   SafeIOThreadConnectionWrapper(std::unique_ptr<IndexedDBConnection> connection)
+       : connection(std::move(connection)),
+@@ -72,6 +70,23 @@ struct SafeIOThreadConnectionWrapper {
+   DISALLOW_COPY_AND_ASSIGN(SafeIOThreadConnectionWrapper);
+ };
+ 
++struct SafeIOThreadCursorWrapper {
++  SafeIOThreadCursorWrapper(std::unique_ptr<IndexedDBCursor> cursor)
++      : cursor(std::move(cursor)),
++        idb_runner(base::ThreadTaskRunnerHandle::Get()) {}
++  ~SafeIOThreadCursorWrapper() {
++    if (cursor)
++      idb_runner->DeleteSoon(FROM_HERE, cursor.release());
++  }
++  SafeIOThreadCursorWrapper(SafeIOThreadCursorWrapper&& other) = default;
++
++  std::unique_ptr<IndexedDBCursor> cursor;
++  scoped_refptr<base::SequencedTaskRunner> idb_runner;
++
++ private:
++  DISALLOW_COPY_AND_ASSIGN(SafeIOThreadCursorWrapper);
++};
++
+ void ConvertBlobInfo(
+     const std::vector<IndexedDBBlobInfo>& blob_info,
+     std::vector<::indexed_db::mojom::BlobInfoPtr>* blob_or_file_info) {
+@@ -129,7 +144,7 @@ class IndexedDBCallbacks::IOThreadHelper {
+                          const content::IndexedDBDatabaseMetadata& metadata);
+   void SendSuccessDatabase(SafeIOThreadConnectionWrapper connection,
+                            const content::IndexedDBDatabaseMetadata& metadata);
+-  void SendSuccessCursor(std::unique_ptr<IndexedDBCursor> cursor,
++  void SendSuccessCursor(SafeIOThreadCursorWrapper cursor,
+                          const IndexedDBKey& key,
+                          const IndexedDBKey& primary_key,
+                          ::indexed_db::mojom::ValuePtr value,
+@@ -328,12 +343,14 @@ void IndexedDBCallbacks::OnSuccess(std::unique_ptr<IndexedDBCursor> cursor,
+     blob_info.swap(value->blob_info);
+   }
+ 
++  SafeIOThreadCursorWrapper cursor_wrapper(std::move(cursor));
++
+   BrowserThread::PostTask(
+       BrowserThread::IO, FROM_HERE,
+       base::Bind(&IOThreadHelper::SendSuccessCursor,
+-                 base::Unretained(io_helper_.get()), base::Passed(&cursor), key,
+-                 primary_key, base::Passed(&mojo_value),
+-                 base::Passed(&blob_info)));
++                 base::Unretained(io_helper_.get()),
++                 base::Passed(&cursor_wrapper), key, primary_key,
++                 base::Passed(&mojo_value), base::Passed(&blob_info)));
+   complete_ = true;
+ }
+ 
+@@ -574,7 +591,7 @@ void IndexedDBCallbacks::IOThreadHelper::SendSuccessDatabase(
+ }
+ 
+ void IndexedDBCallbacks::IOThreadHelper::SendSuccessCursor(
+-    std::unique_ptr<IndexedDBCursor> cursor,
++    SafeIOThreadCursorWrapper cursor,
+     const IndexedDBKey& key,
+     const IndexedDBKey& primary_key,
+     ::indexed_db::mojom::ValuePtr value,
+@@ -587,7 +604,7 @@ void IndexedDBCallbacks::IOThreadHelper::SendSuccessCursor(
+     return;
+   }
+   auto cursor_impl = base::MakeUnique<CursorImpl>(
+-      std::move(cursor), origin_, dispatcher_host_.get(), idb_runner_);
++      std::move(cursor.cursor), origin_, dispatcher_host_.get(), idb_runner_);
+ 
+   if (value && !CreateAllBlobs(blob_info, &value->blob_or_file_info))
+     return;

--- a/patches/047-backport_d007b8b7.patch
+++ b/patches/047-backport_d007b8b7.patch
@@ -1,0 +1,55 @@
+Backport of "[IndexedDB] Fix Cursor UAF".
+See https://chromium-review.googlesource.com/526284
+
+diff --git a/content/browser/indexed_db/cursor_impl.cc b/content/browser/indexed_db/cursor_impl.cc
+index 15382eb88178..60c171ad204a 100644
+--- a/content/browser/indexed_db/cursor_impl.cc
++++ b/content/browser/indexed_db/cursor_impl.cc
+@@ -96,9 +96,7 @@ CursorImpl::IDBThreadHelper::IDBThreadHelper(
+     std::unique_ptr<IndexedDBCursor> cursor)
+     : cursor_(std::move(cursor)) {}
+ 
+-CursorImpl::IDBThreadHelper::~IDBThreadHelper() {
+-  cursor_->RemoveCursorFromTransaction();
+-}
++CursorImpl::IDBThreadHelper::~IDBThreadHelper() {}
+ 
+ void CursorImpl::IDBThreadHelper::Advance(
+     uint32_t count,
+diff --git a/content/browser/indexed_db/indexed_db_cursor.cc b/content/browser/indexed_db/indexed_db_cursor.cc
+index f9a130cc6234..c84547fb43f9 100644
+--- a/content/browser/indexed_db/indexed_db_cursor.cc
++++ b/content/browser/indexed_db/indexed_db_cursor.cc
+@@ -70,6 +70,8 @@ IndexedDBCursor::IndexedDBCursor(
+ }
+ 
+ IndexedDBCursor::~IndexedDBCursor() {
++  if (transaction_)
++    transaction_->UnregisterOpenCursor(this);
+   // Call to make sure we complete our lifetime trace.
+   Close();
+ }
+@@ -106,11 +108,6 @@ void IndexedDBCursor::Advance(uint32_t count,
+                         ptr_factory_.GetWeakPtr(), count, callbacks));
+ }
+ 
+-void IndexedDBCursor::RemoveCursorFromTransaction() {
+-  if (transaction_)
+-    transaction_->UnregisterOpenCursor(this);
+-}
+-
+ leveldb::Status IndexedDBCursor::CursorAdvanceOperation(
+     uint32_t count,
+     scoped_refptr<IndexedDBCallbacks> callbacks,
+diff --git a/content/browser/indexed_db/indexed_db_cursor.h b/content/browser/indexed_db/indexed_db_cursor.h
+index 591f9f890502..1d10e901d70c 100644
+--- a/content/browser/indexed_db/indexed_db_cursor.h
++++ b/content/browser/indexed_db/indexed_db_cursor.h
+@@ -44,7 +44,6 @@ class CONTENT_EXPORT IndexedDBCursor {
+                                                          : cursor_->value();
+   }
+ 
+-  void RemoveCursorFromTransaction();
+   void Close();
+ 
+   leveldb::Status CursorIterationOperation(


### PR DESCRIPTION
Backports [72d995cf2cc67c9c8aa7164f6d72d7aa3380a35c ](https://chromium.googlesource.com/chromium/src/+/72d995cf2cc67c9c8aa7164f6d72d7aa3380a35c) and [d007b8b750851fe1b375c463009ea3b24e5c021d](https://chromium.googlesource.com/chromium/src/+/d007b8b750851fe1b375c463009ea3b24e5c021d). Related to https://github.com/electron/electron/issues/12552.

There's no PRs to master or other branches since Chromium 60+ is not affected.

/cc @ckerr, @deepak1556 