### PR TITLE
build: [gn] redirect //chrome:packed_resources to //electron's version

### DIFF
--- a/patches/common/chromium/resource_file_conflict.patch
+++ b/patches/common/chromium/resource_file_conflict.patch
@@ -1,19 +1,20 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index fbcf20c..78789a9 100644
+index fbcf20c..d2173e2 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1656,6 +1656,10 @@ if (is_chrome_branded && !is_android) {
+@@ -1656,6 +1656,11 @@ if (is_chrome_branded && !is_android) {
    }
  }
  
 +if (is_electron_gn_build) {
 +  group("packed_resources") {
++    public_deps = [ "//electron:packed_resources" ]
 +  }
 +} else {
  chrome_paks("packed_resources") {
    if (is_mac) {
      output_dir = "$root_gen_dir/repack"
-@@ -1677,6 +1681,7 @@ chrome_paks("packed_resources") {
+@@ -1677,6 +1682,7 @@ chrome_paks("packed_resources") {
      ]
    }
  }


### PR DESCRIPTION
We don't use this target, but gn refuses to generate the Release build files on Linux without this:
```
ERROR Input to targets not generated by a dependency.
The file:
  //out/Release/locales/en-US.pak
is listed as an input or source for the targets:
  //chrome/installer/linux:stable_deb
  //chrome/installer/linux:stable_rpm
  //chrome/installer/linux:beta_deb
  //chrome/installer/linux:beta_rpm
  //chrome/installer/linux:unstable_deb
  //chrome/installer/linux:unstable_rpm
but this file was not generated by any dependencies of the targets. The target
that generates the file is:
  //electron:packed_resources_locales_en-US
```