### PR TITLE
Don't lock the scheme registry

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -341,3 +341,10 @@ patches:
     in electron (and other applications). This patch provides a way to disable
     the redraw locking mechanism, which fixes these issues. The electron issue
     can be found at https://github.com/electron/electron/issues/1821
+-
+  owners: nornagon
+  file: no_lock_scheme_registry.patch
+  description: |
+    Electron apps can register URL schemes after the app has started via the
+    registerURLSchemeAs* WebFrame APIs, so locking the scheme registry on boot
+    doesn't make sense. Effectively this just disables some DCHECKs.

--- a/patches/common/chromium/no_lock_scheme_registry.patch
+++ b/patches/common/chromium/no_lock_scheme_registry.patch
@@ -1,0 +1,13 @@
+diff --git a/content/app/content_main_runner.cc b/content/app/content_main_runner.cc
+index d2275a49982e..f3c47a7e790c 100644
+--- a/content/app/content_main_runner.cc
++++ b/content/app/content_main_runner.cc
+@@ -617,7 +617,7 @@ class ContentMainRunnerImpl : public ContentMainRunner {
+ #endif
+ 
+     RegisterPathProvider();
+-    RegisterContentSchemes(true);
++    RegisterContentSchemes(false);
+ 
+ #if defined(OS_ANDROID) && (ICU_UTIL_DATA_IMPL == ICU_UTIL_DATA_FILE)
+     int icudata_fd = g_fds->MaybeGet(kAndroidICUDataDescriptor);


### PR DESCRIPTION
This effectively just disables some DCHECKs.