### PR TITLE
build: [gn win] link against static crt in non-component builds

### DIFF
--- a/patches/common/chromium/build_gn.patch
+++ b/patches/common/chromium/build_gn.patch
@@ -73,7 +73,7 @@ index 1f6bc13e087f..4630045ff554 100644
  # what each value does.
  config("default_crt") {
 -  if (is_component_build) {
-+  if (is_component_build || is_electron_build) {
++  if (is_component_build || (is_electron_build && !is_electron_gn_build)) {
      # Component mode: dynamic CRT. Since the library is shared, it requires
      # exceptions or will give errors about things not matching, so keep
      # exceptions on.


### PR DESCRIPTION
Fixes link errors of the form:
```
node.lib(node_lib.Protocol.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value 'MD_DynamicRelease' in atom_main.obj
```

This is because in the GN build, node is linked statically instead of
dynamically in non-component builds.