### PR TITLE
backport: Allow lookup of videodecoder service to fix HW video decoding on macOS 10.13

### DIFF
--- a/patches/086-backport-f0c82253.patch
+++ b/patches/086-backport-f0c82253.patch
@@ -1,0 +1,26 @@
+Allow lookup of videodecoder service to fix HW video decoding on macOS 10.13
+
+Tha macOS sandbox has apparently changed in 10.13.  If we don't allow
+lookup of the global Mach service com.apple.coremedia.videodecoder,
+VTDecompressionSessionCreate() fails with
+kVTVideoDecoderNotAvailableNowErr for some videos.
+
+Bug: 767037
+Change-Id: I4fee235d3808a504d57660976ef96b3a0a0f54d7
+Reviewed-on: https://chromium-review.googlesource.com/677290
+Commit-Queue: Robert Sesek <rsesek@chromium.org>
+Reviewed-by: Robert Sesek <rsesek@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#503747}
+
+diff --git a/content/browser/gpu.sb b/content/browser/gpu.sb
+index 55bb657236a0..4f8fe59f08ba 100644
+--- a/content/browser/gpu.sb
++++ b/content/browser/gpu.sb
+@@ -26,3 +26,7 @@
+ ; https://crbug.com/515280
+ (if (param-true? elcap-or-later)
+   (allow file-read* (regex #"^/System/Library/Extensions($|/)")))
++
++; Needed for VideoToolbox usage - https://crbug.com/767037
++(if (param-true? macos-1013)
++  (allow mach-lookup (global-name "com.apple.coremedia.videodecoder")))


### PR DESCRIPTION
https://chromium-review.googlesource.com/677290