### PR TITLE
Only build native_mksnapshot for arm and arm64

### DIFF
--- a/script/build
+++ b/script/build
@@ -9,6 +9,7 @@ import platform
 from lib.config import MIPS64EL_GCC, set_mips64el_env, get_output_dir, \
                        SOURCE_ROOT, VENDOR_DIR, DEPOT_TOOLS_DIR, \
                        COMPONENTS
+
 from lib.ninja import run as run_ninja
 
 
@@ -30,7 +31,7 @@ def main():
   os.chdir(SOURCE_ROOT)
 
   # Build everything by default.
-  components_to_build = COMPONENTS
+  components_to_build = list(COMPONENTS)
 
   if args.debug:
     components_to_build = ['shared_library', 'ffmpeg']
@@ -38,6 +39,8 @@ def main():
     components_to_build = ['static_library', 'ffmpeg']
   elif args.component is not None:
     components_to_build = args.component
+  elif "arm" not in target_arch:
+    components_to_build.remove('native_mksnapshot')
 
   for component in components_to_build:
     out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)

--- a/script/create-dist
+++ b/script/create-dist
@@ -51,7 +51,7 @@ STATIC_LIBRARY_SUFFIX = {
   'win32': 'lib',
 }[TARGET_PLATFORM]
 
-COMPONENTS = ['static_library', 'shared_library','native_mksnapshot']
+COMPONENTS = ['static_library', 'shared_library', 'native_mksnapshot']
 BINARIES = {
   'all': [
     'content_shell.pak',
@@ -405,7 +405,8 @@ def generate_ninja(args, ninja):
       BINARIES[TARGET_PLATFORM].remove(lib)
 
   for component in COMPONENTS:
-    if args.component == 'all' or args.component == component:
+    if ((args.component == 'all' or args.component == component) and
+        (component != 'native_mksnapshot' or 'arm' in target_arch)):
       copy_binaries(target_arch, component, create_debug_archive,
                     args.keep_debug_symbols, ninja)
       copy_generated_sources(target_arch, component, ninja)

--- a/script/run-gn
+++ b/script/run-gn
@@ -42,7 +42,8 @@ def main():
      gn_args.update(args.args)
 
   for component in args.components:
-    generate_build_files(component, args.target_arch, **gn_args)
+    if component != 'native_mksnapshot' or 'arm' in args.target_arch:
+      generate_build_files(component, args.target_arch, **gn_args)
 
 
 def generate_build_files(component, target_arch, **gnargs):

--- a/script/update
+++ b/script/update
@@ -16,8 +16,7 @@ import lib.util as util
 
 from lib.config import MIPS64EL_GCC, MIPS64EL_GCC_URL, MIPS64EL_SYSROOT, \
                        set_mips64el_env, IS_ARM64_HOST, IS_ARMV7_HOST, \
-                       SOURCE_ROOT, VENDOR_DIR, DEPOT_TOOLS_DIR, SRC_DIR, \
-                       COMPONENTS
+                       SOURCE_ROOT, VENDOR_DIR, DEPOT_TOOLS_DIR, SRC_DIR
 
 
 CHROMIUMCONTENT_SOURCE_DIR = os.path.join(SOURCE_ROOT, 'chromiumcontent')


### PR DESCRIPTION
This PR changes script/build to not build native_mksnapshot if you are not on hardware capable of building those binaries.  Fixes #509 