### PR TITLE
Only run builds if they are branch build or fork pr for VSTS

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -2,6 +2,7 @@ resources:
 - repo: self
 phases:
 - phase: Build_libchromiumcontent
+  condition: or(eq(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
   queue:
     parallel: 4
     timeoutInMinutes: 180


### PR DESCRIPTION
This PR should fix VSTS so that we only run PR builds for PRs coming from forks.  All PRs that come from branches will get built automatically as branch builds.