### PR TITLE
Fix static download

### DIFF
--- a/script/download
+++ b/script/download
@@ -52,7 +52,8 @@ def main():
                          args.force, args.verbose)
       if (args.static and
           not os.path.exists(os.path.join(args.path, 'static_library'))):
-        download(args.path, base_url, commit, STATIC_LIBRARY_FILENAME)
+        download(args.path, base_url, commit, STATIC_LIBRARY_FILENAME,
+                 args.verbose)
       generate_filenames_gypi(os.path.join(args.path, 'filenames.gypi'),
                               os.path.join(args.path, 'src'),
                               os.path.join(args.path, 'shared_library'),


### PR DESCRIPTION
As part of #590, I made changes to only show download percentage when running with verbose (-v) mode in this commit: bdfcdb0fe1f4d94755e04fcf65a5767d4055d1d5.  This broke the static libcc download.  This PR fixes that.