### PR TITLE
backport: VP9 temporal index bounds check

### DIFF
--- a/patches/common/webrtc/.patches.yaml
+++ b/patches/common/webrtc/.patches.yaml
@@ -25,3 +25,9 @@ patches:
   owners: ajmacd
   file: fix_jitter_buffer_with_opus_dtx.patch
   description: "https://webrtc-review.googlesource.com/c/src/+/18181"
+-
+  owners: alexeykuzmin
+  file: backport_a157e0809.patch
+  description:
+    VP9 temporal index bounds check. Landed in 67.0.3396.62.
+    https://webrtc-review.googlesource.com/73701

--- a/patches/common/webrtc/backport_a157e0809.patch
+++ b/patches/common/webrtc/backport_a157e0809.patch
@@ -1,0 +1,18 @@
+a157e080931581b5f6f3f9bc580a137e6062e45b
+diff --git a/modules/video_coding/rtp_frame_reference_finder.cc b/modules/video_coding/rtp_frame_reference_finder.cc
+index be05e56070..09b2593531 100644
+--- a/modules/video_coding/rtp_frame_reference_finder.cc
++++ b/modules/video_coding/rtp_frame_reference_finder.cc
+@@ -533,6 +533,12 @@ bool RtpFrameReferenceFinder::MissingRequiredFrameVp9(uint16_t picture_id,
+   size_t gof_idx = diff % info.gof->num_frames_in_gof;
+   size_t temporal_idx = info.gof->temporal_idx[gof_idx];
+ 
++  if (temporal_idx >= kMaxTemporalLayers) {
++    LOG(LS_WARNING) << "At most " << kMaxTemporalLayers << " temporal "
++                    << "layers are supported.";
++    return true;
++  }
++
+   // For every reference this frame has, check if there is a frame missing in
+   // the interval (|ref_pid|, |picture_id|) in any of the lower temporal
+   // layers. If so, we are missing a required frame.


### PR DESCRIPTION
https://webrtc-review.googlesource.com/73701
Landed in 67.0.3396.62

TODO: Backport the change to 2.0 and maybe to 1.8 branches.