### PR TITLE
build: [gn] allow electron targets to depend on gtk

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -329,3 +329,8 @@ patches:
   description: |
     https://chromium.googlesource.com/chromium/src/+/e3a883075f699e67ab47d9991ac55b143017cfc3
     The change originally landed in 67.0.3380.0.
+-
+  owners: nornagon
+  file: gtk_visibility.patch
+  description: |
+    Allow electron and brightray to depend on GTK in the GN build.

--- a/patches/common/chromium/gtk_visibility.patch
+++ b/patches/common/chromium/gtk_visibility.patch
@@ -1,0 +1,13 @@
+diff --git a/build/config/linux/gtk/BUILD.gn b/build/config/linux/gtk/BUILD.gn
+index eb75461..2116f93 100644
+--- a/build/config/linux/gtk/BUILD.gn
++++ b/build/config/linux/gtk/BUILD.gn
+@@ -17,6 +17,8 @@ assert(is_linux, "This file should only be referenced on Linux")
+ group("gtk") {
+   visibility = [
+     "//chrome/test:interactive_ui_tests",
++    "//electron:*",
++    "//electron/brightray:*",
+     "//examples:peerconnection_client",
+     "//gpu/gles2_conform_support:gles2_conform_test_windowless",
+     "//remoting/host",


### PR DESCRIPTION
Without this, GN throws an error saying that targets in //electron and //electron/brightray aren't allowed to depend on //build/config/linux/gtk.