### PR TITLE
fix: Process metrics fix backport

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -295,3 +295,9 @@ patches:
   description: |
     Do not check for unique origin in CacheStorage, in Electron we may have
     scripts running without an origin.
+-
+  owners: torycl
+  file: backport_e3a883075.patch
+  description: |
+    https://chromium.googlesource.com/chromium/src/+/e3a883075f699e67ab47d9991ac55b143017cfc3
+    The change originally landed in 67.0.3380.0.

--- a/patches/common/chromium/backport_e3a883075.patch
+++ b/patches/common/chromium/backport_e3a883075.patch
@@ -1,0 +1,18 @@
+diff --git a/base/process/process_metrics_win.cc b/base/process/process_metrics_win.cc
+index 61f0bf4ad06f..897ec93a16a6 100644
+--- a/base/process/process_metrics_win.cc
++++ b/base/process/process_metrics_win.cc
+@@ -325,11 +325,11 @@ bool ProcessMetrics::GetIOCounters(IoCounters* io_counters) const {
+ 
+ ProcessMetrics::ProcessMetrics(ProcessHandle process) : last_system_time_(0) {
+   if (process) {
+-    HANDLE duplicate_handle;
++    HANDLE duplicate_handle = INVALID_HANDLE_VALUE;
+     BOOL result = ::DuplicateHandle(::GetCurrentProcess(), process,
+                                     ::GetCurrentProcess(), &duplicate_handle,
+                                     PROCESS_QUERY_INFORMATION, FALSE, 0);
+-    DCHECK(result);
++    DPCHECK(result);
+     process_.Set(duplicate_handle);
+   }
+ }

--- a/patches/common/chromium/dcheck.patch
+++ b/patches/common/chromium/dcheck.patch
@@ -237,21 +237,3 @@ index 674b0e9a909c..a1bff6e40f56 100644
     if (base_computed_style_ && computed_style)
       DCHECK(*base_computed_style_ == *computed_style);
   #endif
-diff --git a/base/process/process_metrics_win.cc b/base/process/process_metrics_win.cc
-index 61f0bf4ad06f..259783ad67a1 100644
---- a/base/process/process_metrics_win.cc
-+++ b/base/process/process_metrics_win.cc
-@@ -326,10 +326,9 @@ bool ProcessMetrics::GetIOCounters(IoCounters* io_counters) const {
- ProcessMetrics::ProcessMetrics(ProcessHandle process) : last_system_time_(0) {
-   if (process) {
-     HANDLE duplicate_handle;
--    BOOL result = ::DuplicateHandle(::GetCurrentProcess(), process,
--                                    ::GetCurrentProcess(), &duplicate_handle,
--                                    PROCESS_QUERY_INFORMATION, FALSE, 0);
--    DCHECK(result);
-+    ::DuplicateHandle(::GetCurrentProcess(), process,
-+                      ::GetCurrentProcess(), &duplicate_handle,
-+                      PROCESS_QUERY_INFORMATION, FALSE, 0);
-     process_.Set(duplicate_handle);
-   }
- }


### PR DESCRIPTION
Backporting the same fix which is already merged in master libcc in commit a5e6964a1d4a5a4bd8a580c5a365ad5d6ff6f6e5 to 3.0.x branch.