### PR TITLE
Use Visual Studio for 2-0-x

### DIFF
--- a/appveyor-override.yml
+++ b/appveyor-override.yml
@@ -1,0 +1,23 @@
+version: 1.0.{build}
+build_cloud: libcc-20
+image: libcc-20-vs2015
+build_script:
+- ps: >-
+    if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+      Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
+    } else {
+      if($env:APPVEYOR_SCHEDULED_BUILD -eq 'True')  {
+        script\cibuild.ps1 -buildTests
+      } else {
+        script\cibuild.ps1
+      }
+      if ($? -ne 'True') {
+        throw "Build failed with exit code $?"
+      } else {
+        "Build succeeded."
+      }
+    }
+test: off
+artifacts:
+- path: libchromiumcontent*
+  name: libchromiumcontent

--- a/script/build
+++ b/script/build
@@ -52,7 +52,7 @@ def main():
   os.chdir(SOURCE_ROOT)
 
   # Build everything by default.
-  components_to_build = COMPONENTS
+  components_to_build = list(COMPONENTS)
 
   if args.debug:
     components_to_build = ['shared_library', 'ffmpeg']
@@ -60,6 +60,8 @@ def main():
     components_to_build = ['static_library', 'ffmpeg']
   elif args.component is not None:
     components_to_build = args.component
+  elif "arm" not in target_arch:
+    components_to_build.remove('native_mksnapshot')
 
   for component in components_to_build:
     out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)

--- a/script/create-dist
+++ b/script/create-dist
@@ -61,7 +61,7 @@ STATIC_LIBRARY_SUFFIX = {
   'win32': 'lib',
 }[TARGET_PLATFORM]
 
-COMPONENTS = ['static_library', 'shared_library','native_mksnapshot']
+COMPONENTS = ['static_library', 'shared_library', 'native_mksnapshot']
 BINARIES = {
   'all': [
     'content_shell.pak',
@@ -406,7 +406,8 @@ def generate_ninja(args, ninja):
       BINARIES[TARGET_PLATFORM].remove(lib)
 
   for component in COMPONENTS:
-    if args.component == 'all' or args.component == component:
+    if ((args.component == 'all' or args.component == component) and
+        (component != 'native_mksnapshot' or 'arm' in target_arch)):
       copy_binaries(target_arch, component, create_debug_archive,
                     args.keep_debug_symbols, ninja)
       copy_generated_sources(target_arch, component, ninja)


### PR DESCRIPTION
This PR updates the 2-0-x branch to use Visual Studio 2015 because Visual Studio 2017 is now the default.