### PR TITLE
fix: Backport patch to fix Widget::OnSizeConstraintsChanged crash (2.0.x)

### DIFF
--- a/patches/089-backport_d65792a.patch
+++ b/patches/089-backport_d65792a.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/views/widget/widget.cc b/ui/views/widget/widget.cc
+index bf4b1d0..a3b72c4 100644
+@@ -1002,7 +1002,8 @@
+
+ void Widget::OnSizeConstraintsChanged() {
+   native_widget_->OnSizeConstraintsChanged();
+-  non_client_view_->SizeConstraintsChanged();
++  if (non_client_view_)
++    non_client_view_->SizeConstraintsChanged();
+ }
+
+ void Widget::OnOwnerClosing() {}


### PR DESCRIPTION
This backports #617 to 2.0.x.