### PR TITLE
chore: fix WTL warnings when building w GN

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -300,3 +300,9 @@ patches:
   file: pepper_flash.patch
   description: |
     Allows building chrome pepper flash integration for Electron.
+-
+  owners: nornagon
+  file: wtl_warnings.patch
+  description: |
+    Fixes a bunch of warnings/errors in WTL code that isn't used by Chromium,
+    but is used by Electron.

--- a/patches/common/chromium/wtl_warnings.patch
+++ b/patches/common/chromium/wtl_warnings.patch
@@ -1,0 +1,444 @@
+diff --git a/third_party/wtl/BUILD.gn b/third_party/wtl/BUILD.gn
+index eba359dfb57b..dc42afd0dd75 100644
+--- a/third_party/wtl/BUILD.gn
++++ b/third_party/wtl/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ config("wtl_includes") {
+   include_dirs = [ "include" ]
++  defines = [ "_WTL_NO_AUTOMATIC_NAMESPACE" ]
+ }
+ 
+ # WTL is only header files so we use a "group" target type which doesn't
+diff --git a/third_party/wtl/include/atldlgs.h b/third_party/wtl/include/atldlgs.h
+index 62db9178013c..4cf496eeea2d 100644
+--- a/third_party/wtl/include/atldlgs.h
++++ b/third_party/wtl/include/atldlgs.h
+@@ -473,7 +473,7 @@ public:
+ 		: CFileDialogImpl<T>(TRUE, lpszDefExt, lpszFileName, dwFlags, lpszFilter, hWndParent), 
+ 		  m_pNextFile(NULL)
+ 	{
+-		m_ofn.Flags |= OFN_ALLOWMULTISELECT;   // Force multiple selection mode
++		this->m_ofn.Flags |= OFN_ALLOWMULTISELECT;   // Force multiple selection mode
+ 
+ #ifndef _UNICODE
+ 		OSVERSIONINFO ovi = { sizeof(ovi) };
+@@ -490,8 +490,8 @@ public:
+ 
+ 	~CMultiFileDialogImpl()
+ 	{
+-		if (m_ofn.lpstrFile != m_szFileName)   // Free the buffer if we allocated it
+-			delete[] m_ofn.lpstrFile;
++		if (this->m_ofn.lpstrFile != this->m_szFileName)   // Free the buffer if we allocated it
++			delete[] this->m_ofn.lpstrFile;
+ 	}
+ 
+ // Operations
+@@ -709,14 +709,14 @@ public:
+ // Implementation
+ 	bool ResizeFilenameBuffer(DWORD dwLength)
+ 	{
+-		if (dwLength > m_ofn.nMaxFile)
++		if (dwLength > this->m_ofn.nMaxFile)
+ 		{
+ 			// Free the old buffer.
+-			if (m_ofn.lpstrFile != m_szFileName)
++			if (this->m_ofn.lpstrFile != this->m_szFileName)
+ 			{
+-				delete[] m_ofn.lpstrFile;
+-				m_ofn.lpstrFile = NULL;
+-				m_ofn.nMaxFile = 0;
++				delete[] this->m_ofn.lpstrFile;
++				this->m_ofn.lpstrFile = NULL;
++				this->m_ofn.nMaxFile = 0;
+ 			}
+ 
+ 			// Allocate the new buffer.
+@@ -724,13 +724,13 @@ public:
+ 			ATLTRY(lpstrBuff = new TCHAR[dwLength]);
+ 			if (lpstrBuff != NULL)
+ 			{
+-				m_ofn.lpstrFile = lpstrBuff;
+-				m_ofn.lpstrFile[0] = 0;
+-				m_ofn.nMaxFile = dwLength;
++				this->m_ofn.lpstrFile = lpstrBuff;
++				this->m_ofn.lpstrFile[0] = 0;
++				this->m_ofn.nMaxFile = dwLength;
+ 			}
+ 		}
+ 
+-		return (m_ofn.lpstrFile != NULL);
++		return (this->m_ofn.lpstrFile != NULL);
+ 	}
+ 
+ 	void OnSelChange(LPOFNOTIFY /*lpon*/)
+@@ -742,12 +742,12 @@ public:
+ #endif
+ 
+ 		// Get the buffer length required to hold the spec.
+-		int nLength = GetSpec(NULL, 0);
++		int nLength = this->GetSpec(NULL, 0);
+ 		if (nLength <= 1)
+ 			return; // no files are selected, presumably
+ 		
+ 		// Add room for the directory, and an extra terminating zero.
+-		nLength += GetFolderPath(NULL, 0) + 1;
++		nLength += this->GetFolderPath(NULL, 0) + 1;
+ 
+ 		if (!ResizeFilenameBuffer(nLength))
+ 		{
+@@ -756,18 +756,18 @@ public:
+ 		}
+ 
+ 		// If we are not following links then our work is done.
+-		if ((m_ofn.Flags & OFN_NODEREFERENCELINKS) != 0)
++		if ((this->m_ofn.Flags & OFN_NODEREFERENCELINKS) != 0)
+ 			return;
+ 
+ 		// Get the file spec, which is the text in the edit control.
+-		if (GetSpec(m_ofn.lpstrFile, m_ofn.nMaxFile) <= 0)
++		if (this->GetSpec(this->m_ofn.lpstrFile, this->m_ofn.nMaxFile) <= 0)
+ 			return;
+ 		
+ 		// Get the ID-list of the current folder.
+-		int nBytes = GetFolderIDList(NULL, 0);
++		int nBytes = this->GetFolderIDList(NULL, 0);
+ 		CTempBuffer<ITEMIDLIST> idlist;
+ 		idlist.AllocateBytes(nBytes);
+-		if ((nBytes <= 0) || (GetFolderIDList(idlist, nBytes) <= 0))
++		if ((nBytes <= 0) || (this->GetFolderIDList(idlist, nBytes) <= 0))
+ 			return;
+ 
+ 		// First bind to the desktop folder, then to the current folder.
+@@ -781,8 +781,8 @@ public:
+ 		// we need to add enough extra buffer space to hold its target path.
+ 		DWORD nExtraChars = 0;
+ 		bool bInsideQuotes = false;
+-		LPCTSTR pAnchor = m_ofn.lpstrFile;
+-		LPCTSTR pChar = m_ofn.lpstrFile;
++		LPCTSTR pAnchor = this->m_ofn.lpstrFile;
++		LPCTSTR pChar = this->m_ofn.lpstrFile;
+ 		for ( ; *pChar; ++pChar)
+ 		{
+ 			// Look for quotation marks.
+@@ -841,7 +841,7 @@ public:
+ 
+ 		// If we need more space for shortcut targets, then reallocate.
+ 		if (nExtraChars > 0)
+-			ATLVERIFY(ResizeFilenameBuffer(m_ofn.nMaxFile + nExtraChars));
++			ATLVERIFY(ResizeFilenameBuffer(this->m_ofn.nMaxFile + nExtraChars));
+ 	}
+ 
+ 	// Helper for _ATM_MIN_CRT
+@@ -1110,59 +1110,59 @@ public:
+ 	}
+ 
+ // Implementation - IFileDialogEvents interface
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnFileOk(IFileDialog* pfd)
++	virtual HRESULT STDMETHODCALLTYPE OnFileOk(IFileDialog* pfd)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnFileOk();
+ 	}
+ 
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnFolderChanging(IFileDialog* pfd, IShellItem* psiFolder)
++	virtual HRESULT STDMETHODCALLTYPE OnFolderChanging(IFileDialog* pfd, IShellItem* psiFolder)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnFolderChanging(psiFolder);
+ 	}
+ 
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnFolderChange(IFileDialog* pfd)
++	virtual HRESULT STDMETHODCALLTYPE OnFolderChange(IFileDialog* pfd)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnFolderChange();
+ 	}
+ 
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnSelectionChange(IFileDialog* pfd)
++	virtual HRESULT STDMETHODCALLTYPE OnSelectionChange(IFileDialog* pfd)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnSelectionChange();
+ 	}
+ 
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnShareViolation(IFileDialog* pfd, IShellItem* psi, FDE_SHAREVIOLATION_RESPONSE* pResponse)
++	virtual HRESULT STDMETHODCALLTYPE OnShareViolation(IFileDialog* pfd, IShellItem* psi, FDE_SHAREVIOLATION_RESPONSE* pResponse)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnShareViolation(psi, pResponse);
+ 	}
+ 
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnTypeChange(IFileDialog* pfd)
++	virtual HRESULT STDMETHODCALLTYPE OnTypeChange(IFileDialog* pfd)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnTypeChange();
+ 	}
+ 
+-	virtual HRESULT STDMETHODCALLTYPE IFileDialogEvents::OnOverwrite(IFileDialog* pfd, IShellItem* psi, FDE_OVERWRITE_RESPONSE* pResponse)
++	virtual HRESULT STDMETHODCALLTYPE OnOverwrite(IFileDialog* pfd, IShellItem* psi, FDE_OVERWRITE_RESPONSE* pResponse)
+ 	{
+ 		T* pT = static_cast<T*>(this);
+ 		ATLASSERT(pT->m_spFileDlg.IsEqualObject(pfd));
+-		pfd;   // avoid level 4 warning
++		(void)pfd;   // avoid level 4 warning
+ 		return pT->OnOverwrite(psi, pResponse);
+ 	}
+ 
+@@ -1222,7 +1222,7 @@ public:
+ 		HRESULT hRet = m_spFileDlg.CoCreateInstance(CLSID_FileOpenDialog);
+ 
+ 		if(SUCCEEDED(hRet))
+-			_Init(lpszFileName, dwOptions, lpszDefExt, arrFilterSpec, uFilterSpecCount);
++			this->_Init(lpszFileName, dwOptions, lpszDefExt, arrFilterSpec, uFilterSpecCount);
+ 	}
+ 
+ 	IFileOpenDialog* GetPtr()
+@@ -1244,6 +1244,7 @@ public:
+ 	                     const COMDLG_FILTERSPEC* arrFilterSpec = NULL, 
+ 	                     UINT uFilterSpecCount = 0U) : CShellFileOpenDialogImpl<CShellFileOpenDialog>(lpszFileName, dwOptions, lpszDefExt, arrFilterSpec, uFilterSpecCount)
+ 	{ }
++	virtual ~CShellFileOpenDialog() = default;
+ 
+ // Implementation (remove _Advise/_Unadvise code using template magic)
+ 	void _Advise(DWORD& /*dwCookie*/)
+@@ -1272,7 +1273,7 @@ public:
+ 		HRESULT hRet = m_spFileDlg.CoCreateInstance(CLSID_FileSaveDialog);
+ 
+ 		if(SUCCEEDED(hRet))
+-			_Init(lpszFileName, dwOptions, lpszDefExt, arrFilterSpec, uFilterSpecCount);
++			this->_Init(lpszFileName, dwOptions, lpszDefExt, arrFilterSpec, uFilterSpecCount);
+ 	}
+ 
+ 	IFileSaveDialog* GetPtr()
+@@ -1294,6 +1295,7 @@ public:
+ 	                     const COMDLG_FILTERSPEC* arrFilterSpec = NULL, 
+ 	                     UINT uFilterSpecCount = 0U) : CShellFileSaveDialogImpl<CShellFileSaveDialog>(lpszFileName, dwOptions, lpszDefExt, arrFilterSpec, uFilterSpecCount)
+ 	{ }
++	virtual ~CShellFileSaveDialog() = default;
+ 
+ // Implementation (remove _Advise/_Unadvise code using template magic)
+ 	void _Advise(DWORD& /*dwCookie*/)
+@@ -2162,7 +2164,7 @@ public:
+ #ifndef _WIN32_WCE
+ 
+ // global helper
+-static HDC _AtlCreateDC(HGLOBAL hDevNames, HGLOBAL hDevMode)
++static inline HDC _AtlCreateDC(HGLOBAL hDevNames, HGLOBAL hDevMode)
+ {
+ 	if(hDevNames == NULL)
+ 		return NULL;
+@@ -2883,7 +2885,7 @@ public:
+ 		return hWnd;
+ 	}
+ 
+-	static const UINT GetFindReplaceMsg()
++	static UINT GetFindReplaceMsg()
+ 	{
+ 		static const UINT nMsgFindReplace = ::RegisterWindowMessage(FINDMSGSTRING);
+ 		return nMsgFindReplace;
+@@ -3753,7 +3755,7 @@ public:
+ // Callback function and overrideables
+ 	static int CALLBACK PropSheetCallback(HWND hWnd, UINT uMsg, LPARAM lParam)
+ 	{
+-		lParam;   // avoid level 4 warning
++		(void)lParam;   // avoid level 4 warning
+ 		int nRet = 0;
+ 
+ 		if(uMsg == PSCB_INITIALIZED)
+@@ -4002,55 +4004,55 @@ public:
+ #if (_WIN32_IE >= 0x0400) && !defined(_WIN32_WCE)
+ 	void SetHeader(LPCTSTR szbmHeader)
+ 	{
+-		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
++		ATLASSERT(this->m_hWnd == NULL);   // can't do this after it's created
+ 
+-		m_psh.dwFlags &= ~PSH_WIZARD;
+-		m_psh.dwFlags |= (PSH_HEADER | PSH_WIZARD97);
+-		m_psh.pszbmHeader = szbmHeader;
++		this->m_psh.dwFlags &= ~PSH_WIZARD;
++		this->m_psh.dwFlags |= (PSH_HEADER | PSH_WIZARD97);
++		this->m_psh.pszbmHeader = szbmHeader;
+ 	}
+ 
+ 	void SetHeader(HBITMAP hbmHeader)
+ 	{
+-		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
++		ATLASSERT(this->m_hWnd == NULL);   // can't do this after it's created
+ 
+-		m_psh.dwFlags &= ~PSH_WIZARD;
+-		m_psh.dwFlags |= (PSH_HEADER | PSH_USEHBMHEADER | PSH_WIZARD97);
+-		m_psh.hbmHeader = hbmHeader;
++		this->m_psh.dwFlags &= ~PSH_WIZARD;
++		this->m_psh.dwFlags |= (PSH_HEADER | PSH_USEHBMHEADER | PSH_WIZARD97);
++		this->m_psh.hbmHeader = hbmHeader;
+ 	}
+ 
+ 	void SetWatermark(LPCTSTR szbmWatermark, HPALETTE hplWatermark = NULL)
+ 	{
+-		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
++		ATLASSERT(this->m_hWnd == NULL);   // can't do this after it's created
+ 
+-		m_psh.dwFlags &= ~PSH_WIZARD;
+-		m_psh.dwFlags |= PSH_WATERMARK | PSH_WIZARD97;
+-		m_psh.pszbmWatermark = szbmWatermark;
++		this->m_psh.dwFlags &= ~PSH_WIZARD;
++		this->m_psh.dwFlags |= PSH_WATERMARK | PSH_WIZARD97;
++		this->m_psh.pszbmWatermark = szbmWatermark;
+ 
+ 		if (hplWatermark != NULL)
+ 		{
+-			m_psh.dwFlags |= PSH_USEHPLWATERMARK;
+-			m_psh.hplWatermark = hplWatermark;
++			this->m_psh.dwFlags |= PSH_USEHPLWATERMARK;
++			this->m_psh.hplWatermark = hplWatermark;
+ 		}
+ 	}
+ 
+ 	void SetWatermark(HBITMAP hbmWatermark, HPALETTE hplWatermark = NULL)
+ 	{
+-		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
++		ATLASSERT(this->m_hWnd == NULL);   // can't do this after it's created
+ 
+-		m_psh.dwFlags &= ~PSH_WIZARD;
+-		m_psh.dwFlags |= (PSH_WATERMARK | PSH_USEHBMWATERMARK | PSH_WIZARD97);
+-		m_psh.hbmWatermark = hbmWatermark;
++		this->m_psh.dwFlags &= ~PSH_WIZARD;
++		this->m_psh.dwFlags |= (PSH_WATERMARK | PSH_USEHBMWATERMARK | PSH_WIZARD97);
++		this->m_psh.hbmWatermark = hbmWatermark;
+ 
+ 		if (hplWatermark != NULL)
+ 		{
+-			m_psh.dwFlags |= PSH_USEHPLWATERMARK;
+-			m_psh.hplWatermark = hplWatermark;
++			this->m_psh.dwFlags |= PSH_USEHPLWATERMARK;
++			this->m_psh.hplWatermark = hplWatermark;
+ 		}
+ 	}
+ 
+ 	void StretchWatermark(bool bStretchWatermark)
+ 	{
+-		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
++		ATLASSERT(this->m_hWnd == NULL);   // can't do this after it's created
+ 		if (bStretchWatermark)
+ 			m_psh.dwFlags |= PSH_STRETCHWATERMARK;
+ 		else
+@@ -4066,17 +4068,17 @@ public:
+ 
+ 	LRESULT OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& /*bHandled*/)
+ 	{
+-		LRESULT lRet = DefWindowProc(uMsg, wParam, lParam);
++		LRESULT lRet = this->DefWindowProc(uMsg, wParam, lParam);
+ 		if(HIWORD(wParam) == BN_CLICKED && (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) &&
+-		   ((m_psh.dwFlags & PSH_MODELESS) != 0) && (GetActivePage() == NULL))
+-			DestroyWindow();
++		   ((m_psh.dwFlags & PSH_MODELESS) != 0) && (this->GetActivePage() == NULL))
++			this->DestroyWindow();
+ 		return lRet;
+ 	}
+ 
+ 	LRESULT OnSysCommand(UINT /*uMsg*/, WPARAM wParam, LPARAM /*lParam*/, BOOL& bHandled)
+ 	{
+ 		if(((m_psh.dwFlags & PSH_MODELESS) == PSH_MODELESS) && ((wParam & 0xFFF0) == SC_CLOSE))
+-			SendMessage(WM_CLOSE);
++			this->SendMessage(WM_CLOSE);
+ 		else
+ 			bHandled = FALSE;
+ 		return 0;
+@@ -5139,11 +5141,11 @@ public:
+ 			baseClass(title, uStartPage, hWndParent),
+ 			m_bReceivedFirstSizeMessage(false)
+ 	{
+-		m_psh.dwFlags &= ~(PSH_NOCONTEXTHELP);
+-		m_psh.dwFlags &= ~(PSH_WIZARD | PSH_WIZARD_LITE);
++		this->m_psh.dwFlags &= ~(PSH_NOCONTEXTHELP);
++		this->m_psh.dwFlags &= ~(PSH_WIZARD | PSH_WIZARD_LITE);
+ 
+-		m_psh.dwFlags |= (PSH_HASHELP | PSH_WIZARDCONTEXTHELP);
+-		m_psh.dwFlags |= PSH_WIZARD97;
++		this->m_psh.dwFlags |= (PSH_HASHELP | PSH_WIZARDCONTEXTHELP);
++		this->m_psh.dwFlags |= PSH_WIZARD97;
+ 
+ 		baseClass::SetHeader(headerBitmap.m_lpstr);
+ 		baseClass::SetWatermark(watermarkBitmap.m_lpstr);
+@@ -5436,26 +5438,26 @@ public:
+ 	CAeroWizardFrameImpl(ATL::_U_STRINGorID title = (LPCTSTR)NULL, UINT uStartPage = 0, HWND hWndParent = NULL) :
+ 		CPropertySheetImpl<T, TBase >(title, uStartPage, hWndParent)
+ 	{
+-		m_psh.dwFlags |= PSH_WIZARD | PSH_AEROWIZARD;
++		this->m_psh.dwFlags |= PSH_WIZARD | PSH_AEROWIZARD;
+ 	}
+ 
+ // Operations
+ 	void EnableResizing()
+ 	{
+ 		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
+-		m_psh.dwFlags |= PSH_RESIZABLE;
++		this->m_psh.dwFlags |= PSH_RESIZABLE;
+ 	}
+ 
+ 	void UseHeaderBitmap()
+ 	{
+ 		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
+-		m_psh.dwFlags |= PSH_HEADERBITMAP;
++		this->m_psh.dwFlags |= PSH_HEADERBITMAP;
+ 	}
+ 
+ 	void SetNoMargin()
+ 	{
+ 		ATLASSERT(m_hWnd == NULL);   // can't do this after it's created
+-		m_psh.dwFlags |= PSH_NOMARGIN;
++		this->m_psh.dwFlags |= PSH_NOMARGIN;
+ 	}
+ 
+ // Override to prevent use
+diff --git a/third_party/wtl/include/atlgdi.h b/third_party/wtl/include/atlgdi.h
+index 510f1e7436f3..14c0b0eb0b41 100644
+--- a/third_party/wtl/include/atlgdi.h
++++ b/third_party/wtl/include/atlgdi.h
+@@ -3432,7 +3432,7 @@ public:
+ 	PIXELFORMATDESCRIPTOR m_pfd;
+ 
+ // Constructor/destructor
+-	CEnhMetaFileInfo(HENHMETAFILE hEMF) : m_pBits(NULL), m_pDesc(NULL), m_hEMF(hEMF)
++	CEnhMetaFileInfo(HENHMETAFILE hEMF) : m_hEMF(hEMF), m_pBits(NULL), m_pDesc(NULL)
+ 	{ }
+ 
+ 	~CEnhMetaFileInfo()
+@@ -3712,7 +3712,7 @@ inline HBITMAP AtlGetDibBitmap(LPBITMAPINFO pbmi)
+ 	void * pBits = NULL;
+ 
+ 	LPBYTE pDibBits = (LPBYTE)pbmi + sizeof(BITMAPINFOHEADER) + AtlGetDibColorTableSize(&pbmi->bmiHeader) * sizeof(RGBQUAD);
+-	if (hbm = CreateDIBSection(dc, pbmi, DIB_RGB_COLORS, &pBits, NULL, NULL)) 
++	if ((hbm = CreateDIBSection(dc, pbmi, DIB_RGB_COLORS, &pBits, NULL, NULL)))
+ 		memcpy(pBits, pDibBits, pbmi->bmiHeader.biSizeImage);
+ 
+ 	return hbm;
+@@ -3764,7 +3764,7 @@ inline HBITMAP AtlCopyBitmap(HBITMAP hbm , SIZE sizeDst, bool bAsBitmap = false)
+ 
+ inline HLOCAL AtlCreatePackedDib16(HBITMAP hbm, SIZE size)
+ {
+-	DIBSECTION ds = { 0 };
++	DIBSECTION ds = { { 0 } };
+ 	LPBYTE pDib = NULL;
+ 	bool bCopied = false;
+ 


### PR DESCRIPTION
Chromium doesn't use this bit of WTL, so they haven't bothered to fix the warnings that are generated in these headers.