### PR TITLE
fix: [gn] port crashpad patch from fork to patch

### DIFF
--- a/patches/common/crashpad/.patches.yaml
+++ b/patches/common/crashpad/.patches.yaml
@@ -1,0 +1,8 @@
+repo: src
+patches:
+-
+  owners: nornagon
+  file: http_status.patch
+  description: |
+    Accept all HTTP codes in [200, 300) as successful, instead of just 200.
+    For example HockeyApp responds with 202.

--- a/patches/common/crashpad/.patches.yaml
+++ b/patches/common/crashpad/.patches.yaml
@@ -1,4 +1,4 @@
-repo: src
+repo: src/third_party/crashpad/crashpad
 patches:
 -
   owners: nornagon

--- a/patches/common/crashpad/http_status.patch
+++ b/patches/common/crashpad/http_status.patch
@@ -1,0 +1,54 @@
+From 800aa10d300af0f3fe162ae586b6b1ebe0566ab4 Mon Sep 17 00:00:00 2001
+From: Catalin Fratila <catalinf@microsoft.com>
+Date: Fri, 19 May 2017 09:28:53 +0200
+Subject: [PATCH] Handle everything not in [200, 300) as error. For example
+ HockeyApp responds with 202.
+
+(cherry picked from commit f7c320766756a8aaa45ccbcff2945053d9f7e109)
+(cherry picked from commit 1875fddc7e671b14d8b54068301d9648d12e9dc2)
+(cherry picked from commit 670fb453b0c3d6ae0a0d5923f68df02464337617)
+---
+ util/net/http_transport_libcurl.cc | 2 +-
+ util/net/http_transport_mac.mm     | 2 +-
+ util/net/http_transport_win.cc     | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/util/net/http_transport_libcurl.cc b/util/net/http_transport_libcurl.cc
+index c16a593..0e262b0 100644
+--- a/util/net/http_transport_libcurl.cc
++++ b/util/net/http_transport_libcurl.cc
+@@ -338,7 +338,7 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
+     return false;
+   }
+ 
+-  if (status != 200) {
++  if (status < 200 || status >= 300) {
+     LOG(ERROR) << base::StringPrintf("HTTP status %ld", status);
+     return false;
+   }
+diff --git a/util/net/http_transport_mac.mm b/util/net/http_transport_mac.mm
+index 8d5f78c..a6434c2 100644
+--- a/util/net/http_transport_mac.mm
++++ b/util/net/http_transport_mac.mm
+@@ -293,7 +293,7 @@ static void Unschedule(CFReadStreamRef stream,
+       return false;
+     }
+     NSInteger http_status = [http_response statusCode];
+-    if (http_status != 200) {
++    if (http_status < 200 || http_status >= 300) {
+       LOG(ERROR) << base::StringPrintf("HTTP status %ld",
+                                        implicit_cast<long>(http_status));
+       return false;
+diff --git a/util/net/http_transport_win.cc b/util/net/http_transport_win.cc
+index 18d343c..40c3061 100644
+--- a/util/net/http_transport_win.cc
++++ b/util/net/http_transport_win.cc
+@@ -375,7 +375,7 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
+     return false;
+   }
+ 
+-  if (status_code != 200) {
++  if (status_code < 200 || status_code >= 300) {
+     LOG(ERROR) << base::StringPrintf("HTTP status %lu", status_code);
+     return false;
+   }


### PR DESCRIPTION
Since the GN build uses the crashpad that's referenced by Chromium's
DEPS, port over the one semantic change from Electron's crashpad fork to
be a patch.