### PR TITLE
Add script/get-patch

### DIFF
--- a/script/get-patch
+++ b/script/get-patch
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""Retrieves commit contents in a patch format.
+
+Use it to export commits from Chromium's and other repos as patch files. E.g.
+$ ./script/get-patch --repo src --commit 72d995cf2 > some/folder/path/backport_72d995cf2.patch
+"""
+
+import argparse
+import sys
+
+from lib.git import get_patch as git_get_patch
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Apply patches to a git repo')
+
+  parser.add_argument('-c', '--commit', help='Commit hash.')
+  parser.add_argument('-r', '--repo', help='Path to a repository root folder.')
+
+  return parser.parse_args()
+
+
+def main():
+  args = parse_args()
+
+  repo = args.repo
+  commit_hash = args.commit
+
+  patch_contents = git_get_patch(repo, commit_hash)
+  sys.stdout.write(patch_contents)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -6,6 +6,8 @@ and make any assumptions about the passed arguments or calls outcomes.
 
 import subprocess
 
+from util import scoped_cwd
+
 
 def apply(repo, patch_path, reverse=False):
   args = ['git', 'apply',
@@ -22,3 +24,14 @@ def apply(repo, patch_path, reverse=False):
   applied_successfully = (return_code == 0)
 
   return applied_successfully
+
+
+def get_patch(repo, commit_hash):
+  args = ['git', 'diff-tree',
+          '-p',
+          commit_hash,
+          '--'  # Explicitly tell Git that `commit_hash` is a revision, not a path.
+          ]
+
+  with scoped_cwd(repo):
+    return subprocess.check_output(args)


### PR DESCRIPTION
Use it to export commits from Chromium's and other repos as patch files. E.g.

```
$ ./script/get-patch --repo src --commit 72d995cf2 > some/folder/path/backport_72d995cf2.patch
```

/cc @MarshallOfSound, @deepak1556, @alespergl 