### PR TITLE
fix: Backport patch to fix Widget::OnSizeConstraintsChanged crash (3.0.x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -306,3 +306,9 @@ patches:
   file: scroll_bounce_flag.patch
   description: |
     Patch to make scrollBounce option work.
+-
+  owners: poiru
+  file: backport_d65792a.patch
+  description: |
+    https://chromium-review.googlesource.com/c/chromium/src/+/1105698
+    Fixes https://github.com/electron/electron/issues/13256

--- a/patches/common/chromium/backport_d65792a.patch
+++ b/patches/common/chromium/backport_d65792a.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/views/widget/widget.cc b/ui/views/widget/widget.cc
+index bf4b1d0..a3b72c4 100644
+@@ -995,7 +996,8 @@
+
+ void Widget::OnSizeConstraintsChanged() {
+   native_widget_->OnSizeConstraintsChanged();
+-  non_client_view_->SizeConstraintsChanged();
++  if (non_client_view_)
++    non_client_view_->SizeConstraintsChanged();
+ }
+
+ void Widget::OnOwnerClosing() {}


### PR DESCRIPTION
This backports #617 to 3.0.x.