### PR TITLE
Fix PR builds for Mac

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -27,7 +27,20 @@ phases:
 
   steps:
   - bash: |
-     echo "##vso[task.setvariable variable=gitcommit]$BUILD_SOURCEVERSION"
+     if [[ -z "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}" ]] || "$SYSTEM_PULLREQUEST_ISFORK" == "True"; then
+       echo "##vso[task.setvariable variable=gitcommit]$BUILD_SOURCEVERSION"
+     else
+       tmp="${BUILD_SOURCEVERSIONMESSAGE/#Merge/}"
+       PR_COMMIT_ID="${tmp%%into*}"
+       echo "PR is for repo branch, using original commit $PR_COMMIT_ID"
+       echo "##vso[task.setvariable variable=gitcommit]$PR_COMMIT_ID"
+       echo "Checking out $PR_COMMIT_ID"
+       git checkout $PR_COMMIT_ID
+       echo "Now switched to `git rev-parse HEAD`"
+     fi
+    name: Get_commit
+
+  - bash: |
      echo "===Bootstrapping===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
      script/bootstrap > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
     name: Bootstrap

--- a/vsts.yml
+++ b/vsts.yml
@@ -27,11 +27,11 @@ phases:
 
   steps:
   - bash: |
-     if [[ -z "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}" ]] || "$SYSTEM_PULLREQUEST_ISFORK" == "True"; then
+     if [[ -z "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}" ]] || "${SYSTEM_PULLREQUEST_ISFORK}" == "True"; then
        echo "##vso[task.setvariable variable=gitcommit]$BUILD_SOURCEVERSION"
      else
-       tmp="${BUILD_SOURCEVERSIONMESSAGE/#Merge/}"
-       PR_COMMIT_ID="${tmp%%into*}"
+       tmp="${BUILD_SOURCEVERSIONMESSAGE/#Merge /}"
+       PR_COMMIT_ID="${tmp%% into*}"
        echo "PR is for repo branch, using original commit $PR_COMMIT_ID"
        echo "##vso[task.setvariable variable=gitcommit]$PR_COMMIT_ID"
        echo "Checking out $PR_COMMIT_ID"


### PR DESCRIPTION
Visual Studio Team Services builds PRs by merging the commit(s) into the target branch and then building that.  Unfortunately this ends up putting PR builds in the wrong location on S3 as well as it produces issues for WIP PRs such as our Chromium upgrades.

This PR will do the following:
1. If the build is not a PR build, it will build the commit.
2. If the build is a PR build, but for a fork, it will build against the result of merging the commit(s) into the target branch.
3. If the build is a PR build from a branch in this repo, it will build the original commit instead of the merge.