### PR TITLE
chore: [gn] make boringssl nodejs-compatible

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -289,3 +289,9 @@ patches:
       errors with Chromium where it is enabled by default.
       This patch will disable Crashpad in Chromium using fallback
       mechanism which uses Breakpad.
+-
+  owners: nornagon
+  file: boringssl_build_gn.patch
+  description: |
+    Build BoringSSL with some extra functions that nodejs needs. Only affects
+    the GN build; with the GYP build, nodejs is still built with OpenSSL.

--- a/patches/common/chromium/boringssl_build_gn.patch
+++ b/patches/common/chromium/boringssl_build_gn.patch
@@ -1,0 +1,18 @@
+diff --git a/third_party/boringssl/BUILD.gn b/third_party/boringssl/BUILD.gn
+index c75fb7c2bb7e..423f4b2ddb10 100644
+--- a/third_party/boringssl/BUILD.gn
++++ b/third_party/boringssl/BUILD.gn
+@@ -44,6 +44,13 @@ config("no_asm_config") {
+ }
+ 
+ all_sources = crypto_sources + ssl_sources
++if (is_electron_build) {
++  # Needed to build a nodejs-compatible boringssl.
++  all_sources += [
++    "src/decrepit/evp/evp_do_all.c",
++    "src/decrepit/xts/xts.c",
++  ]
++}
+ 
+ # Windows' assembly is built with Yasm. The other platforms use the platform
+ # assembler.


### PR DESCRIPTION
Adds in some functions from boringssl that aren't built by default in Chromium, but which node.js needs. Without these, nodejs fails to link against boringssl.