### PR TITLE
Remove some new private APIs in MAS build (3-0-x)

### DIFF
--- a/patches/mas/chromium/no_private_api.patch
+++ b/patches/mas/chromium/no_private_api.patch
@@ -228,6 +228,34 @@ index 6b955bdb3724..1775f3b3c1d4 100644
  }
  
  // You are about to read a pretty disgusting hack. In a static initializer,
+diff --git a/media/audio/BUILD.gn b/media/audio/BUILD.gn
+index 10d786f..2d96723 100644
+--- a/media/audio/BUILD.gn
++++ b/media/audio/BUILD.gn
+@@ -184,8 +184,8 @@ source_set("audio") {
+       "mac/audio_low_latency_input_mac.h",
+       "mac/audio_manager_mac.cc",
+       "mac/audio_manager_mac.h",
+-      "mac/coreaudio_dispatch_override.cc",
+-      "mac/coreaudio_dispatch_override.h",
++      # "mac/coreaudio_dispatch_override.cc",
++      # "mac/coreaudio_dispatch_override.h",
+       "mac/scoped_audio_unit.cc",
+       "mac/scoped_audio_unit.h",
+     ]
+diff --git a/media/audio/mac/audio_manager_mac.cc b/media/audio/mac/audio_manager_mac.cc
+index 1a74579..0a15778 100644
+--- a/media/audio/mac/audio_manager_mac.cc
++++ b/media/audio/mac/audio_manager_mac.cc
+@@ -993,7 +993,7 @@ AudioParameters AudioManagerMac::GetPreferredOutputStreamParameters(
+ 
+ void AudioManagerMac::InitializeOnAudioThread() {
+   DCHECK(GetTaskRunner()->BelongsToCurrentThread());
+-  InitializeCoreAudioDispatchOverride();
++  // InitializeCoreAudioDispatchOverride();
+   power_observer_.reset(new AudioPowerObserver());
+ }
+ 
 diff --git a/net/dns/dns_config_service_posix.cc b/net/dns/dns_config_service_posix.cc
 index 706ba6e8e882..3fbe80c91cd9 100644
 --- a/net/dns/dns_config_service_posix.cc

--- a/patches/mas/chromium/no_private_api.patch
+++ b/patches/mas/chromium/no_private_api.patch
@@ -356,6 +356,62 @@ index dfba0bded9e3..876f96999f53 100644
  }
  
  }  // namespace sandbox
+diff --git a/sandbox/mac/seatbelt_extension.cc b/sandbox/mac/seatbelt_extension.cc
+index 9073364..2356add 100644
+--- a/sandbox/mac/seatbelt_extension.cc
++++ b/sandbox/mac/seatbelt_extension.cc
+@@ -8,6 +8,7 @@
+ #include "base/memory/ptr_util.h"
+ #include "sandbox/mac/seatbelt_extension_token.h"
+ 
++#ifndef MAS_BUILD
+ // libsandbox private API.
+ extern "C" {
+ extern const char* APP_SANDBOX_READ;
+@@ -18,6 +19,7 @@ char* sandbox_extension_issue_file(const char* type,
+                                    const char* path,
+                                    uint32_t flags);
+ }
++#endif
+ 
+ namespace sandbox {
+ 
+@@ -46,7 +48,11 @@ std::unique_ptr<SeatbeltExtension> SeatbeltExtension::FromToken(
+ 
+ bool SeatbeltExtension::Consume() {
+   DCHECK(!token_.empty());
++#ifndef MAS_BUILD
+   handle_ = sandbox_extension_consume(token_.c_str());
++#else
++  handle_ = -1;
++#endif
+   return handle_ > 0;
+ }
+ 
+@@ -58,7 +64,11 @@ bool SeatbeltExtension::ConsumePermanently() {
+ }
+ 
+ bool SeatbeltExtension::Revoke() {
++#ifndef MAS_BUILD
+   int rv = sandbox_extension_release(handle_);
++#else
++  int rv = -1;
++#endif
+   handle_ = 0;
+   token_.clear();
+   return rv == 0;
+@@ -76,9 +86,11 @@ SeatbeltExtension::SeatbeltExtension(const std::string& token)
+ char* SeatbeltExtension::IssueToken(SeatbeltExtension::Type type,
+                                     const std::string& resource) {
+   switch (type) {
++#ifndef MAS_BUILD
+     case FILE_READ:
+       return sandbox_extension_issue_file(APP_SANDBOX_READ, resource.c_str(),
+                                           0);
++#endif
+     default:
+       NOTREACHED();
+       return nullptr;
 diff --git a/ui/views/cocoa/bridged_native_widget.mm b/ui/views/cocoa/bridged_native_widget.mm
 index 3c6e9903d7df..ddc9061c64d1 100644
 --- a/ui/views/cocoa/bridged_native_widget.mm

--- a/patches/mas/chromium/no_private_api.patch
+++ b/patches/mas/chromium/no_private_api.patch
@@ -228,6 +228,50 @@ index 6b955bdb3724..1775f3b3c1d4 100644
  }
  
  // You are about to read a pretty disgusting hack. In a static initializer,
+diff --git a/device/bluetooth/bluetooth_adapter_mac.mm b/device/bluetooth/bluetooth_adapter_mac.mm
+index 09123af..69d6b92 100644
+--- a/device/bluetooth/bluetooth_adapter_mac.mm
++++ b/device/bluetooth/bluetooth_adapter_mac.mm
+@@ -32,6 +32,7 @@
+ #include "device/bluetooth/bluetooth_low_energy_central_manager_delegate.h"
+ #include "device/bluetooth/bluetooth_socket_mac.h"
+ 
++#ifndef MAS_BUILD
+ extern "C" {
+ // Undocumented IOBluetooth Preference API [1]. Used by `blueutil` [2] and
+ // `Karabiner` [3] to programmatically control the Bluetooth state. Calling the
+@@ -45,6 +46,7 @@
+ // [4] https://support.apple.com/kb/PH25091
+ void IOBluetoothPreferenceSetControllerPowerState(int state);
+ }
++#endif
+ 
+ namespace {
+ 
+@@ -118,8 +120,10 @@ CBCentralManagerState GetCBManagerState(CBCentralManager* manager) {
+       controller_state_function_(
+           base::BindRepeating(&BluetoothAdapterMac::GetHostControllerState,
+                               base::Unretained(this))),
++#ifndef MAS_BUILD
+       power_state_function_(
+           base::BindRepeating(IOBluetoothPreferenceSetControllerPowerState)),
++#endif
+       should_update_name_(true),
+       classic_discovery_manager_(
+           BluetoothDiscoveryManagerMac::CreateClassic(this)),
+@@ -302,8 +306,12 @@ CBCentralManagerState GetCBManagerState(CBCentralManager* manager) {
+ }
+ 
+ bool BluetoothAdapterMac::SetPoweredImpl(bool powered) {
++#ifndef MAS_BUILD
+   power_state_function_.Run(base::strict_cast<int>(powered));
+   return true;
++#else
++  return false;
++#endif
+ }
+ 
+ void BluetoothAdapterMac::RemovePairingDelegateInternal(
 diff --git a/media/audio/BUILD.gn b/media/audio/BUILD.gn
 index 10d786f..2d96723 100644
 --- a/media/audio/BUILD.gn


### PR DESCRIPTION
Backports https://github.com/electron/libchromiumcontent/pull/580 to `electron-3-0-x`.