### PR TITLE
build: [gn] use electron's custom sysroots

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -339,3 +339,9 @@ patches:
   file: gtk_visibility.patch
   description: |
     Allow electron and brightray to depend on GTK in the GN build.
+-
+  owners: nornagon
+  file: sysroot.patch
+  description: |
+    Make chrome's install-sysroot scripts point to our custom sysroot builds,
+    which include extra deps that Electron needs (e.g. libnotify)

--- a/patches/common/chromium/sysroot.patch
+++ b/patches/common/chromium/sysroot.patch
@@ -1,0 +1,149 @@
+diff --git a/build/config/sysroot.gni b/build/config/sysroot.gni
+index d5daf2df2e41..46999e2e2198 100644
+--- a/build/config/sysroot.gni
++++ b/build/config/sysroot.gni
+@@ -32,17 +32,17 @@ if (current_os == target_os && current_cpu == target_cpu &&
+   # By default build against a sysroot image downloaded from Cloud Storage
+   # during gclient runhooks.
+   if (current_cpu == "x64") {
+-    sysroot = "$target_sysroot_dir/debian_sid_amd64-sysroot"
++    sysroot = "$target_sysroot_dir/debian_stretch_amd64-sysroot"
+   } else if (current_cpu == "x86") {
+-    sysroot = "$target_sysroot_dir/debian_sid_i386-sysroot"
++    sysroot = "$target_sysroot_dir/debian_stretch_i386-sysroot"
+   } else if (current_cpu == "mipsel") {
+-    sysroot = "$target_sysroot_dir/debian_sid_mips-sysroot"
++    sysroot = "$target_sysroot_dir/debian_stretch_mips-sysroot"
+   } else if (current_cpu == "mips64el") {
+-    sysroot = "$target_sysroot_dir/debian_sid_mips64el-sysroot"
++    sysroot = "$target_sysroot_dir/debian_stretch_mips64el-sysroot"
+   } else if (current_cpu == "arm") {
+-    sysroot = "$target_sysroot_dir/debian_sid_arm-sysroot"
++    sysroot = "$target_sysroot_dir/debian_stretch_arm-sysroot"
+   } else if (current_cpu == "arm64") {
+-    sysroot = "$target_sysroot_dir/debian_sid_arm64-sysroot"
++    sysroot = "$target_sysroot_dir/debian_stretch_arm64-sysroot"
+   } else {
+     assert(false, "No linux sysroot for cpu: $target_cpu")
+   }
+diff --git a/build/linux/sysroot_scripts/install-sysroot.py b/build/linux/sysroot_scripts/install-sysroot.py
+index 6fb13c8bc6d8..b50e34d84ba6 100755
+--- a/build/linux/sysroot_scripts/install-sysroot.py
++++ b/build/linux/sysroot_scripts/install-sysroot.py
+@@ -32,8 +32,8 @@ import urllib2
+ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ sys.path.append(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+ 
+-URL_PREFIX = 'https://commondatastorage.googleapis.com'
+-URL_PATH = 'chrome-linux-sysroot/toolchain'
++URL_PREFIX = 'http://s3.amazonaws.com'
++URL_PATH = 'gh-contractor-zcbenz/toolchain'
+ 
+ VALID_ARCHS = ('arm', 'arm64', 'i386', 'amd64', 'mips', 'mips64el')
+ 
+@@ -87,7 +87,7 @@ def main(args):
+ def InstallDefaultSysrootForArch(target_arch):
+   if target_arch not in VALID_ARCHS:
+     raise Error('Unknown architecture: %s' % target_arch)
+-  InstallSysroot('Sid', target_arch)
++  InstallSysroot('Stretch', target_arch)
+ 
+ 
+ def InstallSysroot(target_platform, target_arch):
+diff --git a/build/linux/sysroot_scripts/sysroots.json b/build/linux/sysroot_scripts/sysroots.json
+index 870a994ec9f3..d916f24a099f 100644
+--- a/build/linux/sysroot_scripts/sysroots.json
++++ b/build/linux/sysroot_scripts/sysroots.json
+@@ -1,74 +1,38 @@
+ {
+-    "sid_amd64": {
+-        "Revision": "15b7efb900d75f7316c6e713e80f87b9904791b1",
+-        "Sha1Sum": "85ac8d5e0f6cff99fc323fd3d29cb73e2aa970e2",
+-        "SysrootDir": "debian_sid_amd64-sysroot",
+-        "Tarball": "debian_sid_amd64_sysroot.tar.xz"
+-    },
+-    "sid_arm": {
+-        "Revision": "15b7efb900d75f7316c6e713e80f87b9904791b1",
+-        "Sha1Sum": "ed31924757f11885a21793dc4b928d07ab25740c",
+-        "SysrootDir": "debian_sid_arm-sysroot",
+-        "Tarball": "debian_sid_arm_sysroot.tar.xz"
+-    },
+-    "sid_arm64": {
+-        "Revision": "15b7efb900d75f7316c6e713e80f87b9904791b1",
+-        "Sha1Sum": "b9447285e58c5260bd9fa2737d1f0d1f82156738",
+-        "SysrootDir": "debian_sid_arm64-sysroot",
+-        "Tarball": "debian_sid_arm64_sysroot.tar.xz"
+-    },
+-    "sid_i386": {
+-        "Revision": "15b7efb900d75f7316c6e713e80f87b9904791b1",
+-        "Sha1Sum": "f09856d93f39e8df84ffd9c04881f44e6cbc0508",
+-        "SysrootDir": "debian_sid_i386-sysroot",
+-        "Tarball": "debian_sid_i386_sysroot.tar.xz"
+-    },
+-    "sid_mips": {
+-        "Revision": "15b7efb900d75f7316c6e713e80f87b9904791b1",
+-        "Sha1Sum": "90586b566b567b2bcf49e7fd112f0c8189bbd07b",
+-        "SysrootDir": "debian_sid_mips-sysroot",
+-        "Tarball": "debian_sid_mips_sysroot.tar.xz"
+-    },
+-    "sid_mips64el": {
+-        "Revision": "15b7efb900d75f7316c6e713e80f87b9904791b1",
+-        "Sha1Sum": "f90c3b81485ffebb283afddb1a72bc61e14c593d",
+-        "SysrootDir": "debian_sid_mips64el-sysroot",
+-        "Tarball": "debian_sid_mips64el_sysroot.tar.xz"
+-    },
+     "stretch_amd64": {
+-        "Revision": "3c248ba4290a5ad07085b7af07e6785bf1ae5b66",
+-        "Sha1Sum": "a668aafe335848c6e4aed11d0b32ea2d5c5a124d",
++        "Revision": "02772eaba5440a79c6bd2d9cb7e42fa836950366",
++        "Sha1Sum": "69457fddca3500e2dde124f77f8382b0a18d765e",
+         "SysrootDir": "debian_stretch_amd64-sysroot",
+-        "Tarball": "debian_stretch_amd64_sysroot.tar.xz"
++        "Tarball": "debian_stretch_amd64_sysroot.tgz"
+     },
+     "stretch_arm": {
+-        "Revision": "3c248ba4290a5ad07085b7af07e6785bf1ae5b66",
+-        "Sha1Sum": "4658f558326d93d8a69fe6940bc19cf7de32cf4d",
++        "Revision": "02772eaba5440a79c6bd2d9cb7e42fa836950366",
++        "Sha1Sum": "3e880f69177992ce02b05deeac619f7591b30287",
+         "SysrootDir": "debian_stretch_arm-sysroot",
+-        "Tarball": "debian_stretch_arm_sysroot.tar.xz"
++        "Tarball": "debian_stretch_arm_sysroot.tgz"
+     },
+     "stretch_arm64": {
+-        "Revision": "3c248ba4290a5ad07085b7af07e6785bf1ae5b66",
+-        "Sha1Sum": "a3c530ff8a5d9be34dd6fc07a05188ea947116cf",
++        "Revision": "02772eaba5440a79c6bd2d9cb7e42fa836950366",
++        "Sha1Sum": "8fd58c7d4b38fa3c6785573c6310cf6ca6c88312",
+         "SysrootDir": "debian_stretch_arm64-sysroot",
+-        "Tarball": "debian_stretch_arm64_sysroot.tar.xz"
++        "Tarball": "debian_stretch_arm64_sysroot.tgz"
+     },
+     "stretch_i386": {
+-        "Revision": "3c248ba4290a5ad07085b7af07e6785bf1ae5b66",
+-        "Sha1Sum": "98425d632814b45289ca6c3acb38d8e11c487ec6",
++        "Revision": "02772eaba5440a79c6bd2d9cb7e42fa836950366",
++        "Sha1Sum": "1bd14db5eb0466064659126d398b38220013fb38",
+         "SysrootDir": "debian_stretch_i386-sysroot",
+-        "Tarball": "debian_stretch_i386_sysroot.tar.xz"
++        "Tarball": "debian_stretch_i386_sysroot.tgz"
+     },
+     "stretch_mips": {
+-        "Revision": "3c248ba4290a5ad07085b7af07e6785bf1ae5b66",
+-        "Sha1Sum": "dcb078646b49c94298cf702acc5ece28a689fea4",
++        "Revision": "02772eaba5440a79c6bd2d9cb7e42fa836950366",
++        "Sha1Sum": "285751660ffab14e6d052c8ddb5c90752a51704d",
+         "SysrootDir": "debian_stretch_mips-sysroot",
+-        "Tarball": "debian_stretch_mips_sysroot.tar.xz"
++        "Tarball": "debian_stretch_mips_sysroot.tgz"
+     },
+     "stretch_mips64el": {
+-        "Revision": "3c248ba4290a5ad07085b7af07e6785bf1ae5b66",
+-        "Sha1Sum": "a68c72c6b6d4fad8d43e268cc081ce6afeaa79e4",
++        "Revision": "02772eaba5440a79c6bd2d9cb7e42fa836950366",
++        "Sha1Sum": "23f51f29bc35a550092dde41dc823780fdb50f9e",
+         "SysrootDir": "debian_stretch_mips64el-sysroot",
+-        "Tarball": "debian_stretch_mips64el_sysroot.tar.xz"
++        "Tarball": "debian_stretch_mips64el_sysroot.tgz"
+     }
+ }


### PR DESCRIPTION
The GYP build uses a version of `install-sysroot.py` that was copied out of `//build/linux/sysroot_scripts` some time ago. This change will only affect GN, and it will cause the GN build to use the custom-built Electron sysroots, stored at http://s3.amazonaws.com/gh-contractor-zcbenz/toolchain and maintained by @zcbenz, instead of chromium's sysroots.

I'm not terribly satisfied with this solution, as it means we need to expend effort to maintain up-to-date sysroots. As far as I know, the only reason we build our own sysroot is to add the `libnotify` headers. Some other solutions that might allow us to use chromium's sysroot unmodified:
- we could build an 'overlay' sysroot, which we could extract on top of the sysroot that chromium builds, with just the libnotify headers (and whatever other changes we need)
- we could package libnotify headers in a different place and manually add them to the include paths of the targets that need them