### PR TITLE
feat: add patch to allow overriding scroll bounce in Electron

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -339,3 +339,10 @@ patches:
   file: gtk_visibility.patch
   description: |
     Allow electron and brightray to depend on GTK in the GN build.
+-
+  owners: marshallofsound
+  file: scroll_bounce.patch
+  description: /
+    https://chromium-review.googlesource.com/c/chromium/src/+/585365
+    Reverts chromium change in the above CR to allow us to override the rubber
+    banding value per-window

--- a/patches/common/chromium/scroll_bounce.patch
+++ b/patches/common/chromium/scroll_bounce.patch
@@ -1,0 +1,15 @@
+diff --git a/content/browser/theme_helper_mac.mm b/content/browser/theme_helper_mac.mm
+index 50a8828bc62a..702c357e4d61 100644
+--- a/content/browser/theme_helper_mac.mm
++++ b/content/browser/theme_helper_mac.mm
+@@ -54,9 +54,8 @@ void FillScrollbarThemeParams(
+       ThemeHelperMac::GetPreferredScrollerStyle();
+   params->button_placement = GetButtonPlacement();
+
+-  id rubber_band_value = [defaults objectForKey:@"NSScrollViewRubberbanding"];
+   params->scroll_view_rubber_banding =
+-      rubber_band_value ? [rubber_band_value boolValue] : YES;
++      [defaults boolForKey:@"NSScrollViewRubberbanding"];
+ }
+
+ void SendSystemColorsChangedMessage(content::mojom::Renderer* renderer) {


### PR DESCRIPTION
This reverses the patch in Chromium that made our per-window logic stop working.  Not sure if it's the best thing to do but it at least restores the old behavior

cc @sethlu @gnahzak 