### PR TITLE
chore: [gn] build icu & v8 statically in GN build

### DIFF
--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -2,11 +2,12 @@ diff --git a/build/config/BUILDCONFIG.gn b/build/config/BUILDCONFIG.gn
 index de3f35f124aa..a52003f1b5e1 100644
 --- a/build/config/BUILDCONFIG.gn
 +++ b/build/config/BUILDCONFIG.gn
-@@ -123,6 +123,8 @@ if (current_os == "") {
+@@ -123,6 +123,9 @@ if (current_os == "") {
  #   even if the value is overridden, which is wasteful. See first bullet.
  
  declare_args() {
 +  is_electron_build = false
++  is_electron_gn_build = false
 +
    # Set to enable the official build level of optimization. This has nothing
    # to do with branding, but enables an additional level of optimization above

--- a/patches/common/icu/build_gn.patch
+++ b/patches/common/icu/build_gn.patch
@@ -7,7 +7,7 @@ index 76914cd7..a44d7896 100644
    ]
  
 -  if (!is_component_build) {
-+  if (!is_component_build && !is_electron_build) {
++  if (!is_component_build && !(is_electron_build && !is_electron_gn_build)) {
      defines += [ "U_STATIC_IMPLEMENTATION" ]
    }
  
@@ -19,7 +19,7 @@ index 76914cd7..a44d7896 100644
 +  # U_COMBINED_IMPLEMENTATION defined.
 +  # Also, for the "static_library" configuration, keep icui18n as
 +  # a shared library so that other Chromium targets build cleanly.
-+  if (is_electron_build) {
++  if (is_electron_build && !is_electron_gn_build) {
 +    defines += [ "U_COMBINED_IMPLEMENTATION" ]
 +
 +    if (!is_component_build) {
@@ -44,7 +44,7 @@ index 76914cd7..a44d7896 100644
 +  # U_COMBINED_IMPLEMENTATION defined.
 +  # Also, for the "static_library" configuration, keep icuuc as
 +  # a shared library so that other Chromium targets build cleanly.
-+  if (is_electron_build) {
++  if (is_electron_build && !is_electron_gn_build) {
 +    defines += [ "U_COMBINED_IMPLEMENTATION" ]
 +
 +    if (!is_component_build) {

--- a/patches/common/v8/build_gn.patch
+++ b/patches/common/v8/build_gn.patch
@@ -26,7 +26,7 @@ index 494ba22f29..6071422d7d 100644
 +  # which Electron would consume, so we don't need to do more complicated tweaks
 +  # but be aware of this and check that it's still the case when upgrading
 +  # to newer Chromium version.
-+  if (is_electron_build && !is_component_build) {
++  if (is_electron_build && !is_electron_gn_build && !is_component_build) {
 +    defines = [ "BUILDING_V8_PLATFORM_SHARED" ]
 +  }
  }
@@ -47,7 +47,7 @@ index 494ba22f29..6071422d7d 100644
 +  # which Electron would consume, so we don't need to do more complicated tweaks
 +  # but be aware of this and check that it's still the case when upgrading
 +  # to newer Chromium version.
-+  if (is_electron_build && !is_component_build) {
++  if (is_electron_build && !is_electron_gn_build && !is_component_build) {
 +    defines = [ "BUILDING_V8_BASE_SHARED" ]
 +  }
  }
@@ -58,7 +58,7 @@ index 494ba22f29..6071422d7d 100644
  config("external_config") {
    defines = []
 -  if (is_component_build) {
-+  if (is_component_build || is_electron_build) {
++  if (is_component_build || (is_electron_build && !is_electron_gn_build)) {
      defines += [ "USING_V8_SHARED" ]
    }
    if (v8_enable_v8_checks) {
@@ -76,7 +76,7 @@ index 494ba22f29..6071422d7d 100644
  }
  
 -if (is_component_build) {
-+if (is_component_build || is_electron_build) {
++if (is_component_build || (is_electron_build && !is_electron_gn_build)) {
    v8_component("v8") {
      sources = [
        "src/v8dll-main.cc",
@@ -88,7 +88,7 @@ index 494ba22f29..6071422d7d 100644
 +    # For Electron "static_library" keep V8 as a shared library. This is only
 +    # needed so that other targets in Chromium build cleanly. Electron doesn't
 +    # need the DLL.
-+    if (is_electron_build && !is_component_build) {
++    if (is_electron_build && !is_electron_gn_build && !is_component_build) {
 +      static_component_type = "shared_library"
 +    }
    }


### PR DESCRIPTION
When building Electron with GN in release mode, all code is linked
statically into a single binary, including node & v8. This is in
contrast to the GYP build, in which node, v8 and icu are linked as a
shared library (due to openssl symbol conflicts).

This change adds a `is_electron_gn_build` flag which defaults to false,
allowing those libraries to be built statically in the GN build, but
be built as a shared library when libcc is to be consumed by the GYP
build of Electron.