### PR TITLE
Do not check for unique origin in CacheStorage

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -306,3 +306,9 @@ patches:
   description: |
     Fixes a bunch of warnings/errors in WTL code that isn't used by Chromium,
     but is used by Electron.
+-
+  owners: zcbenz
+  file: no_cache_storage_check.patch
+  description: |
+    Do not check for unique origin in CacheStorage, in Electron we may have
+    scripts running without an origin.

--- a/patches/common/chromium/no_cache_storage_check.patch
+++ b/patches/common/chromium/no_cache_storage_check.patch
@@ -1,0 +1,13 @@
+diff --git a/content/browser/cache_storage/cache_storage.cc b/content/browser/cache_storage/cache_storage.cc
+index ce6a21b..10a3b18 100644
+--- a/content/browser/cache_storage/cache_storage.cc
++++ b/content/browser/cache_storage/cache_storage.cc
+@@ -129,7 +129,7 @@ class CacheStorage::CacheLoader {
+         blob_context_(blob_context),
+         cache_storage_(cache_storage),
+         origin_(origin) {
+-    DCHECK(!origin_.unique());
++    // DCHECK(!origin_.unique());
+   }
+ 
+   virtual ~CacheLoader() {}


### PR DESCRIPTION
In Electron we may have scripts running without an origin (for example from Node.js), and it will trigger an assertion in `CacheStorage`. The chromium commit introduced the check is https://chromium.googlesource.com/chromium/src/+/b6a21896d9687ff8c7c6aa809e45b3efe2fefb50%5E%21/#F0.

This patch intends to disable a behavior instead of temporarily disabling a check, so I did not put it in `dcheck.patch`.

This should be able to fix the second crash in https://github.com/electron/electron/issues/12835#issuecomment-398941227.