### PR TITLE
Add error output to VSTS build logs

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -28,28 +28,28 @@ phases:
   steps:
   - bash: |
      echo "##vso[task.setvariable variable=gitcommit]$BUILD_SOURCEVERSION"
-     echo "===Bootstrapping===" | tee -a buildlog.txt
-     script/bootstrap | tee -a buildlog.txt
+     echo "===Bootstrapping===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/bootstrap > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
     name: Bootstrap
 
   - bash: |
-     echo "===Updating for $TARGET_ARCH===" | tee -a buildlog.txt
-     script/update --clean -t $TARGET_ARCH | tee -a buildlog.txt
+     echo "===Updating for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/update --clean -t $TARGET_ARCH > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
     name: Update
 
   - bash: |
-     echo "===Building $COMPONENT for $TARGET_ARCH===" | tee -a buildlog.txt
-     script/build -t $TARGET_ARCH -c $COMPONENT | tee -a buildlog.txt
+     echo "===Building $COMPONENT for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/build -t $TARGET_ARCH -c $COMPONENT > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
     name: Build_library
 
   - bash: |
-     echo "===Building ffmpeg for $TARGET_ARCH===" | tee -a buildlog.txt
-     script/build -t $TARGET_ARCH -c ffmpeg | tee -a buildlog.txt
+     echo "===Building ffmpeg for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/build -t $TARGET_ARCH -c ffmpeg > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
     name: Build_ffmpeg
 
   - bash: |
-     echo "===Create $COMPONENT distribution for $TARGET_ARCH===" | tee -a buildlog.txt
-     script/create-dist -t $TARGET_ARCH -c $COMPONENT | tee -a buildlog.txt
+     echo "===Create $COMPONENT distribution for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/create-dist -t $TARGET_ARCH -c $COMPONENT > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
      mkdir s3files
      mv libchromiumcontent* s3files
      mv buildlog.txt s3files
@@ -72,7 +72,7 @@ phases:
        echo "Skipping build results upload because there is not a PR number"
      else
        npm install --prefix ./script/reportbuild
-       LIBCHROMIUMCONTENT_GITHUB_TOKEN=$(LIBCHROMIUMCONTENT_GITHUB_TOKEN) node script/reportbuild/upload-build-results.js --buildName=$AGENT_JOBNAME --logFile=$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)/buildlog.txt --prNumber=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER --commitId=$BUILD_SOURCEVERSION --failed
+       LIBCHROMIUMCONTENT_GITHUB_TOKEN=$(LIBCHROMIUMCONTENT_GITHUB_TOKEN) node script/reportbuild/upload-build-results.js --buildName="$AGENT_JOBNAME" --logFile="$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)/buildlog.txt" --prNumber="$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" --commitId="$BUILD_SOURCEVERSION" --failed
       fi
     condition: failed()
 
@@ -81,7 +81,7 @@ phases:
        echo "Skipping build results upload because there is not a PR number"
      else
        npm install --prefix ./script/reportbuild
-       LIBCHROMIUMCONTENT_GITHUB_TOKEN=$(LIBCHROMIUMCONTENT_GITHUB_TOKEN) node script/reportbuild/upload-build-results.js --buildName=$AGENT_JOBNAME --logFile=$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)/buildlog.txt --prNumber=$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER --commitId=$BUILD_SOURCEVERSION
+       LIBCHROMIUMCONTENT_GITHUB_TOKEN=$(LIBCHROMIUMCONTENT_GITHUB_TOKEN) node script/reportbuild/upload-build-results.js --buildName="$AGENT_JOBNAME" --logFile="$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)/buildlog.txt" --prNumber="$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" --commitId="$BUILD_SOURCEVERSION"
       fi
 
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3


### PR DESCRIPTION
#515 added the VSTS build logs as comments in the PR, but unfortunately did not capture error output (aka stderr).  This PR adds the capture of that information.