### PR TITLE
Add patch to make scrollBounce option work

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -365,3 +365,8 @@ patches:
     that chrome code hardcodes require that we generate resources at these
     paths, but GN throws errors if there are multiple targets that generate the
     same files.
+-
+  owners: zcbenz
+  file: scroll_bounce_flag.patch
+  description: |
+    Patch to make scrollBounce option work.

--- a/patches/common/chromium/scroll_bounce_flag.patch
+++ b/patches/common/chromium/scroll_bounce_flag.patch
@@ -1,0 +1,13 @@
+diff --git a/content/renderer/render_thread_impl.cc b/content/renderer/render_thread_impl.cc
+index 81d3f80..a8c4a57 100644
+--- a/content/renderer/render_thread_impl.cc
++++ b/content/renderer/render_thread_impl.cc
+@@ -1737,7 +1737,7 @@ bool RenderThreadImpl::IsGpuMemoryBufferCompositorResourcesEnabled() {
+ }
+ 
+ bool RenderThreadImpl::IsElasticOverscrollEnabled() {
+-  return is_elastic_overscroll_enabled_;
++  return base::CommandLine::ForCurrentProcess()->HasSwitch("scroll-bounce");
+ }
+ 
+ scoped_refptr<base::SingleThreadTaskRunner>


### PR DESCRIPTION
This patch makes the renderer process to use `--scroll-bounce` command line flag to enable rubber banding.

This is required to fix https://github.com/electron/electron/issues/13493.

Chromium does not provide a way for us to inject code just before renderer process is started, when Chromium reads system rubber banding setting. I tried to set `NSScrollViewRubberbanding` in a few places but they all have race conditions when creating multiple windows with different settings, see https://github.com/electron/electron/pull/13797 for an example.

This patch is the simplest solution (and probably the most decent one) that I can find, and it is very easy to maintain.