### PR TITLE
Fix assertion when preventDefault is called for new-window

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -312,3 +312,13 @@ patches:
   description: |
     Do not check for unique origin in CacheStorage, in Electron we may have
     scripts running without an origin.
+-
+  owners: zcbenz
+  file: blink_fix_prototype_assert.patch
+  description: |
+    A recent Chromium change has accidentally added assertion for the case when
+    a new window object may not have a prototype attached. In Electron it may
+    happen when preventDefault for a native new-window event.
+    https://chromium.googlesource.com/chromium/src/+/f47b361887a31cccf42a6e21a82bccf28372bdaa%5E%21
+    In the long term we should investigate why it happened, and take a more
+    formal fix. But for now I'm just make this assertion silently pass away.

--- a/patches/common/chromium/blink_fix_prototype_assert.patch
+++ b/patches/common/chromium/blink_fix_prototype_assert.patch
@@ -1,0 +1,17 @@
+diff --git a/third_party/WebKit/Source/platform/bindings/V8ObjectConstructor.cpp b/third_party/WebKit/Source/platform/bindings/V8ObjectConstructor.cpp
+index aedc832..8c26681 100644
+--- a/third_party/WebKit/Source/platform/bindings/V8ObjectConstructor.cpp
++++ b/third_party/WebKit/Source/platform/bindings/V8ObjectConstructor.cpp
+@@ -94,8 +94,10 @@ v8::Local<v8::Function> V8ObjectConstructor::CreateInterfaceObject(
+     bool get_prototype_value =
+         interface_object->Get(context, V8AtomicString(isolate, "prototype"))
+             .ToLocal(&prototype_value);
+-    CHECK(get_prototype_value);
+-    CHECK(prototype_value->IsObject());
++    // CHECK(get_prototype_value);
++    // CHECK(prototype_value->IsObject());
++    if (!get_prototype_value || !prototype_value->IsObject())
++      return v8::Local<v8::Function>();
+ 
+     prototype_object = prototype_value.As<v8::Object>();
+     if (prototype_object->InternalFieldCount() ==


### PR DESCRIPTION
Refs https://github.com/electron/electron/issues/13316.

A recent Chromium change has accidentally added assertion for the case when a new window object may not have a prototype attached. In Electron it may happen when preventDefault for a native new-window event.
https://chromium.googlesource.com/chromium/src/+/f47b361887a31cccf42a6e21a82bccf28372bdaa%5E%21

In the long term we should investigate why it happened, and take a more formal fix. But for now I'm just make this assertion silently pass away.