### PR TITLE
build: [gn] resolve resource path conflict

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -357,3 +357,11 @@ patches:
   description: |
     Guard usages in blink of private Mac APIs by MAS_BUILD, so they can be
     excluded for people who want to submit their apps to the Mac App store.
+-
+  owners: nornagon
+  file: resource_file_conflict.patch
+  description: |
+    Resolve conflict between //chrome's .pak files and //electron's. The paths
+    that chrome code hardcodes require that we generate resources at these
+    paths, but GN throws errors if there are multiple targets that generate the
+    same files.

--- a/patches/common/chromium/resource_file_conflict.patch
+++ b/patches/common/chromium/resource_file_conflict.patch
@@ -1,0 +1,23 @@
+diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
+index fbcf20c..78789a9 100644
+--- a/chrome/BUILD.gn
++++ b/chrome/BUILD.gn
+@@ -1656,6 +1656,10 @@ if (is_chrome_branded && !is_android) {
+   }
+ }
+ 
++if (is_electron_gn_build) {
++  group("packed_resources") {
++  }
++} else {
+ chrome_paks("packed_resources") {
+   if (is_mac) {
+     output_dir = "$root_gen_dir/repack"
+@@ -1677,6 +1681,7 @@ chrome_paks("packed_resources") {
+     ]
+   }
+ }
++}
+ 
+ repack("browser_tests_pak") {
+   sources = [


### PR DESCRIPTION
Code in //ui expects resources to exist in fixed locations, namely:

- chrome_100_percent.pak
- chrome_200_percent.pak
- locales/{locale_code}.pak

alongside `chrome.exe`. However, Electron puts different things in those .pak
files than the chrome build does, and needs to generate them in the same place,
which causes GN to throw errors (despite the fact that no target in the
transitive dependencies from //electron causes the //chrome version of those
resources to be generated).