### PR TITLE
Move //chromiumcontent to //libchromiumcontent/chromiumcontent

### DIFF
--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -1,4 +1,4 @@
-root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
+root_extra_deps = [ "//libchromiumcontent/chromiumcontent" ]
 is_component_build = false
 is_debug = false
 enable_nacl = false

--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -1,4 +1,4 @@
-root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
+root_extra_deps = [ "//libchromiumcontent/chromiumcontent" ]
 is_electron_build = true
 is_component_build = true
 is_debug = true

--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -1,4 +1,4 @@
-root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
+root_extra_deps = [ "//libchromiumcontent/chromiumcontent" ]
 is_electron_build = true
 is_component_build = false
 is_official_build = true

--- a/chromiumcontent/args/tests.gn
+++ b/chromiumcontent/args/tests.gn
@@ -1,4 +1,4 @@
-root_extra_deps = [ "//chromiumcontent:chromiumcontent_tests" ]
+root_extra_deps = [ "//libchromiumcontent/chromiumcontent:chromiumcontent_tests" ]
 is_debug = false
 is_electron_build = true
 is_component_build = true

--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -15,7 +15,7 @@ index de3f35f124aa..a52003f1b5e1 100644
    "//build/config/compiler:runtime_library",
    "//build/config/coverage:default_coverage",
    "//build/config/sanitizers:default_sanitizer_flags",
-+  "//chromiumcontent/config:mas_build",
++  "//libchromiumcontent/chromiumcontent/config:mas_build",
  ]
  if (is_win) {
    default_compiler_configs += [
@@ -70,7 +70,7 @@ index 6c86a6454256..2bc8c31396af 100644
  }
  
  executable("character_data_generator") {
-+  configs += [ "//chromiumcontent/config:build_time_executable" ]
++  configs += [ "//libchromiumcontent/chromiumcontent/config:build_time_executable" ]
    sources = [
      "text/CharacterPropertyDataGenerator.cpp",
      "text/CharacterPropertyDataGenerator.h",

--- a/patches/common/v8/build_gn.patch
+++ b/patches/common/v8/build_gn.patch
@@ -66,7 +66,7 @@ index 494ba22f29..6071422d7d 100644
  
      configs = [ ":internal_config" ]
  
-+    configs += [ "//chromiumcontent/config:build_time_executable" ]
++    configs += [ "//libchromiumcontent/chromiumcontent/config:build_time_executable" ]
 +
      deps = [
        ":v8_base",

--- a/script/build
+++ b/script/build
@@ -41,9 +41,9 @@ def main():
 
   for component in components_to_build:
     out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
-    target = 'chromiumcontent:chromiumcontent'
+    target = 'libchromiumcontent/chromiumcontent:chromiumcontent'
     if component == 'tests':
-      target = 'chromiumcontent:chromiumcontent_tests'
+      target = 'libchromiumcontent/chromiumcontent:chromiumcontent_tests'
     if component == 'native_mksnapshot':
       target = 'v8:mksnapshot'
     run_ninja(os.path.relpath(out_dir), target=target, env=env)
@@ -51,7 +51,7 @@ def main():
     if component == 'static_library':
       subenv = env.copy()
       subenv['CHROMIUMCONTENT_2ND_PASS'] = '1'
-      target = 'chromiumcontent:libs'
+      target = 'libchromiumcontent/chromiumcontent:libs'
       run_ninja(os.path.relpath(out_dir), target=target, env=subenv)
 
 

--- a/script/update
+++ b/script/update
@@ -21,7 +21,8 @@ from lib.config import MIPS64EL_GCC, MIPS64EL_GCC_URL, MIPS64EL_SYSROOT, \
 
 
 CHROMIUMCONTENT_SOURCE_DIR = os.path.join(SOURCE_ROOT, 'chromiumcontent')
-CHROMIUMCONTENT_DESTINATION_DIR = os.path.join(SRC_DIR, 'chromiumcontent')
+CHROMIUMCONTENT_DESTINATION_DIR = os.path.join(
+    SRC_DIR, 'libchromiumcontent', 'chromiumcontent')
 
 DEBIAN_MIRROR = 'http://ftp.jp.debian.org/debian/pool/main/'
 BINTOOLS_NAME = 'c/cross-binutils/binutils-aarch64-linux-gnu_2.25-5_amd64.deb'


### PR DESCRIPTION
This is to support compatibility with the GN build, which checks out the
libchromiumcontent repo at `src/libchromiumcontent`.