### PR TITLE
Fix mac static builds for 2-0-x

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -12,7 +12,7 @@ phases:
         TARGET_ARCH: x64
         TARGET_TYPE: mas
       libchromiumcontent-mas-static:
-        COMPONENT: shared_library
+        COMPONENT: static_library
         MAS_BUILD: 1
         TARGET_ARCH: x64
         TARGET_TYPE: mas
@@ -21,7 +21,7 @@ phases:
         TARGET_ARCH: x64
         TARGET_TYPE: osx
       libchromiumcontent-osx-static:
-        COMPONENT: shared_library
+        COMPONENT: static_library
         TARGET_ARCH: x64
         TARGET_TYPE: osx
 


### PR DESCRIPTION
Static builds were accidentally building the shared library instead.
Backports #523 to 2-0-x
(cherry picked from commit b9a74d0dbea4454fa9301d9871a026f0d2dcd8a9)