### PR TITLE
GN build support

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,0 +1,11 @@
+use_relative_paths = True
+
+vars = {
+  'pyyaml_version': '3.12',
+  'yaml_git':
+    'https://github.com/yaml',
+}
+
+deps = {
+  "vendor/pyyaml": (Var("yaml_git")) + '/pyyaml.git@' + (Var("pyyaml_version")),
+}

--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -62,6 +62,22 @@ index 5e1f7fcc4d83..15723e6b7184 100644
      # Component mode: dynamic CRT. Since the library is shared, it requires
      # exceptions or will give errors about things not matching, so keep
      # exceptions on.
+diff --git a/build/secondary/third_party/crashpad/crashpad/handler/BUILD.gn b/build/secondary/third_party/crashpad/crashpad/handler/BUILD.gn
+index 4d385dd5512b..b747197f03d9 100644
+--- a/build/secondary/third_party/crashpad/crashpad/handler/BUILD.gn
++++ b/build/secondary/third_party/crashpad/crashpad/handler/BUILD.gn
+@@ -54,9 +54,11 @@ executable("crashpad_handler") {
+   if (is_mac && is_component_build) {
+     # The handler is in Chromium.app/Contents/Versions/X/Chromium Framework.framework/Versions/A/Helpers/
+     # so set rpath up to the base.
++    # In Electron, the handler is in Electron.app/Contents/Resources/Electron Framework.framework/Versions/A/Resources/
++    # which is one less level of nesting.
+     ldflags = [
+       "-rpath",
+-      "@loader_path/../../../../../../../..",
++      "@loader_path/../../../../../../..",
+     ]
+   }
 diff --git a/third_party/WebKit/Source/platform/BUILD.gn b/third_party/WebKit/Source/platform/BUILD.gn
 index 6c86a6454256..2bc8c31396af 100644
 --- a/third_party/WebKit/Source/platform/BUILD.gn

--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -78,6 +78,7 @@ index 4d385dd5512b..b747197f03d9 100644
 +      "@loader_path/../../../../../../..",
      ]
    }
+ 
 diff --git a/third_party/WebKit/Source/platform/BUILD.gn b/third_party/WebKit/Source/platform/BUILD.gn
 index 6c86a6454256..2bc8c31396af 100644
 --- a/third_party/WebKit/Source/platform/BUILD.gn
@@ -103,3 +104,16 @@ index 9e744b9940e2..09208f2e98fa 100644
        ldflags = [
          # Not to strip important symbols by -Wl,-dead_strip.
          "-Wl,-exported_symbol,_PPP_GetInterface",
+diff --git a/.gn b/.gn
+index 9e744b9940e2..09208f2e98fa 100644
+--- a/.gn
++++ b/.gn
+@@ -245,4 +245,8 @@ exec_script_whitelist =
+       # Not gypi-to-gn.
+       "//google_apis/BUILD.gn",
+       "//printing/BUILD.gn",
++      # While electron transitions to GN, we use gypi_to_gn to synchronize
++      # file lists
++      "//electron/BUILD.gn",
++      "//electron/brightray/BUILD.gn",
+     ]


### PR DESCRIPTION
Supports building Electron alongside Chromium.

Depends on #536. See also [electron/electron#12837](https://github.com/electron/electron/pull/12837).