### PR TITLE
Backport "Enforce flush ordering between contexts in GPU process on macOS."

### DIFF
--- a/patches/090-backport_325151c.patch
+++ b/patches/090-backport_325151c.patch
@@ -1,0 +1,183 @@
+diff --git a/gpu/command_buffer/tests/gl_texture_mailbox_unittest.cc b/gpu/command_buffer/tests/gl_texture_mailbox_unittest.cc
+index 1cb88ceeaf830..e950fd1862250 100644
+--- a/gpu/command_buffer/tests/gl_texture_mailbox_unittest.cc
++++ b/gpu/command_buffer/tests/gl_texture_mailbox_unittest.cc
+@@ -8,6 +8,7 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ 
++#include "gpu/command_buffer/client/gles2_implementation.h"
+ #include "gpu/command_buffer/client/gles2_lib.h"
+ #include "gpu/command_buffer/common/mailbox.h"
+ #include "gpu/command_buffer/service/gles2_cmd_decoder.h"
+@@ -91,6 +92,23 @@ class GLTextureMailboxTest : public testing::Test {
+     return mailbox;
+   }
+ 
++  void AllocateTextureBackedFramebuffer(GLuint* tex, GLuint* fbo) {
++    glGenTextures(1, tex);
++    glBindTexture(GL_TEXTURE_2D, *tex);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 2, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++                 nullptr);
++    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
++    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
++    glGenFramebuffers(1, fbo);
++    glBindFramebuffer(GL_FRAMEBUFFER, *fbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                           *tex, 0);
++    ASSERT_EQ(static_cast<GLenum>(GL_FRAMEBUFFER_COMPLETE),
++              glCheckFramebufferStatus(GL_FRAMEBUFFER));
++  }
++
+   GLManager gl1_;
+   GLManager gl2_;
+ };
+@@ -355,6 +373,87 @@ TEST_F(GLTextureMailboxTest, SharedTextures) {
+   EXPECT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
+ }
+ 
++TEST_F(GLTextureMailboxTest, OrderingBarrierImpliesFlush) {
++  SetUpContexts();
++  gl2_.MakeCurrent();
++
++  // If the current platform requires the use of virtualized GL contexts
++  // for correctness, this harness does not respect that flag, so skip
++  // this test.
++  if (gl2_.workarounds().use_virtualized_gl_contexts) {
++    SUCCEED() << "Platform requires virtualized GL contexts; skipping.";
++    return;
++  }
++
++  GLuint fbo2 = 0;
++  glGenFramebuffers(1, &fbo2);
++  glBindFramebuffer(GL_FRAMEBUFFER, fbo2);
++  GLuint tex2 = 0;
++  glGenTextures(1, &tex2);
++  glBindTexture(GL_TEXTURE_2D, tex2);
++  gl1_.MakeCurrent();
++  GLuint tex1 = 0;
++  GLuint fbo1 = 0;
++  AllocateTextureBackedFramebuffer(&tex1, &fbo1);
++
++  // Many times:
++  //  - Set the texture to one color in context 1
++  //  - Mailbox the texture to context 2
++  //  - Set the texture to another color in context 2
++  //  - Mailbox the texture to context 1
++  //  - Read back the framebuffer in context 1
++  //  - Assert it's the color set by context 2
++
++  GLbyte mailbox[GL_MAILBOX_SIZE_CHROMIUM];
++  glGenMailboxCHROMIUM(mailbox);
++  glProduceTextureCHROMIUM(GL_TEXTURE_2D, mailbox);
++
++  for (int i = 0; i < 1000; ++i) {
++    // Assume context 1 is current.
++    // Clear to red
++    glClearColor(1.0, 0.0, 0.0, 1.0);
++    glClear(GL_COLOR_BUFFER_BIT);
++    // Enforce ordering with respect to context 2.
++    gl1_.gles2_implementation()->OrderingBarrierCHROMIUM();
++    // Consume texture in context 2.
++    gl2_.MakeCurrent();
++    glConsumeTextureCHROMIUM(GL_TEXTURE_2D, mailbox);
++    EXPECT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++    // Set up framebuffer in context 2 (strictly, not necessary, could
++    // do this just once).
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                           tex2, 0);
++    EXPECT_EQ(static_cast<GLenum>(GL_FRAMEBUFFER_COMPLETE),
++              glCheckFramebufferStatus(GL_FRAMEBUFFER));
++    // Clear to green.
++    glClearColor(0.0, 1.0, 0.0, 1.0);
++    glClear(GL_COLOR_BUFFER_BIT);
++    // Enforce ordering with respect to context 2.
++    gl2_.gles2_implementation()->OrderingBarrierCHROMIUM();
++    // Consume texture in context 1.
++    gl1_.MakeCurrent();
++    // Read back framebuffer.
++    GLubyte pixel[4];
++    glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, &pixel[0]);
++    EXPECT_EQ(0, pixel[0]);
++    EXPECT_EQ(255, pixel[1]);
++    EXPECT_EQ(0, pixel[2]);
++    EXPECT_EQ(255, pixel[3]);
++  }
++
++  glBindFramebuffer(GL_FRAMEBUFFER, 0);
++  glDeleteFramebuffers(1, &fbo1);
++  glBindTexture(GL_TEXTURE_2D, 0);
++  glDeleteTextures(1, &tex1);
++  EXPECT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  gl2_.MakeCurrent();
++  glBindFramebuffer(GL_FRAMEBUFFER, 0);
++  glDeleteFramebuffers(1, &fbo2);
++  glBindTexture(GL_TEXTURE_2D, 0);
++  glDeleteTextures(1, &tex2);
++  EXPECT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++}
++
+ TEST_F(GLTextureMailboxTest, TakeFrontBuffer) {
+   SetUpContexts();
+   gl1_.MakeCurrent();
+diff --git a/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp b/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp
+index d43720833702c..3d8a25c4e6f52 100644
+--- a/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp
++++ b/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp
+@@ -396,7 +396,19 @@ bool DrawingBuffer::FinishPrepareTextureMailboxGpu(
+ #if defined(OS_MACOSX)
+     gl_->DescheduleUntilFinishedCHROMIUM();
+ #endif
+-    gl_->Flush();
++    // It's critical to order the execution of this context's work relative
++    // to other contexts, in particular the compositor. Previously this
++    // used to be a Flush, and there was a bug that we didn't flush before
++    // InsertFenceSyncCHROMIUM, above. On some platforms this caused
++    // incorrect rendering with complex WebGL content that wasn't always
++    // properly flushed to the driver. There is now a basic assumption that
++    // there are implicit flushes between contexts at the lowest level.
++    //
++    // Note also that theoretically this should be ShallowFlushCHROMIUM,
++    // but as we are moving toward using unverified sync tokens everywhere,
++    // and this code is working, we would rather not incur two synchronous
++    // IPCs here (which that would imply).
++    gl_->OrderingBarrierCHROMIUM();
+     gl_->GenSyncTokenCHROMIUM(
+         fence_sync, color_buffer_for_mailbox->produce_sync_token.GetData());
+   }
+diff --git a/ui/gl/gl_context_cgl.cc b/ui/gl/gl_context_cgl.cc
+index dab9d279020c0..6b85039c6dd56 100644
+--- a/ui/gl/gl_context_cgl.cc
++++ b/ui/gl/gl_context_cgl.cc
+@@ -242,6 +242,16 @@ bool GLContextCGL::MakeCurrent(GLSurface* surface) {
+   if (IsCurrent(surface))
+     return true;
+ 
++  // It's likely we're going to switch OpenGL contexts at this point.
++  // Before doing so, if there is a current context, flush it. There
++  // are many implicit assumptions of flush ordering between contexts
++  // at higher levels, and if a flush isn't performed, OpenGL commands
++  // may be issued in unexpected orders, causing flickering and other
++  // artifacts.
++  if (CGLGetCurrentContext() != nullptr) {
++    glFlush();
++  }
++
+   ScopedReleaseCurrent release_current;
+   TRACE_EVENT0("gpu", "GLContextCGL::MakeCurrent");
+ 
+@@ -270,6 +280,12 @@ void GLContextCGL::ReleaseCurrent(GLSurface* surface) {
+   if (!IsCurrent(surface))
+     return;
+ 
++  // Before releasing the current context, flush it. This ensures that
++  // all commands issued by higher levels will be seen by the OpenGL
++  // implementation, which is assumed throughout the code. See comment
++  // in MakeCurrent, above.
++  glFlush();
++
+   SetCurrent(nullptr);
+   CGLSetCurrentContext(nullptr);
+ }


### PR DESCRIPTION
This is a backport of https://chromium-review.googlesource.com/c/chromium/src/+/687832 targeting the 2-0-x branch of Electron.

This is a crucial patch for Figma, since without it mac users will see flickering when their GPU is under heavy load.

@poiru