### PR TITLE
Add a patch to fix a Mac screen sharing crash.

### DIFF
--- a/patches/third_party/webrtc/005-mac_invalid_cursor_screenshare_crash.patch
+++ b/patches/third_party/webrtc/005-mac_invalid_cursor_screenshare_crash.patch
@@ -1,0 +1,14 @@
+diff --git a/modules/desktop_capture/mouse_cursor_monitor_mac.mm b/modules/desktop_capture/mouse_cursor_monitor_mac.mm
+index 213071952..64edcfb2f 100644
+--- a/modules/desktop_capture/mouse_cursor_monitor_mac.mm
++++ b/modules/desktop_capture/mouse_cursor_monitor_mac.mm
+@@ -251,6 +251,9 @@ void MouseCursorMonitorMac::CaptureImage(float scale) {
+   NSCursor* nscursor = [NSCursor currentSystemCursor];
+ 
+   NSImage* nsimage = [nscursor image];
++  if (nsimage == nil || !nsimage.isValid) {
++    return;
++  }
+   NSSize nssize = [nsimage size];  // DIP size
+ 
+   // For retina screen, we need to paint the cursor in current graphic context


### PR DESCRIPTION
Backports the change here:
https://chromium.googlesource.com/external/webrtc/trunk/webrtc/+/07961e9d2becadcf9419cede22aa0bf3058ccaa2%5E%21/#F0

fixing the crash reported here:
https://bugs.chromium.org/p/chromium/issues/detail?id=752036
(requires a chromium.org account to view)

We've had crashes with the same stack trace reported by Slack screen
sharing users. Since we can't reproduced the crash internally, I haven't
been able to verify the fix, but by inspection it's very likely to work.

The upstream fix was released in M60 so this isn't as issue in Electron
2.x which uses M61. We've verified this with users.