### PR TITLE
src: add patches for Node upgrade v10.6.0

### DIFF
--- a/patches/common/v8/.patches.yaml
+++ b/patches/common/v8/.patches.yaml
@@ -42,3 +42,35 @@ patches:
   owners: alexeykuzmin
   file: backport_23652c5f.patch
   description: Node 10.2.0 needs it.
+-
+  owners: codebytere
+  file: backport_91ddb65d.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: cherry-pick_6989b3f6d7.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: cherry-pick_a440efb27f.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: cherry-pick_5dd3395.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: backport_aa6ce3e.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: cherry-pick_b20faff.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: cherry-pick_acc336c.patch
+  description: Node 10.6.0 needs it.
+-
+  owners: codebytere
+  file: cherry-pick_70c4340.patch
+  description: Node 10.6.0 needs it.

--- a/patches/common/v8/backport_91ddb65d.patch
+++ b/patches/common/v8/backport_91ddb65d.patch
@@ -1,0 +1,2338 @@
+diff --git a/src/bootstrapper.cc b/src/bootstrapper.cc
+index 0eec2c6d09..8b272d0576 100644
+--- a/src/bootstrapper.cc
++++ b/src/bootstrapper.cc
+@@ -1587,6 +1587,50 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
+     native_context()->set_async_iterator_value_unwrap_shared_fun(*info);
+   }
+
++  {  // --- A s y n c G e n e r a t o r ---
++    Handle<JSFunction> await_caught =
++        SimpleCreateFunction(isolate, factory->empty_string(),
++                             Builtins::kAsyncGeneratorAwaitCaught, 1, false);
++    native_context()->set_async_generator_await_caught(*await_caught);
++
++    Handle<JSFunction> await_uncaught =
++        SimpleCreateFunction(isolate, factory->empty_string(),
++                             Builtins::kAsyncGeneratorAwaitUncaught, 1, false);
++    native_context()->set_async_generator_await_uncaught(*await_uncaught);
++
++    Handle<SharedFunctionInfo> info = SimpleCreateSharedFunctionInfo(
++        isolate, Builtins::kAsyncGeneratorAwaitResolveClosure,
++        factory->empty_string(), 1);
++    native_context()->set_async_generator_await_resolve_shared_fun(*info);
++
++    info = SimpleCreateSharedFunctionInfo(
++        isolate, Builtins::kAsyncGeneratorAwaitRejectClosure,
++        factory->empty_string(), 1);
++    native_context()->set_async_generator_await_reject_shared_fun(*info);
++
++    info = SimpleCreateSharedFunctionInfo(
++        isolate, Builtins::kAsyncGeneratorYieldResolveClosure,
++        factory->empty_string(), 1);
++    native_context()->set_async_generator_yield_resolve_shared_fun(*info);
++
++    info = SimpleCreateSharedFunctionInfo(
++        isolate, Builtins::kAsyncGeneratorReturnResolveClosure,
++        factory->empty_string(), 1);
++    native_context()->set_async_generator_return_resolve_shared_fun(*info);
++
++    info = SimpleCreateSharedFunctionInfo(
++        isolate, Builtins::kAsyncGeneratorReturnClosedResolveClosure,
++        factory->empty_string(), 1);
++    native_context()->set_async_generator_return_closed_resolve_shared_fun(
++        *info);
++
++    info = SimpleCreateSharedFunctionInfo(
++        isolate, Builtins::kAsyncGeneratorReturnClosedRejectClosure,
++        factory->empty_string(), 1);
++    native_context()->set_async_generator_return_closed_reject_shared_fun(
++        *info);
++  }
++
+   {  // --- A r r a y ---
+     Handle<JSFunction> array_function = InstallFunction(
+         global, "Array", JS_ARRAY_TYPE, JSArray::kSize, 0,
+@@ -4025,6 +4069,34 @@ void Bootstrapper::ExportFromRuntime(Isolate* isolate,
+     JSFunction::SetPrototype(async_function_constructor,
+                              async_function_prototype);
+
++    {
++      Handle<JSFunction> function =
++          SimpleCreateFunction(isolate, factory->empty_string(),
++                               Builtins::kAsyncFunctionAwaitCaught, 2, false);
++      native_context->set_async_function_await_caught(*function);
++    }
++
++    {
++      Handle<JSFunction> function =
++          SimpleCreateFunction(isolate, factory->empty_string(),
++                               Builtins::kAsyncFunctionAwaitUncaught, 2, false);
++      native_context->set_async_function_await_uncaught(*function);
++    }
++
++    {
++      Handle<SharedFunctionInfo> info = SimpleCreateSharedFunctionInfo(
++          isolate, Builtins::kAsyncFunctionAwaitRejectClosure,
++          factory->empty_string(), 1);
++      native_context->set_async_function_await_reject_shared_fun(*info);
++    }
++
++    {
++      Handle<SharedFunctionInfo> info = SimpleCreateSharedFunctionInfo(
++          isolate, Builtins::kAsyncFunctionAwaitResolveClosure,
++          factory->empty_string(), 1);
++      native_context->set_async_function_await_resolve_shared_fun(*info);
++    }
++
+     {
+       Handle<JSFunction> function =
+           SimpleCreateFunction(isolate, factory->empty_string(),
+diff --git a/src/builtins/builtins-async-function-gen.cc b/src/builtins/builtins-async-function-gen.cc
+index 0db53c687e..0d0e34ee0d 100644
+--- a/src/builtins/builtins-async-function-gen.cc
++++ b/src/builtins/builtins-async-function-gen.cc
+@@ -21,18 +21,37 @@ class AsyncFunctionBuiltinsAssembler : public AsyncBuiltinsAssembler {
+                           Node* const awaited, Node* const outer_promise,
+                           const bool is_predicted_as_caught);
+
+-  void AsyncFunctionAwaitResume(Node* const context, Node* const argument,
+-                                Node* const generator,
+-                                JSGeneratorObject::ResumeMode resume_mode);
++  void AsyncFunctionAwaitResumeClosure(
++      Node* const context, Node* const sent_value,
++      JSGeneratorObject::ResumeMode resume_mode);
+ };
+
+-void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwaitResume(
+-    Node* const context, Node* const argument, Node* const generator,
++namespace {
++
++// Describe fields of Context associated with AsyncFunctionAwait resume
++// closures.
++// TODO(jgruber): Refactor to reuse code for upcoming async-generators.
++class AwaitContext {
++ public:
++  enum Fields { kGeneratorSlot = Context::MIN_CONTEXT_SLOTS, kLength };
++};
++
++}  // anonymous namespace
++
++void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwaitResumeClosure(
++    Node* context, Node* sent_value,
+     JSGeneratorObject::ResumeMode resume_mode) {
+-  CSA_ASSERT(this, IsJSGeneratorObject(generator));
+   DCHECK(resume_mode == JSGeneratorObject::kNext ||
+          resume_mode == JSGeneratorObject::kThrow);
+
++  Node* const generator =
++      LoadContextElement(context, AwaitContext::kGeneratorSlot);
++  CSA_SLOW_ASSERT(this, HasInstanceType(generator, JS_GENERATOR_OBJECT_TYPE));
++
++  // Inline version of GeneratorPrototypeNext / GeneratorPrototypeReturn with
++  // unnecessary runtime checks removed.
++  // TODO(jgruber): Refactor to reuse code from builtins-generator.cc.
++
+   // Ensure that the generator is neither closed nor running.
+   CSA_SLOW_ASSERT(
+       this,
+@@ -47,23 +66,31 @@ void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwaitResume(
+
+   // Resume the {receiver} using our trampoline.
+   Callable callable = CodeFactory::ResumeGenerator(isolate());
+-  TailCallStub(callable, context, argument, generator);
++  CallStub(callable, context, sent_value, generator);
++
++  // The resulting Promise is a throwaway, so it doesn't matter what it
++  // resolves to. What is important is that we don't end up keeping the
++  // whole chain of intermediate Promises alive by returning the return value
++  // of ResumeGenerator, as that would create a memory leak.
+ }
+
+-TF_BUILTIN(AsyncFunctionAwaitFulfill, AsyncFunctionBuiltinsAssembler) {
+-  Node* const argument = Parameter(Descriptor::kArgument);
+-  Node* const generator = Parameter(Descriptor::kGenerator);
++TF_BUILTIN(AsyncFunctionAwaitRejectClosure, AsyncFunctionBuiltinsAssembler) {
++  CSA_ASSERT_JS_ARGC_EQ(this, 1);
++  Node* const sentError = Parameter(Descriptor::kSentError);
+   Node* const context = Parameter(Descriptor::kContext);
+-  AsyncFunctionAwaitResume(context, argument, generator,
+-                           JSGeneratorObject::kNext);
++
++  AsyncFunctionAwaitResumeClosure(context, sentError,
++                                  JSGeneratorObject::kThrow);
++  Return(UndefinedConstant());
+ }
+
+-TF_BUILTIN(AsyncFunctionAwaitReject, AsyncFunctionBuiltinsAssembler) {
+-  Node* const argument = Parameter(Descriptor::kArgument);
+-  Node* const generator = Parameter(Descriptor::kGenerator);
++TF_BUILTIN(AsyncFunctionAwaitResolveClosure, AsyncFunctionBuiltinsAssembler) {
++  CSA_ASSERT_JS_ARGC_EQ(this, 1);
++  Node* const sentValue = Parameter(Descriptor::kSentValue);
+   Node* const context = Parameter(Descriptor::kContext);
+-  AsyncFunctionAwaitResume(context, argument, generator,
+-                           JSGeneratorObject::kThrow);
++
++  AsyncFunctionAwaitResumeClosure(context, sentValue, JSGeneratorObject::kNext);
++  Return(UndefinedConstant());
+ }
+
+ // ES#abstract-ops-async-function-await
+@@ -78,12 +105,25 @@ TF_BUILTIN(AsyncFunctionAwaitReject, AsyncFunctionBuiltinsAssembler) {
+ void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwait(
+     Node* const context, Node* const generator, Node* const awaited,
+     Node* const outer_promise, const bool is_predicted_as_caught) {
+-  CSA_SLOW_ASSERT(this, IsJSGeneratorObject(generator));
+-  CSA_SLOW_ASSERT(this, IsJSPromise(outer_promise));
+-
+-  Await(context, generator, awaited, outer_promise,
+-        Builtins::kAsyncFunctionAwaitFulfill,
+-        Builtins::kAsyncFunctionAwaitReject, is_predicted_as_caught);
++  CSA_SLOW_ASSERT(this, HasInstanceType(generator, JS_GENERATOR_OBJECT_TYPE));
++  CSA_SLOW_ASSERT(this, HasInstanceType(outer_promise, JS_PROMISE_TYPE));
++
++  ContextInitializer init_closure_context = [&](Node* context) {
++    StoreContextElementNoWriteBarrier(context, AwaitContext::kGeneratorSlot,
++                                      generator);
++  };
++
++  // TODO(jgruber): AsyncBuiltinsAssembler::Await currently does not reuse
++  // the awaited promise if it is already a promise. Reuse is non-spec compliant
++  // but part of our old behavior gives us a couple of percent
++  // performance boost.
++  // TODO(jgruber): Use a faster specialized version of
++  // InternalPerformPromiseThen.
++
++  Await(context, generator, awaited, outer_promise, AwaitContext::kLength,
++        init_closure_context, Context::ASYNC_FUNCTION_AWAIT_RESOLVE_SHARED_FUN,
++        Context::ASYNC_FUNCTION_AWAIT_REJECT_SHARED_FUN,
++        is_predicted_as_caught);
+
+   // Return outer promise to avoid adding an load of the outer promise before
+   // suspending in BytecodeGenerator.
+@@ -93,28 +133,30 @@ void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwait(
+ // Called by the parser from the desugaring of 'await' when catch
+ // prediction indicates that there is a locally surrounding catch block.
+ TF_BUILTIN(AsyncFunctionAwaitCaught, AsyncFunctionBuiltinsAssembler) {
++  CSA_ASSERT_JS_ARGC_EQ(this, 3);
+   Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const value = Parameter(Descriptor::kValue);
++  Node* const awaited = Parameter(Descriptor::kAwaited);
+   Node* const outer_promise = Parameter(Descriptor::kOuterPromise);
+   Node* const context = Parameter(Descriptor::kContext);
+
+   static const bool kIsPredictedAsCaught = true;
+
+-  AsyncFunctionAwait(context, generator, value, outer_promise,
++  AsyncFunctionAwait(context, generator, awaited, outer_promise,
+                      kIsPredictedAsCaught);
+ }
+
+ // Called by the parser from the desugaring of 'await' when catch
+ // prediction indicates no locally surrounding catch block.
+ TF_BUILTIN(AsyncFunctionAwaitUncaught, AsyncFunctionBuiltinsAssembler) {
++  CSA_ASSERT_JS_ARGC_EQ(this, 3);
+   Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const value = Parameter(Descriptor::kValue);
++  Node* const awaited = Parameter(Descriptor::kAwaited);
+   Node* const outer_promise = Parameter(Descriptor::kOuterPromise);
+   Node* const context = Parameter(Descriptor::kContext);
+
+   static const bool kIsPredictedAsCaught = false;
+
+-  AsyncFunctionAwait(context, generator, value, outer_promise,
++  AsyncFunctionAwait(context, generator, awaited, outer_promise,
+                      kIsPredictedAsCaught);
+ }
+
+diff --git a/src/builtins/builtins-async-gen.cc b/src/builtins/builtins-async-gen.cc
+index 073c96a2e0..ba0226d7b3 100644
+--- a/src/builtins/builtins-async-gen.cc
++++ b/src/builtins/builtins-async-gen.cc
+@@ -13,58 +13,6 @@ namespace internal {
+
+ using compiler::Node;
+
+-void AsyncBuiltinsAssembler::Await(Node* context, Node* generator, Node* value,
+-                                   Node* outer_promise,
+-                                   Builtins::Name fulfill_builtin,
+-                                   Builtins::Name reject_builtin,
+-                                   Node* is_predicted_as_caught) {
+-  CSA_SLOW_ASSERT(this, Word32Or(IsJSAsyncGeneratorObject(generator),
+-                                 IsJSGeneratorObject(generator)));
+-  CSA_SLOW_ASSERT(this, IsJSPromise(outer_promise));
+-  CSA_SLOW_ASSERT(this, IsBoolean(is_predicted_as_caught));
+-
+-  Node* const native_context = LoadNativeContext(context);
+-
+-  // TODO(bmeurer): This could be optimized and folded into a single allocation.
+-  Node* const promise = AllocateAndInitJSPromise(native_context);
+-  Node* const promise_reactions =
+-      LoadObjectField(promise, JSPromise::kReactionsOrResultOffset);
+-  Node* const fulfill_handler =
+-      HeapConstant(Builtins::CallableFor(isolate(), fulfill_builtin).code());
+-  Node* const reject_handler =
+-      HeapConstant(Builtins::CallableFor(isolate(), reject_builtin).code());
+-  Node* const reaction = AllocatePromiseReaction(
+-      promise_reactions, generator, fulfill_handler, reject_handler);
+-  StoreObjectField(promise, JSPromise::kReactionsOrResultOffset, reaction);
+-  PromiseSetHasHandler(promise);
+-
+-  // Perform ! Call(promiseCapability.[[Resolve]], undefined, « value »).
+-  CallBuiltin(Builtins::kResolvePromise, native_context, promise, value);
+-
+-  // When debugging, we need to link from the {generator} to the
+-  // {outer_promise} of the async function/generator.
+-  Label done(this);
+-  GotoIfNot(IsPromiseHookEnabledOrDebugIsActive(), &done);
+-  CallRuntime(Runtime::kSetProperty, native_context, generator,
+-              LoadRoot(Heap::kgenerator_outer_promise_symbolRootIndex),
+-              outer_promise, SmiConstant(LanguageMode::kStrict));
+-  GotoIf(IsFalse(is_predicted_as_caught), &done);
+-  GotoIf(TaggedIsSmi(value), &done);
+-  GotoIfNot(IsJSPromise(value), &done);
+-  PromiseSetHandledHint(value);
+-  Goto(&done);
+-  BIND(&done);
+-}
+-
+-void AsyncBuiltinsAssembler::Await(Node* context, Node* generator, Node* value,
+-                                   Node* outer_promise,
+-                                   Builtins::Name fulfill_builtin,
+-                                   Builtins::Name reject_builtin,
+-                                   bool is_predicted_as_caught) {
+-  return Await(context, generator, value, outer_promise, fulfill_builtin,
+-               reject_builtin, BooleanConstant(is_predicted_as_caught));
+-}
+-
+ namespace {
+ // Describe fields of Context associated with the AsyncIterator unwrap closure.
+ class ValueUnwrapContext {
+@@ -74,6 +22,161 @@ class ValueUnwrapContext {
+
+ }  // namespace
+
++Node* AsyncBuiltinsAssembler::Await(
++    Node* context, Node* generator, Node* value, Node* outer_promise,
++    int context_length, const ContextInitializer& init_closure_context,
++    Node* on_resolve_context_index, Node* on_reject_context_index,
++    Node* is_predicted_as_caught) {
++  DCHECK_GE(context_length, Context::MIN_CONTEXT_SLOTS);
++
++  Node* const native_context = LoadNativeContext(context);
++
++  static const int kWrappedPromiseOffset = FixedArray::SizeFor(context_length);
++  static const int kThrowawayPromiseOffset =
++      kWrappedPromiseOffset + JSPromise::kSizeWithEmbedderFields;
++  static const int kResolveClosureOffset =
++      kThrowawayPromiseOffset + JSPromise::kSizeWithEmbedderFields;
++  static const int kRejectClosureOffset =
++      kResolveClosureOffset + JSFunction::kSizeWithoutPrototype;
++  static const int kTotalSize =
++      kRejectClosureOffset + JSFunction::kSizeWithoutPrototype;
++
++  Node* const base = AllocateInNewSpace(kTotalSize);
++  Node* const closure_context = base;
++  {
++    // Initialize closure context
++    InitializeFunctionContext(native_context, closure_context, context_length);
++    init_closure_context(closure_context);
++  }
++
++  // Let promiseCapability be ! NewPromiseCapability(%Promise%).
++  Node* const promise_fun =
++      LoadContextElement(native_context, Context::PROMISE_FUNCTION_INDEX);
++  CSA_ASSERT(this, IsFunctionWithPrototypeSlotMap(LoadMap(promise_fun)));
++  Node* const promise_map =
++      LoadObjectField(promise_fun, JSFunction::kPrototypeOrInitialMapOffset);
++  // Assert that the JSPromise map has an instance size is
++  // JSPromise::kSizeWithEmbedderFields.
++  CSA_ASSERT(this, WordEqual(LoadMapInstanceSizeInWords(promise_map),
++                             IntPtrConstant(JSPromise::kSizeWithEmbedderFields /
++                                            kPointerSize)));
++  Node* const wrapped_value = InnerAllocate(base, kWrappedPromiseOffset);
++  {
++    // Initialize Promise
++    StoreMapNoWriteBarrier(wrapped_value, promise_map);
++    InitializeJSObjectFromMap(
++        wrapped_value, promise_map,
++        IntPtrConstant(JSPromise::kSizeWithEmbedderFields));
++    PromiseInit(wrapped_value);
++  }
++
++  Node* const throwaway = InnerAllocate(base, kThrowawayPromiseOffset);
++  {
++    // Initialize throwawayPromise
++    StoreMapNoWriteBarrier(throwaway, promise_map);
++    InitializeJSObjectFromMap(
++        throwaway, promise_map,
++        IntPtrConstant(JSPromise::kSizeWithEmbedderFields));
++    PromiseInit(throwaway);
++  }
++
++  Node* const on_resolve = InnerAllocate(base, kResolveClosureOffset);
++  {
++    // Initialize resolve handler
++    InitializeNativeClosure(closure_context, native_context, on_resolve,
++                            on_resolve_context_index);
++  }
++
++  Node* const on_reject = InnerAllocate(base, kRejectClosureOffset);
++  {
++    // Initialize reject handler
++    InitializeNativeClosure(closure_context, native_context, on_reject,
++                            on_reject_context_index);
++  }
++
++  {
++    // Add PromiseHooks if needed
++    Label next(this);
++    GotoIfNot(IsPromiseHookEnabledOrDebugIsActive(), &next);
++    CallRuntime(Runtime::kPromiseHookInit, context, wrapped_value,
++                outer_promise);
++    CallRuntime(Runtime::kPromiseHookInit, context, throwaway, wrapped_value);
++    Goto(&next);
++    BIND(&next);
++  }
++
++  // Perform ! Call(promiseCapability.[[Resolve]], undefined, « promise »).
++  CallBuiltin(Builtins::kResolvePromise, context, wrapped_value, value);
++
++  // The Promise will be thrown away and not handled, but it shouldn't trigger
++  // unhandled reject events as its work is done
++  PromiseSetHasHandler(throwaway);
++
++  Label do_perform_promise_then(this);
++  GotoIfNot(IsDebugActive(), &do_perform_promise_then);
++  {
++    Label common(this);
++    GotoIf(TaggedIsSmi(value), &common);
++    GotoIfNot(HasInstanceType(value, JS_PROMISE_TYPE), &common);
++    {
++      // Mark the reject handler callback to be a forwarding edge, rather
++      // than a meaningful catch handler
++      Node* const key =
++          HeapConstant(factory()->promise_forwarding_handler_symbol());
++      CallRuntime(Runtime::kSetProperty, context, on_reject, key,
++                  TrueConstant(), SmiConstant(LanguageMode::kStrict));
++
++      GotoIf(IsFalse(is_predicted_as_caught), &common);
++      PromiseSetHandledHint(value);
++    }
++
++    Goto(&common);
++    BIND(&common);
++    // Mark the dependency to outer Promise in case the throwaway Promise is
++    // found on the Promise stack
++    CSA_SLOW_ASSERT(this, HasInstanceType(outer_promise, JS_PROMISE_TYPE));
++
++    Node* const key = HeapConstant(factory()->promise_handled_by_symbol());
++    CallRuntime(Runtime::kSetProperty, context, throwaway, key, outer_promise,
++                SmiConstant(LanguageMode::kStrict));
++  }
++
++  Goto(&do_perform_promise_then);
++  BIND(&do_perform_promise_then);
++  return CallBuiltin(Builtins::kPerformPromiseThen, context, wrapped_value,
++                     on_resolve, on_reject, throwaway);
++}
++
++void AsyncBuiltinsAssembler::InitializeNativeClosure(Node* context,
++                                                     Node* native_context,
++                                                     Node* function,
++                                                     Node* context_index) {
++  Node* const function_map = LoadContextElement(
++      native_context, Context::STRICT_FUNCTION_WITHOUT_PROTOTYPE_MAP_INDEX);
++  // Ensure that we don't have to initialize prototype_or_initial_map field of
++  // JSFunction.
++  CSA_ASSERT(this, WordEqual(LoadMapInstanceSizeInWords(function_map),
++                             IntPtrConstant(JSFunction::kSizeWithoutPrototype /
++                                            kPointerSize)));
++  STATIC_ASSERT(JSFunction::kSizeWithoutPrototype == 7 * kPointerSize);
++  StoreMapNoWriteBarrier(function, function_map);
++  StoreObjectFieldRoot(function, JSObject::kPropertiesOrHashOffset,
++                       Heap::kEmptyFixedArrayRootIndex);
++  StoreObjectFieldRoot(function, JSObject::kElementsOffset,
++                       Heap::kEmptyFixedArrayRootIndex);
++  StoreObjectFieldRoot(function, JSFunction::kFeedbackCellOffset,
++                       Heap::kManyClosuresCellRootIndex);
++
++  Node* shared_info = LoadContextElement(native_context, context_index);
++  CSA_ASSERT(this, IsSharedFunctionInfo(shared_info));
++  StoreObjectFieldNoWriteBarrier(
++      function, JSFunction::kSharedFunctionInfoOffset, shared_info);
++  StoreObjectFieldNoWriteBarrier(function, JSFunction::kContextOffset, context);
++
++  Node* const code = GetSharedFunctionInfoCode(shared_info);
++  StoreObjectFieldNoWriteBarrier(function, JSFunction::kCodeOffset, code);
++}
++
+ Node* AsyncBuiltinsAssembler::CreateUnwrapClosure(Node* native_context,
+                                                   Node* done) {
+   Node* const map = LoadContextElement(
+diff --git a/src/builtins/builtins-async-gen.h b/src/builtins/builtins-async-gen.h
+index 70f68a498b..45d7c8689a 100644
+--- a/src/builtins/builtins-async-gen.h
++++ b/src/builtins/builtins-async-gen.h
+@@ -16,23 +16,48 @@ class AsyncBuiltinsAssembler : public PromiseBuiltinsAssembler {
+       : PromiseBuiltinsAssembler(state) {}
+
+  protected:
+-  void Await(Node* context, Node* generator, Node* value, Node* outer_promise,
+-             Builtins::Name fulfill_builtin, Builtins::Name reject_builtin,
+-             Node* is_predicted_as_caught);
+-  void Await(Node* context, Node* generator, Node* value, Node* outer_promise,
+-             Builtins::Name fulfill_builtin, Builtins::Name reject_builtin,
+-             bool is_predicted_as_caught);
++  typedef std::function<void(Node*)> ContextInitializer;
++
++  // Perform steps to resume generator after `value` is resolved.
++  // `on_reject_context_index` is an index into the Native Context, which should
++  // point to a SharedFunctioninfo instance used to create the closure. The
++  // value following the reject index should be a similar value for the resolve
++  // closure. Returns the Promise-wrapped `value`.
++  Node* Await(Node* context, Node* generator, Node* value, Node* outer_promise,
++              int context_length,
++              const ContextInitializer& init_closure_context,
++              Node* on_resolve_context_index, Node* on_reject_context_index,
++              Node* is_predicted_as_caught);
++  Node* Await(Node* context, Node* generator, Node* value, Node* outer_promise,
++              int context_length,
++              const ContextInitializer& init_closure_context,
++              int on_resolve_context_index, int on_reject_context_index,
++              Node* is_predicted_as_caught) {
++    return Await(context, generator, value, outer_promise, context_length,
++                 init_closure_context, IntPtrConstant(on_resolve_context_index),
++                 IntPtrConstant(on_reject_context_index),
++                 is_predicted_as_caught);
++  }
++  Node* Await(Node* context, Node* generator, Node* value, Node* outer_promise,
++              int context_length,
++              const ContextInitializer& init_closure_context,
++              int on_resolve_context_index, int on_reject_context_index,
++              bool is_predicted_as_caught) {
++    return Await(context, generator, value, outer_promise, context_length,
++                 init_closure_context, on_resolve_context_index,
++                 on_reject_context_index,
++                 BooleanConstant(is_predicted_as_caught));
++  }
+
+   // Return a new built-in function object as defined in
+   // Async Iterator Value Unwrap Functions
+   Node* CreateUnwrapClosure(Node* const native_context, Node* const done);
+
+  private:
++  void InitializeNativeClosure(Node* context, Node* native_context,
++                               Node* function, Node* context_index);
+   Node* AllocateAsyncIteratorValueUnwrapContext(Node* native_context,
+                                                 Node* done);
+-  Node* AllocateAwaitPromiseJobTask(Node* generator, Node* fulfill_handler,
+-                                    Node* reject_handler, Node* promise,
+-                                    Node* context);
+ };
+
+ }  // namespace internal
+diff --git a/src/builtins/builtins-async-generator-gen.cc b/src/builtins/builtins-async-generator-gen.cc
+index 290252da62..dd6c644196 100644
+--- a/src/builtins/builtins-async-generator-gen.cc
++++ b/src/builtins/builtins-async-generator-gen.cc
+@@ -140,8 +140,8 @@ class AsyncGeneratorBuiltinsAssembler : public AsyncBuiltinsAssembler {
+   // for AsyncGenerators.
+   template <typename Descriptor>
+   void AsyncGeneratorAwait(bool is_catchable);
+-  void AsyncGeneratorAwaitResume(
+-      Node* context, Node* generator, Node* argument,
++  void AsyncGeneratorAwaitResumeClosure(
++      Node* context, Node* value,
+       JSAsyncGeneratorObject::ResumeMode resume_mode);
+ };
+
+@@ -219,9 +219,11 @@ Node* AsyncGeneratorBuiltinsAssembler::AllocateAsyncGeneratorRequest(
+   return request;
+ }
+
+-void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwaitResume(
+-    Node* context, Node* generator, Node* argument,
++void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwaitResumeClosure(
++    Node* context, Node* value,
+     JSAsyncGeneratorObject::ResumeMode resume_mode) {
++  Node* const generator =
++      LoadContextElement(context, AwaitContext::kGeneratorSlot);
+   CSA_SLOW_ASSERT(this, TaggedIsAsyncGenerator(generator));
+
+   SetGeneratorNotAwaiting(generator);
+@@ -233,30 +235,36 @@ void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwaitResume(
+                                  JSGeneratorObject::kResumeModeOffset,
+                                  SmiConstant(resume_mode));
+
+-  CallStub(CodeFactory::ResumeGenerator(isolate()), context, argument,
+-           generator);
++  CallStub(CodeFactory::ResumeGenerator(isolate()), context, value, generator);
+
+   TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
+ }
+
+ template <typename Descriptor>
+ void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwait(bool is_catchable) {
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const value = Parameter(Descriptor::kValue);
+-  Node* const context = Parameter(Descriptor::kContext);
++  Node* generator = Parameter(Descriptor::kGenerator);
++  Node* value = Parameter(Descriptor::kAwaited);
++  Node* context = Parameter(Descriptor::kContext);
+
+   CSA_SLOW_ASSERT(this, TaggedIsAsyncGenerator(generator));
+
+   Node* const request = LoadFirstAsyncGeneratorRequestFromQueue(generator);
+   CSA_ASSERT(this, IsNotUndefined(request));
+
++  ContextInitializer init_closure_context = [&](Node* context) {
++    StoreContextElementNoWriteBarrier(context, AwaitContext::kGeneratorSlot,
++                                      generator);
++  };
++
+   Node* outer_promise =
+       LoadObjectField(request, AsyncGeneratorRequest::kPromiseOffset);
+
++  const int resolve_index = Context::ASYNC_GENERATOR_AWAIT_RESOLVE_SHARED_FUN;
++  const int reject_index = Context::ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN;
++
+   SetGeneratorAwaiting(generator);
+-  Await(context, generator, value, outer_promise,
+-        Builtins::kAsyncGeneratorAwaitFulfill,
+-        Builtins::kAsyncGeneratorAwaitReject, is_catchable);
++  Await(context, generator, value, outer_promise, AwaitContext::kLength,
++        init_closure_context, resolve_index, reject_index, is_catchable);
+   Return(UndefinedConstant());
+ }
+
+@@ -367,20 +375,18 @@ TF_BUILTIN(AsyncGeneratorPrototypeThrow, AsyncGeneratorBuiltinsAssembler) {
+                         "[AsyncGenerator].prototype.throw");
+ }
+
+-TF_BUILTIN(AsyncGeneratorAwaitFulfill, AsyncGeneratorBuiltinsAssembler) {
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const argument = Parameter(Descriptor::kArgument);
+-  Node* const context = Parameter(Descriptor::kContext);
+-  AsyncGeneratorAwaitResume(context, generator, argument,
+-                            JSAsyncGeneratorObject::kNext);
++TF_BUILTIN(AsyncGeneratorAwaitResolveClosure, AsyncGeneratorBuiltinsAssembler) {
++  Node* value = Parameter(Descriptor::kValue);
++  Node* context = Parameter(Descriptor::kContext);
++  AsyncGeneratorAwaitResumeClosure(context, value,
++                                   JSAsyncGeneratorObject::kNext);
+ }
+
+-TF_BUILTIN(AsyncGeneratorAwaitReject, AsyncGeneratorBuiltinsAssembler) {
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const argument = Parameter(Descriptor::kArgument);
+-  Node* const context = Parameter(Descriptor::kContext);
+-  AsyncGeneratorAwaitResume(context, generator, argument,
+-                            JSAsyncGeneratorObject::kThrow);
++TF_BUILTIN(AsyncGeneratorAwaitRejectClosure, AsyncGeneratorBuiltinsAssembler) {
++  Node* value = Parameter(Descriptor::kValue);
++  Node* context = Parameter(Descriptor::kContext);
++  AsyncGeneratorAwaitResumeClosure(context, value,
++                                   JSAsyncGeneratorObject::kThrow);
+ }
+
+ TF_BUILTIN(AsyncGeneratorAwaitUncaught, AsyncGeneratorBuiltinsAssembler) {
+@@ -518,34 +524,11 @@ TF_BUILTIN(AsyncGeneratorResolve, AsyncGeneratorBuiltinsAssembler) {
+                                    done);
+   }
+
+-  // We know that {iter_result} itself doesn't have any "then" property and
+-  // we also know that the [[Prototype]] of {iter_result} is the intrinsic
+-  // %ObjectPrototype%. So we can skip the [[Resolve]] logic here completely
+-  // and directly call into the FulfillPromise operation if we can prove
+-  // that the %ObjectPrototype% also doesn't have any "then" property. This
+-  // is guarded by the Promise#then protector.
+-  Label if_fast(this), if_slow(this, Label::kDeferred), return_promise(this);
+-  GotoIfForceSlowPath(&if_slow);
+-  Branch(IsPromiseThenProtectorCellInvalid(), &if_slow, &if_fast);
+-
+-  BIND(&if_fast);
+-  {
+-    // Skip the "then" on {iter_result} and directly fulfill the {promise}
+-    // with the {iter_result}.
+-    CallBuiltin(Builtins::kFulfillPromise, context, promise, iter_result);
+-    Goto(&return_promise);
+-  }
+-
+-  BIND(&if_slow);
+-  {
+-    // Perform Call(promiseCapability.[[Resolve]], undefined, «iteratorResult»).
+-    CallBuiltin(Builtins::kResolvePromise, context, promise, iter_result);
+-    Goto(&return_promise);
+-  }
++  // Perform Call(promiseCapability.[[Resolve]], undefined, «iteratorResult»).
++  CallBuiltin(Builtins::kResolvePromise, context, promise, iter_result);
+
+   // Per spec, AsyncGeneratorResolve() returns undefined. However, for the
+   // benefit of %TraceExit(), return the Promise.
+-  BIND(&return_promise);
+   Return(promise);
+ }
+
+@@ -571,54 +554,31 @@ TF_BUILTIN(AsyncGeneratorYield, AsyncGeneratorBuiltinsAssembler) {
+   Node* const request = LoadFirstAsyncGeneratorRequestFromQueue(generator);
+   Node* const outer_promise = LoadPromiseFromAsyncGeneratorRequest(request);
+
+-  // Mark the generator as "awaiting".
+-  SetGeneratorAwaiting(generator);
++  ContextInitializer init_closure_context = [&](Node* context) {
++    StoreContextElementNoWriteBarrier(context, AwaitContext::kGeneratorSlot,
++                                      generator);
++  };
+
+-  // We can skip the creation of a temporary promise and the whole
+-  // [[Resolve]] logic if we already know that the {value} that's
+-  // being yielded is a primitive, as in that case we would immediately
+-  // fulfill the temporary promise anyways and schedule a fulfill
+-  // reaction job. This gives a nice performance boost for async
+-  // generators that yield only primitives, e.g. numbers or strings.
+-  Label if_primitive(this), if_generic(this);
+-  GotoIfForceSlowPath(&if_generic);
+-  GotoIf(IsPromiseHookEnabledOrDebugIsActive(), &if_generic);
+-  GotoIf(TaggedIsSmi(value), &if_primitive);
+-  Branch(IsJSReceiver(value), &if_generic, &if_primitive);
+-
+-  BIND(&if_generic);
+-  {
+-    Await(context, generator, value, outer_promise,
+-          Builtins::kAsyncGeneratorYieldFulfill,
+-          Builtins::kAsyncGeneratorAwaitReject, is_caught);
+-    Return(UndefinedConstant());
+-  }
++  const int on_resolve = Context::ASYNC_GENERATOR_YIELD_RESOLVE_SHARED_FUN;
++  const int on_reject = Context::ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN;
+
+-  BIND(&if_primitive);
+-  {
+-    // For primitive {value}s we can skip the allocation of the temporary
+-    // promise and the resolution of that, and directly allocate the fulfill
+-    // reaction job.
+-    Node* const microtask = AllocatePromiseReactionJobTask(
+-        Heap::kPromiseFulfillReactionJobTaskMapRootIndex, context, value,
+-        HeapConstant(Builtins::CallableFor(
+-                         isolate(), Builtins::kAsyncGeneratorYieldFulfill)
+-                         .code()),
+-        generator);
+-    TailCallBuiltin(Builtins::kEnqueueMicrotask, context, microtask);
+-  }
++  SetGeneratorAwaiting(generator);
++  Await(context, generator, value, outer_promise, AwaitContext::kLength,
++        init_closure_context, on_resolve, on_reject, is_caught);
++  Return(UndefinedConstant());
+ }
+
+-TF_BUILTIN(AsyncGeneratorYieldFulfill, AsyncGeneratorBuiltinsAssembler) {
++TF_BUILTIN(AsyncGeneratorYieldResolveClosure, AsyncGeneratorBuiltinsAssembler) {
+   Node* const context = Parameter(Descriptor::kContext);
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const argument = Parameter(Descriptor::kArgument);
++  Node* const value = Parameter(Descriptor::kValue);
++  Node* const generator =
++      LoadContextElement(context, AwaitContext::kGeneratorSlot);
+
+   SetGeneratorNotAwaiting(generator);
+
+   // Per proposal-async-iteration/#sec-asyncgeneratoryield step 9
+   // Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *false*).
+-  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, argument,
++  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, value,
+               FalseConstant());
+
+   TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
+@@ -644,33 +604,39 @@ TF_BUILTIN(AsyncGeneratorReturn, AsyncGeneratorBuiltinsAssembler) {
+   Node* const generator = Parameter(Descriptor::kGenerator);
+   Node* const value = Parameter(Descriptor::kValue);
+   Node* const is_caught = Parameter(Descriptor::kIsCaught);
+-  Node* const context = Parameter(Descriptor::kContext);
+   Node* const req = LoadFirstAsyncGeneratorRequestFromQueue(generator);
+-  Node* const outer_promise = LoadPromiseFromAsyncGeneratorRequest(req);
+   CSA_ASSERT(this, IsNotUndefined(req));
+
+-  Label if_closed(this, Label::kDeferred), if_not_closed(this), done(this);
++  Label perform_await(this);
++  VARIABLE(var_on_resolve, MachineType::PointerRepresentation(),
++           IntPtrConstant(
++               Context::ASYNC_GENERATOR_RETURN_CLOSED_RESOLVE_SHARED_FUN));
++  VARIABLE(
++      var_on_reject, MachineType::PointerRepresentation(),
++      IntPtrConstant(Context::ASYNC_GENERATOR_RETURN_CLOSED_REJECT_SHARED_FUN));
++
+   Node* const state = LoadGeneratorState(generator);
+-  SetGeneratorAwaiting(generator);
+-  Branch(IsGeneratorStateClosed(state), &if_closed, &if_not_closed);
++  GotoIf(IsGeneratorStateClosed(state), &perform_await);
++  var_on_resolve.Bind(
++      IntPtrConstant(Context::ASYNC_GENERATOR_RETURN_RESOLVE_SHARED_FUN));
++  var_on_reject.Bind(
++      IntPtrConstant(Context::ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN));
++  Goto(&perform_await);
+
+-  BIND(&if_closed);
+-  {
+-    Await(context, generator, value, outer_promise,
+-          Builtins::kAsyncGeneratorReturnClosedFulfill,
+-          Builtins::kAsyncGeneratorReturnClosedReject, is_caught);
+-    Goto(&done);
+-  }
++  BIND(&perform_await);
+
+-  BIND(&if_not_closed);
+-  {
+-    Await(context, generator, value, outer_promise,
+-          Builtins::kAsyncGeneratorReturnFulfill,
+-          Builtins::kAsyncGeneratorAwaitReject, is_caught);
+-    Goto(&done);
+-  }
++  ContextInitializer init_closure_context = [&](Node* context) {
++    StoreContextElementNoWriteBarrier(context, AwaitContext::kGeneratorSlot,
++                                      generator);
++  };
++
++  SetGeneratorAwaiting(generator);
++  Node* const context = Parameter(Descriptor::kContext);
++  Node* const outer_promise = LoadPromiseFromAsyncGeneratorRequest(req);
++  Await(context, generator, value, outer_promise, AwaitContext::kLength,
++        init_closure_context, var_on_resolve.value(), var_on_reject.value(),
++        is_caught);
+
+-  BIND(&done);
+   Return(UndefinedConstant());
+ }
+
+@@ -678,44 +644,47 @@ TF_BUILTIN(AsyncGeneratorReturn, AsyncGeneratorBuiltinsAssembler) {
+ // Resume the generator with "return" resume_mode, and finally perform
+ // AsyncGeneratorResumeNext. Per
+ // proposal-async-iteration/#sec-asyncgeneratoryield step 8.e
+-TF_BUILTIN(AsyncGeneratorReturnFulfill, AsyncGeneratorBuiltinsAssembler) {
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const argument = Parameter(Descriptor::kArgument);
++TF_BUILTIN(AsyncGeneratorReturnResolveClosure,
++           AsyncGeneratorBuiltinsAssembler) {
+   Node* const context = Parameter(Descriptor::kContext);
+-  AsyncGeneratorAwaitResume(context, generator, argument,
+-                            JSGeneratorObject::kReturn);
++  Node* const value = Parameter(Descriptor::kValue);
++  AsyncGeneratorAwaitResumeClosure(context, value, JSGeneratorObject::kReturn);
+ }
+
+ // On-resolve closure for Await in AsyncGeneratorReturn
+ // Perform AsyncGeneratorResolve({awaited_value}, true) and finally perform
+ // AsyncGeneratorResumeNext.
+-TF_BUILTIN(AsyncGeneratorReturnClosedFulfill, AsyncGeneratorBuiltinsAssembler) {
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const argument = Parameter(Descriptor::kArgument);
++TF_BUILTIN(AsyncGeneratorReturnClosedResolveClosure,
++           AsyncGeneratorBuiltinsAssembler) {
+   Node* const context = Parameter(Descriptor::kContext);
++  Node* const value = Parameter(Descriptor::kValue);
++  Node* const generator =
++      LoadContextElement(context, AwaitContext::kGeneratorSlot);
+
+   SetGeneratorNotAwaiting(generator);
+
+   // https://tc39.github.io/proposal-async-iteration/
+   //    #async-generator-resume-next-return-processor-fulfilled step 2:
+   //  Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
+-  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, argument,
++  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, value,
+               TrueConstant());
+
+   TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
+ }
+
+-TF_BUILTIN(AsyncGeneratorReturnClosedReject, AsyncGeneratorBuiltinsAssembler) {
+-  Node* const generator = Parameter(Descriptor::kGenerator);
+-  Node* const argument = Parameter(Descriptor::kArgument);
++TF_BUILTIN(AsyncGeneratorReturnClosedRejectClosure,
++           AsyncGeneratorBuiltinsAssembler) {
+   Node* const context = Parameter(Descriptor::kContext);
++  Node* const value = Parameter(Descriptor::kValue);
++  Node* const generator =
++      LoadContextElement(context, AwaitContext::kGeneratorSlot);
+
+   SetGeneratorNotAwaiting(generator);
+
+   // https://tc39.github.io/proposal-async-iteration/
+   //    #async-generator-resume-next-return-processor-rejected step 2:
+   // Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
+-  CallBuiltin(Builtins::kAsyncGeneratorReject, context, generator, argument);
++  CallBuiltin(Builtins::kAsyncGeneratorReject, context, generator, value);
+
+   TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
+ }
+diff --git a/src/builtins/builtins-definitions.h b/src/builtins/builtins-definitions.h
+index d0ef062903..7daaa69f8d 100644
+--- a/src/builtins/builtins-definitions.h
++++ b/src/builtins/builtins-definitions.h
+@@ -375,10 +375,10 @@ namespace internal {
+   CPP(ArrayBufferPrototypeSlice)                                               \
+                                                                                \
+   /* AsyncFunction */                                                          \
+-  TFC(AsyncFunctionAwaitFulfill, PromiseReactionHandler, 1)                    \
+-  TFC(AsyncFunctionAwaitReject, PromiseReactionHandler, 1)                     \
+-  TFS(AsyncFunctionAwaitCaught, kGenerator, kValue, kOuterPromise)             \
+-  TFS(AsyncFunctionAwaitUncaught, kGenerator, kValue, kOuterPromise)           \
++  TFJ(AsyncFunctionAwaitCaught, 3, kGenerator, kAwaited, kOuterPromise)        \
++  TFJ(AsyncFunctionAwaitUncaught, 3, kGenerator, kAwaited, kOuterPromise)      \
++  TFJ(AsyncFunctionAwaitRejectClosure, 1, kSentError)                          \
++  TFJ(AsyncFunctionAwaitResolveClosure, 1, kSentValue)                         \
+   TFJ(AsyncFunctionPromiseCreate, 0)                                           \
+   TFJ(AsyncFunctionPromiseRelease, 1, kPromise)                                \
+                                                                                \
+@@ -835,8 +835,8 @@ namespace internal {
+   /* ES #sec-promise.prototype.catch */                                        \
+   TFJ(PromisePrototypeCatch, 1, kOnRejected)                                   \
+   /* ES #sec-promisereactionjob */                                             \
+-  TFS(PromiseRejectReactionJob, kReason, kHandler, kPayload)                   \
+-  TFS(PromiseFulfillReactionJob, kValue, kHandler, kPayload)                   \
++  TFS(PromiseRejectReactionJob, kReason, kHandler, kPromiseOrCapability)       \
++  TFS(PromiseFulfillReactionJob, kValue, kHandler, kPromiseOrCapability)       \
+   /* ES #sec-promiseresolvethenablejob */                                      \
+   TFS(PromiseResolveThenableJob, kPromiseToResolve, kThenable, kThen)          \
+   /* ES #sec-promise.resolve */                                                \
+@@ -1203,17 +1203,6 @@ namespace internal {
+                                                                                \
+   /* AsyncGenerator */                                                         \
+                                                                                \
+-  /* Await (proposal-async-iteration/#await), with resume behaviour */         \
+-  /* specific to Async Generators. Internal / Not exposed to JS code. */       \
+-  TFS(AsyncGeneratorAwaitCaught, kGenerator, kValue)                           \
+-  TFS(AsyncGeneratorAwaitUncaught, kGenerator, kValue)                         \
+-  TFC(AsyncGeneratorAwaitFulfill, PromiseReactionHandler, 1)                   \
+-  TFC(AsyncGeneratorAwaitReject, PromiseReactionHandler, 1)                    \
+-  TFC(AsyncGeneratorYieldFulfill, PromiseReactionHandler, 1)                   \
+-  TFC(AsyncGeneratorReturnClosedFulfill, PromiseReactionHandler, 1)            \
+-  TFC(AsyncGeneratorReturnClosedReject, PromiseReactionHandler, 1)             \
+-  TFC(AsyncGeneratorReturnFulfill, PromiseReactionHandler, 1)                  \
+-                                                                               \
+   TFS(AsyncGeneratorResolve, kGenerator, kValue, kDone)                        \
+   TFS(AsyncGeneratorReject, kGenerator, kValue)                                \
+   TFS(AsyncGeneratorYield, kGenerator, kValue, kIsCaught)                      \
+@@ -1236,6 +1225,17 @@ namespace internal {
+   TFJ(AsyncGeneratorPrototypeThrow,                                            \
+       SharedFunctionInfo::kDontAdaptArgumentsSentinel)                         \
+                                                                                \
++  /* Await (proposal-async-iteration/#await), with resume behaviour */         \
++  /* specific to Async Generators. Internal / Not exposed to JS code. */       \
++  TFJ(AsyncGeneratorAwaitCaught, 2, kGenerator, kAwaited)                      \
++  TFJ(AsyncGeneratorAwaitUncaught, 2, kGenerator, kAwaited)                    \
++  TFJ(AsyncGeneratorAwaitResolveClosure, 1, kValue)                            \
++  TFJ(AsyncGeneratorAwaitRejectClosure, 1, kValue)                             \
++  TFJ(AsyncGeneratorYieldResolveClosure, 1, kValue)                            \
++  TFJ(AsyncGeneratorReturnClosedResolveClosure, 1, kValue)                     \
++  TFJ(AsyncGeneratorReturnClosedRejectClosure, 1, kValue)                      \
++  TFJ(AsyncGeneratorReturnResolveClosure, 1, kValue)                           \
++                                                                               \
+   /* Async-from-Sync Iterator */                                               \
+                                                                                \
+   /* %AsyncFromSyncIteratorPrototype% */                                       \
+@@ -1311,7 +1311,11 @@ namespace internal {
+   V(AsyncFromSyncIteratorPrototypeNext)              \
+   V(AsyncFromSyncIteratorPrototypeReturn)            \
+   V(AsyncFromSyncIteratorPrototypeThrow)             \
++  V(AsyncFunctionAwaitCaught)                        \
++  V(AsyncFunctionAwaitUncaught)                      \
+   V(AsyncGeneratorResolve)                           \
++  V(AsyncGeneratorAwaitCaught)                       \
++  V(AsyncGeneratorAwaitUncaught)                     \
+   V(PromiseAll)                                      \
+   V(PromiseConstructor)                              \
+   V(PromiseConstructorLazyDeoptContinuation)         \
+diff --git a/src/builtins/builtins-internal-gen.cc b/src/builtins/builtins-internal-gen.cc
+index 5c3842761e..c1bf7df2ec 100644
+--- a/src/builtins/builtins-internal-gen.cc
++++ b/src/builtins/builtins-internal-gen.cc
+@@ -669,7 +669,7 @@ class InternalBuiltinsAssembler : public CodeStubAssembler {
+   void LeaveMicrotaskContext();
+
+   void RunPromiseHook(Runtime::FunctionId id, TNode<Context> context,
+-                      SloppyTNode<HeapObject> payload);
++                      SloppyTNode<HeapObject> promise_or_capability);
+
+   TNode<Object> GetPendingException() {
+     auto ref = ExternalReference::Create(kPendingExceptionAddress, isolate());
+@@ -790,12 +790,20 @@ void InternalBuiltinsAssembler::LeaveMicrotaskContext() {
+
+ void InternalBuiltinsAssembler::RunPromiseHook(
+     Runtime::FunctionId id, TNode<Context> context,
+-    SloppyTNode<HeapObject> payload) {
++    SloppyTNode<HeapObject> promise_or_capability) {
+   Label hook(this, Label::kDeferred), done_hook(this);
+   Branch(IsPromiseHookEnabledOrDebugIsActive(), &hook, &done_hook);
+   BIND(&hook);
+   {
+-    CallRuntime(id, context, payload);
++    // Get to the underlying JSPromise instance.
++    Node* const promise = Select<HeapObject>(
++        IsJSPromise(promise_or_capability),
++        [=] { return promise_or_capability; },
++        [=] {
++          return CAST(LoadObjectField(promise_or_capability,
++                                      PromiseCapability::kPromiseOffset));
++        });
++    CallRuntime(id, context, promise);
+     Goto(&done_hook);
+   }
+   BIND(&done_hook);
+@@ -1008,19 +1016,21 @@ TF_BUILTIN(RunMicrotasks, InternalBuiltinsAssembler) {
+             LoadObjectField(microtask, PromiseReactionJobTask::kArgumentOffset);
+         Node* const handler =
+             LoadObjectField(microtask, PromiseReactionJobTask::kHandlerOffset);
+-        Node* const payload =
+-            LoadObjectField(microtask, PromiseReactionJobTask::kPayloadOffset);
++        Node* const promise_or_capability = LoadObjectField(
++            microtask, PromiseReactionJobTask::kPromiseOrCapabilityOffset);
+
+         // Run the promise before/debug hook if enabled.
+-        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context, payload);
++        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context,
++                       promise_or_capability);
+
+         Node* const result =
+             CallBuiltin(Builtins::kPromiseFulfillReactionJob, microtask_context,
+-                        argument, handler, payload);
++                        argument, handler, promise_or_capability);
+         GotoIfException(result, &if_exception, &var_exception);
+
+         // Run the promise after/debug hook if enabled.
+-        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context, payload);
++        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context,
++                       promise_or_capability);
+
+         LeaveMicrotaskContext();
+         SetCurrentContext(current_context);
+@@ -1041,19 +1051,21 @@ TF_BUILTIN(RunMicrotasks, InternalBuiltinsAssembler) {
+             LoadObjectField(microtask, PromiseReactionJobTask::kArgumentOffset);
+         Node* const handler =
+             LoadObjectField(microtask, PromiseReactionJobTask::kHandlerOffset);
+-        Node* const payload =
+-            LoadObjectField(microtask, PromiseReactionJobTask::kPayloadOffset);
++        Node* const promise_or_capability = LoadObjectField(
++            microtask, PromiseReactionJobTask::kPromiseOrCapabilityOffset);
+
+         // Run the promise before/debug hook if enabled.
+-        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context, payload);
++        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context,
++                       promise_or_capability);
+
+         Node* const result =
+             CallBuiltin(Builtins::kPromiseRejectReactionJob, microtask_context,
+-                        argument, handler, payload);
++                        argument, handler, promise_or_capability);
+         GotoIfException(result, &if_exception, &var_exception);
+
+         // Run the promise after/debug hook if enabled.
+-        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context, payload);
++        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context,
++                       promise_or_capability);
+
+         LeaveMicrotaskContext();
+         SetCurrentContext(current_context);
+diff --git a/src/builtins/builtins-promise-gen.cc b/src/builtins/builtins-promise-gen.cc
+index dd38dbc543..868b45a831 100644
+--- a/src/builtins/builtins-promise-gen.cc
++++ b/src/builtins/builtins-promise-gen.cc
+@@ -391,15 +391,15 @@ TF_BUILTIN(PerformPromiseThen, PromiseBuiltinsAssembler) {
+   Return(result_promise);
+ }
+
+-Node* PromiseBuiltinsAssembler::AllocatePromiseReaction(Node* next,
+-                                                        Node* payload,
+-                                                        Node* fulfill_handler,
+-                                                        Node* reject_handler) {
++Node* PromiseBuiltinsAssembler::AllocatePromiseReaction(
++    Node* next, Node* promise_or_capability, Node* fulfill_handler,
++    Node* reject_handler) {
+   Node* const reaction = Allocate(PromiseReaction::kSize);
+   StoreMapNoWriteBarrier(reaction, Heap::kPromiseReactionMapRootIndex);
+   StoreObjectFieldNoWriteBarrier(reaction, PromiseReaction::kNextOffset, next);
+-  StoreObjectFieldNoWriteBarrier(reaction, PromiseReaction::kPayloadOffset,
+-                                 payload);
++  StoreObjectFieldNoWriteBarrier(reaction,
++                                 PromiseReaction::kPromiseOrCapabilityOffset,
++                                 promise_or_capability);
+   StoreObjectFieldNoWriteBarrier(
+       reaction, PromiseReaction::kFulfillHandlerOffset, fulfill_handler);
+   StoreObjectFieldNoWriteBarrier(
+@@ -408,7 +408,8 @@ Node* PromiseBuiltinsAssembler::AllocatePromiseReaction(Node* next,
+ }
+
+ Node* PromiseBuiltinsAssembler::AllocatePromiseReactionJobTask(
+-    Node* map, Node* context, Node* argument, Node* handler, Node* payload) {
++    Node* map, Node* context, Node* argument, Node* handler,
++    Node* promise_or_capability) {
+   Node* const microtask = Allocate(PromiseReactionJobTask::kSize);
+   StoreMapNoWriteBarrier(microtask, map);
+   StoreObjectFieldNoWriteBarrier(
+@@ -418,18 +419,19 @@ Node* PromiseBuiltinsAssembler::AllocatePromiseReactionJobTask(
+   StoreObjectFieldNoWriteBarrier(
+       microtask, PromiseReactionJobTask::kHandlerOffset, handler);
+   StoreObjectFieldNoWriteBarrier(
+-      microtask, PromiseReactionJobTask::kPayloadOffset, payload);
++      microtask, PromiseReactionJobTask::kPromiseOrCapabilityOffset,
++      promise_or_capability);
+   return microtask;
+ }
+
+ Node* PromiseBuiltinsAssembler::AllocatePromiseReactionJobTask(
+     Heap::RootListIndex map_root_index, Node* context, Node* argument,
+-    Node* handler, Node* payload) {
++    Node* handler, Node* promise_or_capability) {
+   DCHECK(map_root_index == Heap::kPromiseFulfillReactionJobTaskMapRootIndex ||
+          map_root_index == Heap::kPromiseRejectReactionJobTaskMapRootIndex);
+   Node* const map = LoadRoot(map_root_index);
+   return AllocatePromiseReactionJobTask(map, context, argument, handler,
+-                                        payload);
++                                        promise_or_capability);
+ }
+
+ Node* PromiseBuiltinsAssembler::AllocatePromiseResolveThenableJobTask(
+@@ -502,8 +504,8 @@ Node* PromiseBuiltinsAssembler::TriggerPromiseReactions(
+                          context);
+         STATIC_ASSERT(PromiseReaction::kFulfillHandlerOffset ==
+                       PromiseReactionJobTask::kHandlerOffset);
+-        STATIC_ASSERT(PromiseReaction::kPayloadOffset ==
+-                      PromiseReactionJobTask::kPayloadOffset);
++        STATIC_ASSERT(PromiseReaction::kPromiseOrCapabilityOffset ==
++                      PromiseReactionJobTask::kPromiseOrCapabilityOffset);
+       } else {
+         Node* handler =
+             LoadObjectField(current, PromiseReaction::kRejectHandlerOffset);
+@@ -515,8 +517,8 @@ Node* PromiseBuiltinsAssembler::TriggerPromiseReactions(
+                          context);
+         StoreObjectField(current, PromiseReactionJobTask::kHandlerOffset,
+                          handler);
+-        STATIC_ASSERT(PromiseReaction::kPayloadOffset ==
+-                      PromiseReactionJobTask::kPayloadOffset);
++        STATIC_ASSERT(PromiseReaction::kPromiseOrCapabilityOffset ==
++                      PromiseReactionJobTask::kPromiseOrCapabilityOffset);
+       }
+       CallBuiltin(Builtins::kEnqueueMicrotask, NoContextConstant(), current);
+       Goto(&loop);
+@@ -1118,28 +1120,20 @@ TF_BUILTIN(PromiseResolveThenableJob, PromiseBuiltinsAssembler) {
+
+ // ES #sec-promisereactionjob
+ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
+-                                                  Node* handler, Node* payload,
++                                                  Node* handler,
++                                                  Node* promise_or_capability,
+                                                   PromiseReaction::Type type) {
+   CSA_ASSERT(this, TaggedIsNotSmi(handler));
+-  CSA_ASSERT(this, Word32Or(IsCallable(handler),
+-                            Word32Or(IsCode(handler), IsUndefined(handler))));
+-  CSA_ASSERT(this, TaggedIsNotSmi(payload));
++  CSA_ASSERT(this, Word32Or(IsUndefined(handler), IsCallable(handler)));
++  CSA_ASSERT(this, TaggedIsNotSmi(promise_or_capability));
++  CSA_ASSERT(this, Word32Or(IsJSPromise(promise_or_capability),
++                            IsPromiseCapability(promise_or_capability)));
+
+   VARIABLE(var_handler_result, MachineRepresentation::kTagged, argument);
+-  Label if_handler_callable(this), if_fulfill(this), if_reject(this),
+-      if_code_handler(this);
+-
+-  GotoIf(IsUndefined(handler),
+-         type == PromiseReaction::kFulfill ? &if_fulfill : &if_reject);
+-  Branch(IsCode(handler), &if_code_handler, &if_handler_callable);
+-
+-  BIND(&if_code_handler);
+-  {
+-    // The {handler} is a Code object that knows how to deal with
+-    // the {payload} and the {argument}.
+-    PromiseReactionHandlerDescriptor descriptor(isolate());
+-    TailCallStub(descriptor, handler, context, argument, payload);
+-  }
++  Label if_handler_callable(this), if_fulfill(this), if_reject(this);
++  Branch(IsUndefined(handler),
++         type == PromiseReaction::kFulfill ? &if_fulfill : &if_reject,
++         &if_handler_callable);
+
+   BIND(&if_handler_callable);
+   {
+@@ -1155,22 +1149,24 @@ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
+   {
+     Label if_promise(this), if_promise_capability(this, Label::kDeferred);
+     Node* const value = var_handler_result.value();
+-    Branch(IsPromiseCapability(payload), &if_promise_capability, &if_promise);
++    Branch(IsPromiseCapability(promise_or_capability), &if_promise_capability,
++           &if_promise);
+
+     BIND(&if_promise);
+     {
+       // For fast native promises we can skip the indirection
+       // via the promiseCapability.[[Resolve]] function and
+       // run the resolve logic directly from here.
+-      TailCallBuiltin(Builtins::kResolvePromise, context, payload, value);
++      TailCallBuiltin(Builtins::kResolvePromise, context, promise_or_capability,
++                      value);
+     }
+
+     BIND(&if_promise_capability);
+     {
+       // In the general case we need to call the (user provided)
+       // promiseCapability.[[Resolve]] function.
+-      Node* const resolve =
+-          LoadObjectField(payload, PromiseCapability::kResolveOffset);
++      Node* const resolve = LoadObjectField(promise_or_capability,
++                                            PromiseCapability::kResolveOffset);
+       Node* const result = CallJS(
+           CodeFactory::Call(isolate(), ConvertReceiverMode::kNullOrUndefined),
+           context, resolve, UndefinedConstant(), value);
+@@ -1183,15 +1179,16 @@ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
+   if (type == PromiseReaction::kReject) {
+     Label if_promise(this), if_promise_capability(this, Label::kDeferred);
+     Node* const reason = var_handler_result.value();
+-    Branch(IsPromiseCapability(payload), &if_promise_capability, &if_promise);
++    Branch(IsPromiseCapability(promise_or_capability), &if_promise_capability,
++           &if_promise);
+
+     BIND(&if_promise);
+     {
+       // For fast native promises we can skip the indirection
+       // via the promiseCapability.[[Reject]] function and
+       // run the resolve logic directly from here.
+-      TailCallBuiltin(Builtins::kRejectPromise, context, payload, reason,
+-                      FalseConstant());
++      TailCallBuiltin(Builtins::kRejectPromise, context, promise_or_capability,
++                      reason, FalseConstant());
+     }
+
+     BIND(&if_promise_capability);
+@@ -1201,8 +1198,8 @@ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
+       Label if_exception(this, Label::kDeferred);
+       VARIABLE(var_exception, MachineRepresentation::kTagged,
+                TheHoleConstant());
+-      Node* const reject =
+-          LoadObjectField(payload, PromiseCapability::kRejectOffset);
++      Node* const reject = LoadObjectField(promise_or_capability,
++                                           PromiseCapability::kRejectOffset);
+       Node* const result = CallJS(
+           CodeFactory::Call(isolate(), ConvertReceiverMode::kNullOrUndefined),
+           context, reject, UndefinedConstant(), reason);
+@@ -1219,7 +1216,8 @@ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
+     // predictions in the debugger will be wrong, which just walks the stack
+     // and checks for certain builtins.
+     TailCallBuiltin(Builtins::kPromiseRejectReactionJob, context,
+-                    var_handler_result.value(), UndefinedConstant(), payload);
++                    var_handler_result.value(), UndefinedConstant(),
++                    promise_or_capability);
+   }
+ }
+
+@@ -1228,9 +1226,10 @@ TF_BUILTIN(PromiseFulfillReactionJob, PromiseBuiltinsAssembler) {
+   Node* const context = Parameter(Descriptor::kContext);
+   Node* const value = Parameter(Descriptor::kValue);
+   Node* const handler = Parameter(Descriptor::kHandler);
+-  Node* const payload = Parameter(Descriptor::kPayload);
++  Node* const promise_or_capability =
++      Parameter(Descriptor::kPromiseOrCapability);
+
+-  PromiseReactionJob(context, value, handler, payload,
++  PromiseReactionJob(context, value, handler, promise_or_capability,
+                      PromiseReaction::kFulfill);
+ }
+
+@@ -1239,9 +1238,10 @@ TF_BUILTIN(PromiseRejectReactionJob, PromiseBuiltinsAssembler) {
+   Node* const context = Parameter(Descriptor::kContext);
+   Node* const reason = Parameter(Descriptor::kReason);
+   Node* const handler = Parameter(Descriptor::kHandler);
+-  Node* const payload = Parameter(Descriptor::kPayload);
++  Node* const promise_or_capability =
++      Parameter(Descriptor::kPromiseOrCapability);
+
+-  PromiseReactionJob(context, reason, handler, payload,
++  PromiseReactionJob(context, reason, handler, promise_or_capability,
+                      PromiseReaction::kReject);
+ }
+
+@@ -1717,23 +1717,21 @@ TF_BUILTIN(ResolvePromise, PromiseBuiltinsAssembler) {
+
+   // 7. If Type(resolution) is not Object, then
+   GotoIf(TaggedIsSmi(resolution), &if_fulfill);
+-  Node* const resolution_map = LoadMap(resolution);
+-  GotoIfNot(IsJSReceiverMap(resolution_map), &if_fulfill);
++  Node* const result_map = LoadMap(resolution);
++  GotoIfNot(IsJSReceiverMap(result_map), &if_fulfill);
+
+   // We can skip the "then" lookup on {resolution} if its [[Prototype]]
+   // is the (initial) Promise.prototype and the Promise#then protector
+   // is intact, as that guards the lookup path for the "then" property
+   // on JSPromise instances which have the (initial) %PromisePrototype%.
+-  Label if_fast(this), if_generic(this), if_slow(this, Label::kDeferred);
++  Label if_fast(this), if_slow(this, Label::kDeferred);
+   Node* const native_context = LoadNativeContext(context);
+-  GotoIfForceSlowPath(&if_slow);
+-  GotoIf(IsPromiseThenProtectorCellInvalid(), &if_slow);
+-  GotoIfNot(IsJSPromiseMap(resolution_map), &if_generic);
+-  Node* const promise_prototype =
+-      LoadContextElement(native_context, Context::PROMISE_PROTOTYPE_INDEX);
+-  Branch(WordEqual(LoadMapPrototype(resolution_map), promise_prototype),
+-         &if_fast, &if_slow);
++  BranchIfPromiseThenLookupChainIntact(native_context, result_map, &if_fast,
++                                       &if_slow);
+
++  // Resolution is a native promise and if it's already resolved or
++  // rejected, shortcircuit the resolution procedure by directly
++  // reusing the value from the promise.
+   BIND(&if_fast);
+   {
+     Node* const then =
+@@ -1742,21 +1740,6 @@ TF_BUILTIN(ResolvePromise, PromiseBuiltinsAssembler) {
+     Goto(&do_enqueue);
+   }
+
+-  BIND(&if_generic);
+-  {
+-    // We can skip the lookup of "then" if the {resolution} is a (newly
+-    // created) IterResultObject, as the Promise#then protector also
+-    // ensures that the intrinsic %ObjectPrototype% doesn't contain any
+-    // "then" property. This helps to avoid negative lookups on iterator
+-    // results from async generators.
+-    CSA_ASSERT(this, IsJSReceiverMap(resolution_map));
+-    CSA_ASSERT(this, Word32BinaryNot(IsPromiseThenProtectorCellInvalid()));
+-    Node* const iterator_result_map =
+-        LoadContextElement(native_context, Context::ITERATOR_RESULT_MAP_INDEX);
+-    Branch(WordEqual(resolution_map, iterator_result_map), &if_fulfill,
+-           &if_slow);
+-  }
+-
+   BIND(&if_slow);
+   {
+     // 8. Let then be Get(resolution, "then").
+diff --git a/src/builtins/builtins-promise-gen.h b/src/builtins/builtins-promise-gen.h
+index f21d86a141..694cea28c0 100644
+--- a/src/builtins/builtins-promise-gen.h
++++ b/src/builtins/builtins-promise-gen.h
+@@ -85,14 +85,16 @@ class PromiseBuiltinsAssembler : public CodeStubAssembler {
+   Node* AllocateAndSetJSPromise(Node* context, v8::Promise::PromiseState status,
+                                 Node* result);
+
+-  Node* AllocatePromiseReaction(Node* next, Node* payload,
++  Node* AllocatePromiseReaction(Node* next, Node* promise_or_capability,
+                                 Node* fulfill_handler, Node* reject_handler);
+
+   Node* AllocatePromiseReactionJobTask(Heap::RootListIndex map_root_index,
+                                        Node* context, Node* argument,
+-                                       Node* handler, Node* payload);
++                                       Node* handler,
++                                       Node* promise_or_capability);
+   Node* AllocatePromiseReactionJobTask(Node* map, Node* context, Node* argument,
+-                                       Node* handler, Node* payload);
++                                       Node* handler,
++                                       Node* promise_or_capability);
+   Node* AllocatePromiseResolveThenableJobTask(Node* promise_to_resolve,
+                                               Node* then, Node* thenable,
+                                               Node* context);
+@@ -192,7 +194,8 @@ class PromiseBuiltinsAssembler : public CodeStubAssembler {
+   Node* PromiseStatus(Node* promise);
+
+   void PromiseReactionJob(Node* context, Node* argument, Node* handler,
+-                          Node* payload, PromiseReaction::Type type);
++                          Node* promise_or_capability,
++                          PromiseReaction::Type type);
+
+   Node* IsPromiseStatus(Node* actual, v8::Promise::PromiseState expected);
+   void PromiseSetStatus(Node* promise, v8::Promise::PromiseState status);
+diff --git a/src/compiler/js-intrinsic-lowering.cc b/src/compiler/js-intrinsic-lowering.cc
+index c570a1f8dd..d9742e47d9 100644
+--- a/src/compiler/js-intrinsic-lowering.cc
++++ b/src/compiler/js-intrinsic-lowering.cc
+@@ -41,14 +41,6 @@ Reduction JSIntrinsicLowering::Reduce(Node* node) {
+       return ReduceCreateJSGeneratorObject(node);
+     case Runtime::kInlineGeneratorGetInputOrDebugPos:
+       return ReduceGeneratorGetInputOrDebugPos(node);
+-    case Runtime::kInlineAsyncFunctionAwaitCaught:
+-      return ReduceAsyncFunctionAwaitCaught(node);
+-    case Runtime::kInlineAsyncFunctionAwaitUncaught:
+-      return ReduceAsyncFunctionAwaitUncaught(node);
+-    case Runtime::kInlineAsyncGeneratorAwaitCaught:
+-      return ReduceAsyncGeneratorAwaitCaught(node);
+-    case Runtime::kInlineAsyncGeneratorAwaitUncaught:
+-      return ReduceAsyncGeneratorAwaitUncaught(node);
+     case Runtime::kInlineAsyncGeneratorReject:
+       return ReduceAsyncGeneratorReject(node);
+     case Runtime::kInlineAsyncGeneratorResolve:
+@@ -185,33 +177,6 @@ Reduction JSIntrinsicLowering::ReduceGeneratorGetInputOrDebugPos(Node* node) {
+   return Change(node, op, generator, effect, control);
+ }
+
+-Reduction JSIntrinsicLowering::ReduceAsyncFunctionAwaitCaught(Node* node) {
+-  return Change(
+-      node,
+-      Builtins::CallableFor(isolate(), Builtins::kAsyncFunctionAwaitCaught), 0);
+-}
+-
+-Reduction JSIntrinsicLowering::ReduceAsyncFunctionAwaitUncaught(Node* node) {
+-  return Change(
+-      node,
+-      Builtins::CallableFor(isolate(), Builtins::kAsyncFunctionAwaitUncaught),
+-      0);
+-}
+-
+-Reduction JSIntrinsicLowering::ReduceAsyncGeneratorAwaitCaught(Node* node) {
+-  return Change(
+-      node,
+-      Builtins::CallableFor(isolate(), Builtins::kAsyncGeneratorAwaitCaught),
+-      0);
+-}
+-
+-Reduction JSIntrinsicLowering::ReduceAsyncGeneratorAwaitUncaught(Node* node) {
+-  return Change(
+-      node,
+-      Builtins::CallableFor(isolate(), Builtins::kAsyncGeneratorAwaitUncaught),
+-      0);
+-}
+-
+ Reduction JSIntrinsicLowering::ReduceAsyncGeneratorReject(Node* node) {
+   return Change(
+       node, Builtins::CallableFor(isolate(), Builtins::kAsyncGeneratorReject),
+diff --git a/src/compiler/js-intrinsic-lowering.h b/src/compiler/js-intrinsic-lowering.h
+index fb745986a6..18fe1248c7 100644
+--- a/src/compiler/js-intrinsic-lowering.h
++++ b/src/compiler/js-intrinsic-lowering.h
+@@ -45,10 +45,6 @@ class V8_EXPORT_PRIVATE JSIntrinsicLowering final
+   Reduction ReduceCreateJSGeneratorObject(Node* node);
+   Reduction ReduceGeneratorClose(Node* node);
+   Reduction ReduceGeneratorGetInputOrDebugPos(Node* node);
+-  Reduction ReduceAsyncFunctionAwaitCaught(Node* node);
+-  Reduction ReduceAsyncFunctionAwaitUncaught(Node* node);
+-  Reduction ReduceAsyncGeneratorAwaitCaught(Node* node);
+-  Reduction ReduceAsyncGeneratorAwaitUncaught(Node* node);
+   Reduction ReduceAsyncGeneratorReject(Node* node);
+   Reduction ReduceAsyncGeneratorResolve(Node* node);
+   Reduction ReduceAsyncGeneratorYield(Node* node);
+diff --git a/src/contexts.h b/src/contexts.h
+index 4cfbb29f06..763f30f193 100644
+--- a/src/contexts.h
++++ b/src/contexts.h
+@@ -32,35 +32,44 @@ enum ContextLookupFlags {
+ // must always be allocated via Heap::AllocateContext() or
+ // Factory::NewContext.
+
+-#define NATIVE_CONTEXT_INTRINSIC_FUNCTIONS(V)                           \
+-  V(ASYNC_FUNCTION_PROMISE_CREATE_INDEX, JSFunction,                    \
+-    async_function_promise_create)                                      \
+-  V(ASYNC_FUNCTION_PROMISE_RELEASE_INDEX, JSFunction,                   \
+-    async_function_promise_release)                                     \
+-  V(IS_ARRAYLIKE, JSFunction, is_arraylike)                             \
+-  V(GENERATOR_NEXT_INTERNAL, JSFunction, generator_next_internal)       \
+-  V(MAKE_ERROR_INDEX, JSFunction, make_error)                           \
+-  V(MAKE_RANGE_ERROR_INDEX, JSFunction, make_range_error)               \
+-  V(MAKE_SYNTAX_ERROR_INDEX, JSFunction, make_syntax_error)             \
+-  V(MAKE_TYPE_ERROR_INDEX, JSFunction, make_type_error)                 \
+-  V(MAKE_URI_ERROR_INDEX, JSFunction, make_uri_error)                   \
+-  V(OBJECT_CREATE, JSFunction, object_create)                           \
+-  V(OBJECT_DEFINE_PROPERTIES, JSFunction, object_define_properties)     \
+-  V(OBJECT_DEFINE_PROPERTY, JSFunction, object_define_property)         \
+-  V(OBJECT_GET_PROTOTYPE_OF, JSFunction, object_get_prototype_of)       \
+-  V(OBJECT_IS_SEALED, JSFunction, object_is_sealed)                     \
+-  V(OBJECT_KEYS, JSFunction, object_keys)                               \
+-  V(REGEXP_INTERNAL_MATCH, JSFunction, regexp_internal_match)           \
+-  V(REFLECT_APPLY_INDEX, JSFunction, reflect_apply)                     \
+-  V(REFLECT_CONSTRUCT_INDEX, JSFunction, reflect_construct)             \
+-  V(REFLECT_DEFINE_PROPERTY_INDEX, JSFunction, reflect_define_property) \
+-  V(REFLECT_DELETE_PROPERTY_INDEX, JSFunction, reflect_delete_property) \
+-  V(MATH_FLOOR_INDEX, JSFunction, math_floor)                           \
+-  V(MATH_POW_INDEX, JSFunction, math_pow)                               \
+-  V(PROMISE_INTERNAL_CONSTRUCTOR_INDEX, JSFunction,                     \
+-    promise_internal_constructor)                                       \
+-  V(IS_PROMISE_INDEX, JSFunction, is_promise)                           \
+-  V(PROMISE_THEN_INDEX, JSFunction, promise_then)
++#define NATIVE_CONTEXT_INTRINSIC_FUNCTIONS(V)                               \
++  V(ASYNC_FUNCTION_AWAIT_CAUGHT_INDEX, JSFunction,                          \
++    async_function_await_caught)                                            \
++  V(ASYNC_FUNCTION_AWAIT_UNCAUGHT_INDEX, JSFunction,                        \
++    async_function_await_uncaught)                                          \
++  V(ASYNC_FUNCTION_PROMISE_CREATE_INDEX, JSFunction,                        \
++    async_function_promise_create)                                          \
++  V(ASYNC_FUNCTION_PROMISE_RELEASE_INDEX, JSFunction,                       \
++    async_function_promise_release)                                         \
++  V(IS_ARRAYLIKE, JSFunction, is_arraylike)                                 \
++  V(GENERATOR_NEXT_INTERNAL, JSFunction, generator_next_internal)           \
++  V(MAKE_ERROR_INDEX, JSFunction, make_error)                               \
++  V(MAKE_RANGE_ERROR_INDEX, JSFunction, make_range_error)                   \
++  V(MAKE_SYNTAX_ERROR_INDEX, JSFunction, make_syntax_error)                 \
++  V(MAKE_TYPE_ERROR_INDEX, JSFunction, make_type_error)                     \
++  V(MAKE_URI_ERROR_INDEX, JSFunction, make_uri_error)                       \
++  V(OBJECT_CREATE, JSFunction, object_create)                               \
++  V(OBJECT_DEFINE_PROPERTIES, JSFunction, object_define_properties)         \
++  V(OBJECT_DEFINE_PROPERTY, JSFunction, object_define_property)             \
++  V(OBJECT_GET_PROTOTYPE_OF, JSFunction, object_get_prototype_of)           \
++  V(OBJECT_IS_EXTENSIBLE, JSFunction, object_is_extensible)                 \
++  V(OBJECT_IS_FROZEN, JSFunction, object_is_frozen)                         \
++  V(OBJECT_IS_SEALED, JSFunction, object_is_sealed)                         \
++  V(OBJECT_KEYS, JSFunction, object_keys)                                   \
++  V(REGEXP_INTERNAL_MATCH, JSFunction, regexp_internal_match)               \
++  V(REFLECT_APPLY_INDEX, JSFunction, reflect_apply)                         \
++  V(REFLECT_CONSTRUCT_INDEX, JSFunction, reflect_construct)                 \
++  V(REFLECT_DEFINE_PROPERTY_INDEX, JSFunction, reflect_define_property)     \
++  V(REFLECT_DELETE_PROPERTY_INDEX, JSFunction, reflect_delete_property)     \
++  V(MATH_FLOOR_INDEX, JSFunction, math_floor)                               \
++  V(MATH_POW_INDEX, JSFunction, math_pow)                                   \
++  V(NEW_PROMISE_CAPABILITY_INDEX, JSFunction, new_promise_capability)       \
++  V(PROMISE_INTERNAL_CONSTRUCTOR_INDEX, JSFunction,                         \
++    promise_internal_constructor)                                           \
++  V(IS_PROMISE_INDEX, JSFunction, is_promise)                               \
++  V(PROMISE_THEN_INDEX, JSFunction, promise_then)                           \
++  V(ASYNC_GENERATOR_AWAIT_CAUGHT, JSFunction, async_generator_await_caught) \
++  V(ASYNC_GENERATOR_AWAIT_UNCAUGHT, JSFunction, async_generator_await_uncaught)
+
+ #define NATIVE_CONTEXT_IMPORTED_FIELDS(V)                                 \
+   V(ARRAY_POP_INDEX, JSFunction, array_pop)                               \
+@@ -114,11 +123,27 @@ enum ContextLookupFlags {
+   V(ARRAY_BUFFER_NOINIT_FUN_INDEX, JSFunction, array_buffer_noinit_fun)        \
+   V(ARRAY_FUNCTION_INDEX, JSFunction, array_function)                          \
+   V(ASYNC_FROM_SYNC_ITERATOR_MAP_INDEX, Map, async_from_sync_iterator_map)     \
++  V(ASYNC_FUNCTION_AWAIT_REJECT_SHARED_FUN, SharedFunctionInfo,                \
++    async_function_await_reject_shared_fun)                                    \
++  V(ASYNC_FUNCTION_AWAIT_RESOLVE_SHARED_FUN, SharedFunctionInfo,               \
++    async_function_await_resolve_shared_fun)                                   \
+   V(ASYNC_FUNCTION_FUNCTION_INDEX, JSFunction, async_function_constructor)     \
+   V(ASYNC_GENERATOR_FUNCTION_FUNCTION_INDEX, JSFunction,                       \
+     async_generator_function_function)                                         \
+   V(ASYNC_ITERATOR_VALUE_UNWRAP_SHARED_FUN, SharedFunctionInfo,                \
+     async_iterator_value_unwrap_shared_fun)                                    \
++  V(ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN, SharedFunctionInfo,               \
++    async_generator_await_reject_shared_fun)                                   \
++  V(ASYNC_GENERATOR_AWAIT_RESOLVE_SHARED_FUN, SharedFunctionInfo,              \
++    async_generator_await_resolve_shared_fun)                                  \
++  V(ASYNC_GENERATOR_YIELD_RESOLVE_SHARED_FUN, SharedFunctionInfo,              \
++    async_generator_yield_resolve_shared_fun)                                  \
++  V(ASYNC_GENERATOR_RETURN_RESOLVE_SHARED_FUN, SharedFunctionInfo,             \
++    async_generator_return_resolve_shared_fun)                                 \
++  V(ASYNC_GENERATOR_RETURN_CLOSED_RESOLVE_SHARED_FUN, SharedFunctionInfo,      \
++    async_generator_return_closed_resolve_shared_fun)                          \
++  V(ASYNC_GENERATOR_RETURN_CLOSED_REJECT_SHARED_FUN, SharedFunctionInfo,       \
++    async_generator_return_closed_reject_shared_fun)                           \
+   V(ATOMICS_OBJECT, JSObject, atomics_object)                                  \
+   V(BIGINT_FUNCTION_INDEX, JSFunction, bigint_function)                        \
+   V(BIGINT64_ARRAY_FUN_INDEX, JSFunction, bigint64_array_fun)                  \
+diff --git a/src/heap-symbols.h b/src/heap-symbols.h
+index a6f80f4175..df4923c06a 100644
+--- a/src/heap-symbols.h
++++ b/src/heap-symbols.h
+@@ -237,7 +237,6 @@
+   V(error_script_symbol)               \
+   V(error_start_pos_symbol)            \
+   V(frozen_symbol)                     \
+-  V(generator_outer_promise_symbol)    \
+   V(generic_symbol)                    \
+   V(home_object_symbol)                \
+   V(intl_initialized_marker_symbol)    \
+diff --git a/src/interface-descriptors.h b/src/interface-descriptors.h
+index e31abca1b0..3f047098b1 100644
+--- a/src/interface-descriptors.h
++++ b/src/interface-descriptors.h
+@@ -79,7 +79,6 @@ class PlatformInterfaceDescriptor;
+   V(FrameDropperTrampoline)           \
+   V(WasmRuntimeCall)                  \
+   V(RunMicrotasks)                    \
+-  V(PromiseReactionHandler)           \
+   BUILTIN_LIST_TFS(V)
+
+ class V8_EXPORT_PRIVATE CallInterfaceDescriptorData {
+@@ -868,13 +867,6 @@ class RunMicrotasksDescriptor final : public CallInterfaceDescriptor {
+                              0)
+ };
+
+-class PromiseReactionHandlerDescriptor final : public CallInterfaceDescriptor {
+- public:
+-  DEFINE_PARAMETERS(kArgument, kGenerator)
+-  DECLARE_DEFAULT_DESCRIPTOR(PromiseReactionHandlerDescriptor,
+-                             CallInterfaceDescriptor, 2)
+-};
+-
+ #define DEFINE_TFS_BUILTIN_DESCRIPTOR(Name, ...)                          \
+   class Name##Descriptor : public CallInterfaceDescriptor {               \
+    public:                                                                \
+diff --git a/src/interpreter/bytecode-generator.cc b/src/interpreter/bytecode-generator.cc
+index 5a2248edf1..5f8ebb5896 100644
+--- a/src/interpreter/bytecode-generator.cc
++++ b/src/interpreter/bytecode-generator.cc
+@@ -3251,20 +3251,22 @@ void BytecodeGenerator::BuildAwait(Expression* await_expr) {
+     // Await(operand) and suspend.
+     RegisterAllocationScope register_scope(this);
+
+-    Runtime::FunctionId id;
++    int await_builtin_context_index;
+     RegisterList args;
+     if (IsAsyncGeneratorFunction(function_kind())) {
+-      id = catch_prediction() == HandlerTable::ASYNC_AWAIT
+-               ? Runtime::kInlineAsyncGeneratorAwaitUncaught
+-               : Runtime::kInlineAsyncGeneratorAwaitCaught;
++      await_builtin_context_index =
++          catch_prediction() == HandlerTable::ASYNC_AWAIT
++              ? Context::ASYNC_GENERATOR_AWAIT_UNCAUGHT
++              : Context::ASYNC_GENERATOR_AWAIT_CAUGHT;
+       args = register_allocator()->NewRegisterList(2);
+       builder()
+           ->MoveRegister(generator_object(), args[0])
+           .StoreAccumulatorInRegister(args[1]);
+     } else {
+-      id = catch_prediction() == HandlerTable::ASYNC_AWAIT
+-               ? Runtime::kInlineAsyncFunctionAwaitUncaught
+-               : Runtime::kInlineAsyncFunctionAwaitCaught;
++      await_builtin_context_index =
++          catch_prediction() == HandlerTable::ASYNC_AWAIT
++              ? Context::ASYNC_FUNCTION_AWAIT_UNCAUGHT_INDEX
++              : Context::ASYNC_FUNCTION_AWAIT_CAUGHT_INDEX;
+       args = register_allocator()->NewRegisterList(3);
+       builder()
+           ->MoveRegister(generator_object(), args[0])
+@@ -3277,7 +3279,7 @@ void BytecodeGenerator::BuildAwait(Expression* await_expr) {
+       builder()->StoreAccumulatorInRegister(args[2]);
+     }
+
+-    builder()->CallRuntime(id, args);
++    builder()->CallJSRuntime(await_builtin_context_index, args);
+   }
+
+   BuildSuspendPoint(await_expr);
+diff --git a/src/interpreter/interpreter-intrinsics-generator.cc b/src/interpreter/interpreter-intrinsics-generator.cc
+index 675a8bcccc..0480dec6cc 100644
+--- a/src/interpreter/interpreter-intrinsics-generator.cc
++++ b/src/interpreter/interpreter-intrinsics-generator.cc
+@@ -402,30 +402,6 @@ Node* IntrinsicsGenerator::GetImportMetaObject(
+   return return_value.value();
+ }
+
+-Node* IntrinsicsGenerator::AsyncFunctionAwaitCaught(
+-    const InterpreterAssembler::RegListNodePair& args, Node* context) {
+-  return IntrinsicAsBuiltinCall(args, context,
+-                                Builtins::kAsyncFunctionAwaitCaught);
+-}
+-
+-Node* IntrinsicsGenerator::AsyncFunctionAwaitUncaught(
+-    const InterpreterAssembler::RegListNodePair& args, Node* context) {
+-  return IntrinsicAsBuiltinCall(args, context,
+-                                Builtins::kAsyncFunctionAwaitUncaught);
+-}
+-
+-Node* IntrinsicsGenerator::AsyncGeneratorAwaitCaught(
+-    const InterpreterAssembler::RegListNodePair& args, Node* context) {
+-  return IntrinsicAsBuiltinCall(args, context,
+-                                Builtins::kAsyncGeneratorAwaitCaught);
+-}
+-
+-Node* IntrinsicsGenerator::AsyncGeneratorAwaitUncaught(
+-    const InterpreterAssembler::RegListNodePair& args, Node* context) {
+-  return IntrinsicAsBuiltinCall(args, context,
+-                                Builtins::kAsyncGeneratorAwaitUncaught);
+-}
+-
+ Node* IntrinsicsGenerator::AsyncGeneratorReject(
+     const InterpreterAssembler::RegListNodePair& args, Node* context) {
+   return IntrinsicAsBuiltinCall(args, context, Builtins::kAsyncGeneratorReject);
+diff --git a/src/interpreter/interpreter-intrinsics.h b/src/interpreter/interpreter-intrinsics.h
+index 6cdfec2d04..3016183c0b 100644
+--- a/src/interpreter/interpreter-intrinsics.h
++++ b/src/interpreter/interpreter-intrinsics.h
+@@ -14,10 +14,6 @@ namespace interpreter {
+ // List of supported intrisics, with upper case name, lower case name and
+ // expected number of arguments (-1 denoting argument count is variable).
+ #define INTRINSICS_LIST(V)                                            \
+-  V(AsyncFunctionAwaitCaught, async_function_await_caught, 3)         \
+-  V(AsyncFunctionAwaitUncaught, async_function_await_uncaught, 3)     \
+-  V(AsyncGeneratorAwaitCaught, async_generator_await_caught, 2)       \
+-  V(AsyncGeneratorAwaitUncaught, async_generator_await_uncaught, 2)   \
+   V(AsyncGeneratorReject, async_generator_reject, 2)                  \
+   V(AsyncGeneratorResolve, async_generator_resolve, 3)                \
+   V(AsyncGeneratorYield, async_generator_yield, 3)                    \
+diff --git a/src/isolate.cc b/src/isolate.cc
+index 8254e60a19..c97ece3ba4 100644
+--- a/src/isolate.cc
++++ b/src/isolate.cc
+@@ -2059,7 +2059,6 @@ void Isolate::PopPromise() {
+ }
+
+ namespace {
+-
+ bool InternalPromiseHasUserDefinedRejectHandler(Isolate* isolate,
+                                                 Handle<JSPromise> promise);
+
+@@ -2106,27 +2105,29 @@ bool InternalPromiseHasUserDefinedRejectHandler(Isolate* isolate,
+   }
+
+   if (promise->status() == Promise::kPending) {
+-    Handle<Object> current(promise->reactions(), isolate);
+-    while (!current->IsSmi()) {
+-      Handle<PromiseReaction> current_reaction =
+-          Handle<PromiseReaction>::cast(current);
+-      Handle<HeapObject> payload(current_reaction->payload(), isolate);
+-      Handle<JSPromise> current_promise;
+-      if (JSPromise::From(payload).ToHandle(&current_promise)) {
+-        if (current_reaction->reject_handler()->IsCallable()) {
+-          Handle<JSReceiver> current_handler(
+-              JSReceiver::cast(current_reaction->reject_handler()), isolate);
+-          if (PromiseHandlerCheck(isolate, current_handler, current_promise)) {
+-            return true;
+-          }
+-        } else {
+-          if (InternalPromiseHasUserDefinedRejectHandler(isolate,
+-                                                         current_promise)) {
+-            return true;
+-          }
++    for (Handle<Object> current(promise->reactions(), isolate);
++         !current->IsSmi();) {
++      Handle<PromiseReaction> reaction = Handle<PromiseReaction>::cast(current);
++      Handle<HeapObject> promise_or_capability(
++          reaction->promise_or_capability(), isolate);
++      Handle<JSPromise> promise = Handle<JSPromise>::cast(
++          promise_or_capability->IsJSPromise()
++              ? promise_or_capability
++              : handle(Handle<PromiseCapability>::cast(promise_or_capability)
++                           ->promise(),
++                       isolate));
++      if (reaction->reject_handler()->IsUndefined(isolate)) {
++        if (InternalPromiseHasUserDefinedRejectHandler(isolate, promise)) {
++          return true;
++        }
++      } else {
++        Handle<JSReceiver> current_handler(
++            JSReceiver::cast(reaction->reject_handler()), isolate);
++        if (PromiseHandlerCheck(isolate, current_handler, promise)) {
++          return true;
+         }
+       }
+-      current = handle(current_reaction->next(), isolate);
++      current = handle(reaction->next(), isolate);
+     }
+   }
+
+diff --git a/src/isolate.h b/src/isolate.h
+index 7c0153f74a..929403e134 100644
+--- a/src/isolate.h
++++ b/src/isolate.h
+@@ -1104,10 +1104,7 @@ class Isolate : private HiddenFactory {
+   bool IsPromiseResolveLookupChainIntact();
+
+   // Make sure a lookup of "then" on any JSPromise whose [[Prototype]] is the
+-  // initial %PromisePrototype% yields the initial method. In addition this
+-  // protector also guards the negative lookup of "then" on the intrinsic
+-  // %ObjectPrototype%, meaning that such lookups are guaranteed to yield
+-  // undefined without triggering any side-effects.
++  // initial %PromisePrototype% yields the initial method.
+   bool IsPromiseThenLookupChainIntact();
+   bool IsPromiseThenLookupChainIntact(Handle<JSReceiver> receiver);
+
+diff --git a/src/lookup.cc b/src/lookup.cc
+index 2050114994..a4cca33d6c 100644
+--- a/src/lookup.cc
++++ b/src/lookup.cc
+@@ -364,14 +364,7 @@ void LookupIterator::InternalUpdateProtector() {
+     if (!isolate_->IsPromiseThenLookupChainIntact()) return;
+     // Setting the "then" property on any JSPromise instance or on the
+     // initial %PromisePrototype% invalidates the Promise#then protector.
+-    // Also setting the "then" property on the initial %ObjectPrototype%
+-    // invalidates the Promise#then protector, since we use this protector
+-    // to guard the fast-path in AsyncGeneratorResolve, where we can skip
+-    // the ResolvePromise step and go directly to FulfillPromise if we
+-    // know that the Object.prototype doesn't contain a "then" method.
+     if (holder_->IsJSPromise() ||
+-        isolate_->IsInAnyContext(*holder_,
+-                                 Context::INITIAL_OBJECT_PROTOTYPE_INDEX) ||
+         isolate_->IsInAnyContext(*holder_, Context::PROMISE_PROTOTYPE_INDEX)) {
+       isolate_->InvalidatePromiseThenProtector();
+     }
+diff --git a/src/objects-debug.cc b/src/objects-debug.cc
+index ba33edb3ab..e12fc75230 100644
+--- a/src/objects-debug.cc
++++ b/src/objects-debug.cc
+@@ -1224,13 +1224,10 @@ void PromiseReactionJobTask::PromiseReactionJobTaskVerify() {
+   VerifyHeapPointer(context());
+   CHECK(context()->IsContext());
+   VerifyHeapPointer(handler());
+-  VerifyHeapPointer(payload());
+-  if (handler()->IsCode()) {
+-    CHECK(payload()->IsJSReceiver());
+-  } else {
+-    CHECK(handler()->IsUndefined(isolate) || handler()->IsCallable());
+-    CHECK(payload()->IsJSPromise() || payload()->IsPromiseCapability());
+-  }
++  CHECK(handler()->IsUndefined(isolate) || handler()->IsCallable());
++  VerifyHeapPointer(promise_or_capability());
++  CHECK(promise_or_capability()->IsJSPromise() ||
++        promise_or_capability()->IsPromiseCapability());
+ }
+
+ void PromiseFulfillReactionJobTask::PromiseFulfillReactionJobTaskVerify() {
+@@ -1272,18 +1269,14 @@ void PromiseReaction::PromiseReactionVerify() {
+   VerifyPointer(next());
+   CHECK(next()->IsSmi() || next()->IsPromiseReaction());
+   VerifyHeapPointer(reject_handler());
++  CHECK(reject_handler()->IsUndefined(isolate) ||
++        reject_handler()->IsCallable());
+   VerifyHeapPointer(fulfill_handler());
+-  VerifyHeapPointer(payload());
+-  if (reject_handler()->IsCode()) {
+-    CHECK(fulfill_handler()->IsCode());
+-    CHECK(payload()->IsJSReceiver());
+-  } else {
+-    CHECK(reject_handler()->IsUndefined(isolate) ||
+-          reject_handler()->IsCallable());
+-    CHECK(fulfill_handler()->IsUndefined(isolate) ||
+-          fulfill_handler()->IsCallable());
+-    CHECK(payload()->IsJSPromise() || payload()->IsPromiseCapability());
+-  }
++  CHECK(fulfill_handler()->IsUndefined(isolate) ||
++        fulfill_handler()->IsCallable());
++  VerifyHeapPointer(promise_or_capability());
++  CHECK(promise_or_capability()->IsJSPromise() ||
++        promise_or_capability()->IsPromiseCapability());
+ }
+
+ void JSPromise::JSPromiseVerify() {
+diff --git a/src/objects-inl.h b/src/objects-inl.h
+index ef84df43c4..d9fe22e187 100644
+--- a/src/objects-inl.h
++++ b/src/objects-inl.h
+@@ -2291,7 +2291,6 @@ ACCESSORS(JSGlobalObject, global_proxy, JSObject, kGlobalProxyOffset)
+
+ ACCESSORS(JSGlobalProxy, native_context, Object, kNativeContextOffset)
+
+-
+ ACCESSORS(AsyncGeneratorRequest, next, Object, kNextOffset)
+ SMI_ACCESSORS(AsyncGeneratorRequest, resume_mode, kResumeModeOffset)
+ ACCESSORS(AsyncGeneratorRequest, value, Object, kValueOffset)
+diff --git a/src/objects-printer.cc b/src/objects-printer.cc
+index 5c14eb7828..99eafbb83f 100644
+--- a/src/objects-printer.cc
++++ b/src/objects-printer.cc
+@@ -1472,7 +1472,7 @@ void PromiseFulfillReactionJobTask::PromiseFulfillReactionJobTaskPrint(
+   os << "\n - argument: " << Brief(argument());
+   os << "\n - context: " << Brief(context());
+   os << "\n - handler: " << Brief(handler());
+-  os << "\n - payload: " << Brief(payload());
++  os << "\n - promise_or_capability: " << Brief(promise_or_capability());
+   os << "\n";
+ }
+
+@@ -1482,7 +1482,7 @@ void PromiseRejectReactionJobTask::PromiseRejectReactionJobTaskPrint(
+   os << "\n - argument: " << Brief(argument());
+   os << "\n - context: " << Brief(context());
+   os << "\n - handler: " << Brief(handler());
+-  os << "\n - payload: " << Brief(payload());
++  os << "\n - promise_or_capability: " << Brief(promise_or_capability());
+   os << "\n";
+ }
+
+@@ -1509,7 +1509,7 @@ void PromiseReaction::PromiseReactionPrint(std::ostream& os) {  // NOLINT
+   os << "\n - next: " << Brief(next());
+   os << "\n - reject_handler: " << Brief(reject_handler());
+   os << "\n - fulfill_handler: " << Brief(fulfill_handler());
+-  os << "\n - payload: " << Brief(payload());
++  os << "\n - promise_or_capability: " << Brief(promise_or_capability());
+   os << "\n";
+ }
+
+diff --git a/src/objects.cc b/src/objects.cc
+index d21f59c412..16c5c5b294 100644
+--- a/src/objects.cc
++++ b/src/objects.cc
+@@ -16118,27 +16118,6 @@ MaybeHandle<Object> JSPromise::Resolve(Handle<JSPromise> promise,
+   return isolate->factory()->undefined_value();
+ }
+
+-// static
+-MaybeHandle<JSPromise> JSPromise::From(Handle<HeapObject> object) {
+-  Isolate* const isolate = object->GetIsolate();
+-  if (object->IsJSPromise()) {
+-    return Handle<JSPromise>::cast(object);
+-  } else if (object->IsPromiseCapability()) {
+-    Handle<PromiseCapability> capability =
+-        Handle<PromiseCapability>::cast(object);
+-    if (capability->promise()->IsJSPromise()) {
+-      return handle(JSPromise::cast(capability->promise()), isolate);
+-    }
+-  } else if (object->IsJSGeneratorObject()) {
+-    Handle<JSGeneratorObject> generator =
+-        Handle<JSGeneratorObject>::cast(object);
+-    Handle<Object> handled_by = JSObject::GetDataProperty(
+-        generator, isolate->factory()->generator_outer_promise_symbol());
+-    if (handled_by->IsJSPromise()) return Handle<JSPromise>::cast(handled_by);
+-  }
+-  return MaybeHandle<JSPromise>();
+-}
+-
+ // static
+ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
+                                                   Handle<Object> reactions,
+@@ -16178,8 +16157,8 @@ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
+           *isolate->native_context());
+       STATIC_ASSERT(PromiseReaction::kFulfillHandlerOffset ==
+                     PromiseFulfillReactionJobTask::kHandlerOffset);
+-      STATIC_ASSERT(PromiseReaction::kPayloadOffset ==
+-                    PromiseFulfillReactionJobTask::kPayloadOffset);
++      STATIC_ASSERT(PromiseReaction::kPromiseOrCapabilityOffset ==
++                    PromiseFulfillReactionJobTask::kPromiseOrCapabilityOffset);
+     } else {
+       DisallowHeapAllocation no_gc;
+       HeapObject* handler = reaction->reject_handler();
+@@ -16189,8 +16168,8 @@ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
+       Handle<PromiseRejectReactionJobTask>::cast(task)->set_context(
+           *isolate->native_context());
+       Handle<PromiseRejectReactionJobTask>::cast(task)->set_handler(handler);
+-      STATIC_ASSERT(PromiseReaction::kPayloadOffset ==
+-                    PromiseRejectReactionJobTask::kPayloadOffset);
++      STATIC_ASSERT(PromiseReaction::kPromiseOrCapabilityOffset ==
++                    PromiseRejectReactionJobTask::kPromiseOrCapabilityOffset);
+     }
+
+     isolate->EnqueueMicrotask(Handle<PromiseReactionJobTask>::cast(task));
+diff --git a/src/objects/js-promise.h b/src/objects/js-promise.h
+index 20a0a90131..434bae8933 100644
+--- a/src/objects/js-promise.h
++++ b/src/objects/js-promise.h
+@@ -59,12 +59,6 @@ class JSPromise : public JSObject {
+   V8_WARN_UNUSED_RESULT static MaybeHandle<Object> Resolve(
+       Handle<JSPromise> promise, Handle<Object> resolution);
+
+-  // This is a helper that extracts the JSPromise from the input
+-  // {object}, which is used as a payload for PromiseReaction and
+-  // PromiseReactionJobTask.
+-  V8_WARN_UNUSED_RESULT static MaybeHandle<JSPromise> From(
+-      Handle<HeapObject> object);
+-
+   DECL_CAST(JSPromise)
+
+   // Dispatched behavior.
+diff --git a/src/objects/promise-inl.h b/src/objects/promise-inl.h
+index 4283f0aa19..f9fb6110f3 100644
+--- a/src/objects/promise-inl.h
++++ b/src/objects/promise-inl.h
+@@ -23,7 +23,8 @@ CAST_ACCESSOR(PromiseResolveThenableJobTask)
+ ACCESSORS(PromiseReaction, next, Object, kNextOffset)
+ ACCESSORS(PromiseReaction, reject_handler, HeapObject, kRejectHandlerOffset)
+ ACCESSORS(PromiseReaction, fulfill_handler, HeapObject, kFulfillHandlerOffset)
+-ACCESSORS(PromiseReaction, payload, HeapObject, kPayloadOffset)
++ACCESSORS(PromiseReaction, promise_or_capability, HeapObject,
++          kPromiseOrCapabilityOffset)
+
+ ACCESSORS(PromiseResolveThenableJobTask, context, Context, kContextOffset)
+ ACCESSORS(PromiseResolveThenableJobTask, promise_to_resolve, JSPromise,
+@@ -34,7 +35,8 @@ ACCESSORS(PromiseResolveThenableJobTask, thenable, JSReceiver, kThenableOffset)
+ ACCESSORS(PromiseReactionJobTask, context, Context, kContextOffset)
+ ACCESSORS(PromiseReactionJobTask, argument, Object, kArgumentOffset);
+ ACCESSORS(PromiseReactionJobTask, handler, HeapObject, kHandlerOffset);
+-ACCESSORS(PromiseReactionJobTask, payload, HeapObject, kPayloadOffset);
++ACCESSORS(PromiseReactionJobTask, promise_or_capability, HeapObject,
++          kPromiseOrCapabilityOffset);
+
+ ACCESSORS(PromiseCapability, promise, HeapObject, kPromiseOffset)
+ ACCESSORS(PromiseCapability, resolve, Object, kResolveOffset)
+diff --git a/src/objects/promise.h b/src/objects/promise.h
+index 36ef4afe1d..5ff5dac6f3 100644
+--- a/src/objects/promise.h
++++ b/src/objects/promise.h
+@@ -26,16 +26,15 @@ class PromiseReactionJobTask : public Microtask {
+  public:
+   DECL_ACCESSORS(argument, Object)
+   DECL_ACCESSORS(context, Context)
+-  // [handler]: This is either a Code object, a Callable or Undefined.
+   DECL_ACCESSORS(handler, HeapObject)
+-  // [payload]: Usually a JSPromise or a PromiseCapability.
+-  DECL_ACCESSORS(payload, HeapObject)
++  // [promise_or_capability]: Either a JSPromise or a PromiseCapability.
++  DECL_ACCESSORS(promise_or_capability, HeapObject)
+
+   static const int kArgumentOffset = Microtask::kHeaderSize;
+   static const int kContextOffset = kArgumentOffset + kPointerSize;
+   static const int kHandlerOffset = kContextOffset + kPointerSize;
+-  static const int kPayloadOffset = kHandlerOffset + kPointerSize;
+-  static const int kSize = kPayloadOffset + kPointerSize;
++  static const int kPromiseOrCapabilityOffset = kHandlerOffset + kPointerSize;
++  static const int kSize = kPromiseOrCapabilityOffset + kPointerSize;
+
+   // Dispatched behavior.
+   DECL_CAST(PromiseReactionJobTask)
+@@ -121,10 +120,9 @@ class PromiseCapability : public Struct {
+ // of microtasks. So the size of PromiseReaction and the size of the
+ // PromiseReactionJobTask has to be same for this to work.
+ //
+-// The PromiseReaction::payload field usually holds a JSPromise
+-// instance (in the fast case of a native promise) or a PromiseCapability
+-// in case of a custom promise. For await we store the JSGeneratorObject
+-// here and use custom Code handlers.
++// The PromiseReaction::promise_or_capability field can either hold a JSPromise
++// instance (in the fast case of a native promise) or a PromiseCapability in
++// case of a Promise subclass.
+ //
+ // We need to keep the context in the PromiseReaction so that we can run
+ // the default handlers (in case they are undefined) in the proper context.
+@@ -138,18 +136,16 @@ class PromiseReaction : public Struct {
+   enum Type { kFulfill, kReject };
+
+   DECL_ACCESSORS(next, Object)
+-  // [reject_handler]: This is either a Code object, a Callable or Undefined.
+   DECL_ACCESSORS(reject_handler, HeapObject)
+-  // [fulfill_handler]: This is either a Code object, a Callable or Undefined.
+   DECL_ACCESSORS(fulfill_handler, HeapObject)
+-  // [payload]: Usually a JSPromise or a PromiseCapability.
+-  DECL_ACCESSORS(payload, HeapObject)
++  DECL_ACCESSORS(promise_or_capability, HeapObject)
+
+   static const int kNextOffset = Struct::kHeaderSize;
+   static const int kRejectHandlerOffset = kNextOffset + kPointerSize;
+   static const int kFulfillHandlerOffset = kRejectHandlerOffset + kPointerSize;
+-  static const int kPayloadOffset = kFulfillHandlerOffset + kPointerSize;
+-  static const int kSize = kPayloadOffset + kPointerSize;
++  static const int kPromiseOrCapabilityOffset =
++      kFulfillHandlerOffset + kPointerSize;
++  static const int kSize = kPromiseOrCapabilityOffset + kPointerSize;
+
+   // Dispatched behavior.
+   DECL_CAST(PromiseReaction)
+diff --git a/src/runtime/runtime-generator.cc b/src/runtime/runtime-generator.cc
+index e69d334042..3c7c808c30 100644
+--- a/src/runtime/runtime-generator.cc
++++ b/src/runtime/runtime-generator.cc
+@@ -70,30 +70,6 @@ RUNTIME_FUNCTION(Runtime_GeneratorGetInputOrDebugPos) {
+   UNREACHABLE();
+ }
+
+-RUNTIME_FUNCTION(Runtime_AsyncFunctionAwaitCaught) {
+-  // Runtime call is implemented in InterpreterIntrinsics and lowered in
+-  // JSIntrinsicLowering
+-  UNREACHABLE();
+-}
+-
+-RUNTIME_FUNCTION(Runtime_AsyncFunctionAwaitUncaught) {
+-  // Runtime call is implemented in InterpreterIntrinsics and lowered in
+-  // JSIntrinsicLowering
+-  UNREACHABLE();
+-}
+-
+-RUNTIME_FUNCTION(Runtime_AsyncGeneratorAwaitCaught) {
+-  // Runtime call is implemented in InterpreterIntrinsics and lowered in
+-  // JSIntrinsicLowering
+-  UNREACHABLE();
+-}
+-
+-RUNTIME_FUNCTION(Runtime_AsyncGeneratorAwaitUncaught) {
+-  // Runtime call is implemented in InterpreterIntrinsics and lowered in
+-  // JSIntrinsicLowering
+-  UNREACHABLE();
+-}
+-
+ RUNTIME_FUNCTION(Runtime_AsyncGeneratorResolve) {
+   // Runtime call is implemented in InterpreterIntrinsics and lowered in
+   // JSIntrinsicLowering
+diff --git a/src/runtime/runtime-promise.cc b/src/runtime/runtime-promise.cc
+index b2a7e8bae1..f5b9db3c02 100644
+--- a/src/runtime/runtime-promise.cc
++++ b/src/runtime/runtime-promise.cc
+@@ -114,14 +114,13 @@ RUNTIME_FUNCTION(Runtime_PromiseHookInit) {
+ RUNTIME_FUNCTION(Runtime_PromiseHookBefore) {
+   HandleScope scope(isolate);
+   DCHECK_EQ(1, args.length());
+-  CONVERT_ARG_HANDLE_CHECKED(HeapObject, payload, 0);
+-  Handle<JSPromise> promise;
+-  if (JSPromise::From(payload).ToHandle(&promise)) {
+-    if (isolate->debug()->is_active()) isolate->PushPromise(promise);
+-    if (promise->IsJSPromise()) {
+-      isolate->RunPromiseHook(PromiseHookType::kBefore, promise,
+-                              isolate->factory()->undefined_value());
+-    }
++  CONVERT_ARG_HANDLE_CHECKED(JSReceiver, maybe_promise, 0);
++  if (!maybe_promise->IsJSPromise()) return isolate->heap()->undefined_value();
++  Handle<JSPromise> promise = Handle<JSPromise>::cast(maybe_promise);
++  if (isolate->debug()->is_active()) isolate->PushPromise(promise);
++  if (promise->IsJSPromise()) {
++    isolate->RunPromiseHook(PromiseHookType::kBefore, promise,
++                            isolate->factory()->undefined_value());
+   }
+   return isolate->heap()->undefined_value();
+ }
+@@ -129,14 +128,13 @@ RUNTIME_FUNCTION(Runtime_PromiseHookBefore) {
+ RUNTIME_FUNCTION(Runtime_PromiseHookAfter) {
+   HandleScope scope(isolate);
+   DCHECK_EQ(1, args.length());
+-  CONVERT_ARG_HANDLE_CHECKED(HeapObject, payload, 0);
+-  Handle<JSPromise> promise;
+-  if (JSPromise::From(payload).ToHandle(&promise)) {
+-    if (isolate->debug()->is_active()) isolate->PopPromise();
+-    if (promise->IsJSPromise()) {
+-      isolate->RunPromiseHook(PromiseHookType::kAfter, promise,
+-                              isolate->factory()->undefined_value());
+-    }
++  CONVERT_ARG_HANDLE_CHECKED(JSReceiver, maybe_promise, 0);
++  if (!maybe_promise->IsJSPromise()) return isolate->heap()->undefined_value();
++  Handle<JSPromise> promise = Handle<JSPromise>::cast(maybe_promise);
++  if (isolate->debug()->is_active()) isolate->PopPromise();
++  if (promise->IsJSPromise()) {
++    isolate->RunPromiseHook(PromiseHookType::kAfter, promise,
++                            isolate->factory()->undefined_value());
+   }
+   return isolate->heap()->undefined_value();
+ }
+diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
+index b7ef0d0af1..846e82782c 100644
+--- a/src/runtime/runtime.h
++++ b/src/runtime/runtime.h
+@@ -224,10 +224,6 @@ namespace internal {
+   F(SetNativeFlag, 1, 1)
+
+ #define FOR_EACH_INTRINSIC_GENERATOR(F)       \
+-  F(AsyncFunctionAwaitCaught, 3, 1)           \
+-  F(AsyncFunctionAwaitUncaught, 3, 1)         \
+-  F(AsyncGeneratorAwaitCaught, 2, 1)          \
+-  F(AsyncGeneratorAwaitUncaught, 2, 1)        \
+   F(AsyncGeneratorHasCatchHandlerForPC, 1, 1) \
+   F(AsyncGeneratorReject, 2, 1)               \
+   F(AsyncGeneratorResolve, 3, 1)              \
+diff --git a/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden b/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden
+index 6d63516b77..8c3c29f71f 100644
+--- a/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden
++++ b/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden
+@@ -39,7 +39,7 @@ bytecodes: [
+                 B(LdaUndefined),
+                 B(Star), R(6),
+                 B(Mov), R(0), R(5),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncGeneratorAwaitUncaught), R(5), U8(2),
++                B(CallJSRuntime), U8(%async_generator_await_uncaught), R(5), U8(2),
+                 B(SuspendGenerator), R(0), R(0), U8(5), U8(1),
+                 B(ResumeGenerator), R(0), R(0), U8(5),
+                 B(Star), R(5),
+@@ -164,7 +164,7 @@ bytecodes: [
+                 B(LdaUndefined),
+                 B(Star), R(6),
+                 B(Mov), R(0), R(5),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncGeneratorAwaitUncaught), R(5), U8(2),
++                B(CallJSRuntime), U8(%async_generator_await_uncaught), R(5), U8(2),
+                 B(SuspendGenerator), R(0), R(0), U8(5), U8(2),
+                 B(ResumeGenerator), R(0), R(0), U8(5),
+                 B(Star), R(5),
+@@ -399,7 +399,7 @@ bytecodes: [
+                 B(LdaUndefined),
+                 B(Star), R(16),
+                 B(Mov), R(2), R(15),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncGeneratorAwaitUncaught), R(15), U8(2),
++                B(CallJSRuntime), U8(%async_generator_await_uncaught), R(15), U8(2),
+                 B(SuspendGenerator), R(2), R(0), U8(15), U8(2),
+                 B(ResumeGenerator), R(2), R(0), U8(15),
+                 B(Star), R(15),
+@@ -573,7 +573,7 @@ bytecodes: [
+                 B(Jump), U8(2),
+                 B(Star), R(13),
+                 B(Mov), R(0), R(12),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncGeneratorAwaitUncaught), R(12), U8(2),
++                B(CallJSRuntime), U8(%async_generator_await_uncaught), R(12), U8(2),
+   /*   49 E> */ B(SuspendGenerator), R(0), R(0), U8(12), U8(1),
+                 B(ResumeGenerator), R(0), R(0), U8(12),
+                 B(Star), R(12),
+@@ -591,7 +591,7 @@ bytecodes: [
+                 B(CallRuntime), U16(Runtime::kThrowThrowMethodMissing), R(0), U8(0),
+                 B(Star), R(13),
+                 B(Mov), R(0), R(12),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncGeneratorAwaitUncaught), R(12), U8(2),
++                B(CallJSRuntime), U8(%async_generator_await_uncaught), R(12), U8(2),
+   /*   49 E> */ B(SuspendGenerator), R(0), R(0), U8(12), U8(2),
+                 B(ResumeGenerator), R(0), R(0), U8(12),
+                 B(Star), R(12),
+@@ -632,7 +632,7 @@ bytecodes: [
+                 B(LdaUndefined),
+                 B(Star), R(6),
+                 B(Mov), R(0), R(5),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncGeneratorAwaitUncaught), R(5), U8(2),
++                B(CallJSRuntime), U8(%async_generator_await_uncaught), R(5), U8(2),
+                 B(SuspendGenerator), R(0), R(0), U8(5), U8(4),
+                 B(ResumeGenerator), R(0), R(0), U8(5),
+                 B(Star), R(5),
+diff --git a/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden b/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden
+index 867e09d6ca..47bcb4aa32 100644
+--- a/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden
++++ b/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden
+@@ -53,7 +53,7 @@ bytecodes: [
+                 B(Star), R(21),
+                 B(Mov), R(2), R(20),
+                 B(Mov), R(11), R(22),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(20), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(20), U8(3),
+   /*   40 E> */ B(SuspendGenerator), R(2), R(0), U8(20), U8(0),
+                 B(ResumeGenerator), R(2), R(0), U8(20),
+                 B(Star), R(20),
+@@ -136,7 +136,7 @@ bytecodes: [
+                 B(Star), R(21),
+                 B(Mov), R(2), R(20),
+                 B(Mov), R(11), R(22),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitCaught), R(20), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_caught), R(20), U8(3),
+                 B(SuspendGenerator), R(2), R(0), U8(20), U8(1),
+                 B(ResumeGenerator), R(2), R(0), U8(20),
+                 B(Star), R(20),
+@@ -159,7 +159,7 @@ bytecodes: [
+                 B(Star), R(20),
+                 B(Mov), R(2), R(19),
+                 B(Mov), R(11), R(21),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(19), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(19), U8(3),
+                 B(SuspendGenerator), R(2), R(0), U8(19), U8(2),
+                 B(ResumeGenerator), R(2), R(0), U8(19),
+                 B(Star), R(19),
+@@ -303,7 +303,7 @@ bytecodes: [
+                 B(Star), R(21),
+                 B(Mov), R(2), R(20),
+                 B(Mov), R(11), R(22),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(20), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(20), U8(3),
+   /*   40 E> */ B(SuspendGenerator), R(2), R(0), U8(20), U8(0),
+                 B(ResumeGenerator), R(2), R(0), U8(20),
+                 B(Star), R(20),
+@@ -387,7 +387,7 @@ bytecodes: [
+                 B(Star), R(21),
+                 B(Mov), R(2), R(20),
+                 B(Mov), R(11), R(22),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitCaught), R(20), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_caught), R(20), U8(3),
+                 B(SuspendGenerator), R(2), R(0), U8(20), U8(1),
+                 B(ResumeGenerator), R(2), R(0), U8(20),
+                 B(Star), R(20),
+@@ -410,7 +410,7 @@ bytecodes: [
+                 B(Star), R(20),
+                 B(Mov), R(2), R(19),
+                 B(Mov), R(11), R(21),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(19), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(19), U8(3),
+                 B(SuspendGenerator), R(2), R(0), U8(19), U8(2),
+                 B(ResumeGenerator), R(2), R(0), U8(19),
+                 B(Star), R(19),
+@@ -569,7 +569,7 @@ bytecodes: [
+                 B(Star), R(21),
+                 B(Mov), R(2), R(20),
+                 B(Mov), R(11), R(22),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(20), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(20), U8(3),
+   /*   40 E> */ B(SuspendGenerator), R(2), R(0), U8(20), U8(0),
+                 B(ResumeGenerator), R(2), R(0), U8(20),
+                 B(Star), R(20),
+@@ -660,7 +660,7 @@ bytecodes: [
+                 B(Star), R(21),
+                 B(Mov), R(2), R(20),
+                 B(Mov), R(11), R(22),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitCaught), R(20), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_caught), R(20), U8(3),
+                 B(SuspendGenerator), R(2), R(0), U8(20), U8(1),
+                 B(ResumeGenerator), R(2), R(0), U8(20),
+                 B(Star), R(20),
+@@ -683,7 +683,7 @@ bytecodes: [
+                 B(Star), R(20),
+                 B(Mov), R(2), R(19),
+                 B(Mov), R(11), R(21),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(19), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(19), U8(3),
+                 B(SuspendGenerator), R(2), R(0), U8(19), U8(2),
+                 B(ResumeGenerator), R(2), R(0), U8(19),
+                 B(Star), R(19),
+diff --git a/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden b/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden
+index 882f61943a..ed0ef4048e 100644
+--- a/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden
++++ b/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden
+@@ -1182,7 +1182,7 @@ bytecodes: [
+   /*   45 S> */ B(Mov), R(2), R(21),
+                 B(Mov), R(0), R(22),
+                 B(Mov), R(11), R(23),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(21), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(21), U8(3),
+   /*   45 E> */ B(SuspendGenerator), R(2), R(0), U8(21), U8(0),
+                 B(ResumeGenerator), R(2), R(0), U8(21),
+                 B(Star), R(21),
+diff --git a/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden b/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden
+index 8be761df37..226fa55039 100644
+--- a/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden
++++ b/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden
+@@ -489,7 +489,7 @@ bytecodes: [
+   /*   52 S> */ B(Mov), R(1), R(7),
+                 B(Mov), R(0), R(8),
+                 B(Mov), R(2), R(9),
+-                B(InvokeIntrinsic), U8(Runtime::k_AsyncFunctionAwaitUncaught), R(7), U8(3),
++                B(CallJSRuntime), U8(%async_function_await_uncaught), R(7), U8(3),
+   /*   52 E> */ B(SuspendGenerator), R(1), R(0), U8(7), U8(0),
+                 B(ResumeGenerator), R(1), R(0), U8(7),
+                 B(Star), R(7),
+diff --git a/test/cctest/test-api.cc b/test/cctest/test-api.cc
+index b1d2aced5e..0cc24b1cbd 100644
+--- a/test/cctest/test-api.cc
++++ b/test/cctest/test-api.cc
+@@ -18432,12 +18432,6 @@ TEST(PromiseHook) {
+   CHECK_EQ(v8::Promise::kFulfilled, GetPromise("p")->State());
+   CHECK_EQ(9, promise_hook_data->promise_hook_count);
+
+-  promise_hook_data->Reset();
+-  source = "(async() => await p)();\n";
+-
+-  CompileRun(source);
+-  CHECK_EQ(11, promise_hook_data->promise_hook_count);
+-
+   delete promise_hook_data;
+   isolate->SetPromiseHook(nullptr);
+ }
+diff --git a/tools/v8heapconst.py b/tools/v8heapconst.py
+index 3fa1889848..da284eb927 100644
+--- a/tools/v8heapconst.py
++++ b/tools/v8heapconst.py
+@@ -265,33 +265,33 @@ KNOWN_MAPS = {
+   ("RO_SPACE", 0x05019): (172, "Tuple2Map"),
+   ("RO_SPACE", 0x05211): (170, "ScriptMap"),
+   ("RO_SPACE", 0x053d9): (162, "InterceptorInfoMap"),
+-  ("RO_SPACE", 0x07b99): (154, "AccessorInfoMap"),
+-  ("RO_SPACE", 0x07da9): (153, "AccessCheckInfoMap"),
+-  ("RO_SPACE", 0x07e11): (155, "AccessorPairMap"),
+-  ("RO_SPACE", 0x07e79): (156, "AliasedArgumentsEntryMap"),
+-  ("RO_SPACE", 0x07ee1): (157, "AllocationMementoMap"),
+-  ("RO_SPACE", 0x07f49): (158, "AllocationSiteMap"),
+-  ("RO_SPACE", 0x07fb1): (159, "AsyncGeneratorRequestMap"),
+-  ("RO_SPACE", 0x08019): (160, "DebugInfoMap"),
+-  ("RO_SPACE", 0x08081): (161, "FunctionTemplateInfoMap"),
+-  ("RO_SPACE", 0x080e9): (163, "InterpreterDataMap"),
+-  ("RO_SPACE", 0x08151): (164, "ModuleInfoEntryMap"),
+-  ("RO_SPACE", 0x081b9): (165, "ModuleMap"),
+-  ("RO_SPACE", 0x08221): (166, "ObjectTemplateInfoMap"),
+-  ("RO_SPACE", 0x08289): (167, "PromiseCapabilityMap"),
+-  ("RO_SPACE", 0x082f1): (168, "PromiseReactionMap"),
+-  ("RO_SPACE", 0x08359): (169, "PrototypeInfoMap"),
+-  ("RO_SPACE", 0x083c1): (171, "StackFrameInfoMap"),
+-  ("RO_SPACE", 0x08429): (173, "Tuple3Map"),
+-  ("RO_SPACE", 0x08491): (174, "WasmCompiledModuleMap"),
+-  ("RO_SPACE", 0x084f9): (175, "WasmDebugInfoMap"),
+-  ("RO_SPACE", 0x08561): (176, "WasmExportedFunctionDataMap"),
+-  ("RO_SPACE", 0x085c9): (177, "WasmSharedModuleDataMap"),
+-  ("RO_SPACE", 0x08631): (178, "CallableTaskMap"),
+-  ("RO_SPACE", 0x08699): (179, "CallbackTaskMap"),
+-  ("RO_SPACE", 0x08701): (180, "PromiseFulfillReactionJobTaskMap"),
+-  ("RO_SPACE", 0x08769): (181, "PromiseRejectReactionJobTaskMap"),
+-  ("RO_SPACE", 0x087d1): (182, "PromiseResolveThenableJobTaskMap"),
++  ("RO_SPACE", 0x07b79): (154, "AccessorInfoMap"),
++  ("RO_SPACE", 0x07d89): (153, "AccessCheckInfoMap"),
++  ("RO_SPACE", 0x07df1): (155, "AccessorPairMap"),
++  ("RO_SPACE", 0x07e59): (156, "AliasedArgumentsEntryMap"),
++  ("RO_SPACE", 0x07ec1): (157, "AllocationMementoMap"),
++  ("RO_SPACE", 0x07f29): (158, "AllocationSiteMap"),
++  ("RO_SPACE", 0x07f91): (159, "AsyncGeneratorRequestMap"),
++  ("RO_SPACE", 0x07ff9): (160, "DebugInfoMap"),
++  ("RO_SPACE", 0x08061): (161, "FunctionTemplateInfoMap"),
++  ("RO_SPACE", 0x080c9): (163, "InterpreterDataMap"),
++  ("RO_SPACE", 0x08131): (164, "ModuleInfoEntryMap"),
++  ("RO_SPACE", 0x08199): (165, "ModuleMap"),
++  ("RO_SPACE", 0x08201): (166, "ObjectTemplateInfoMap"),
++  ("RO_SPACE", 0x08269): (167, "PromiseCapabilityMap"),
++  ("RO_SPACE", 0x082d1): (168, "PromiseReactionMap"),
++  ("RO_SPACE", 0x08339): (169, "PrototypeInfoMap"),
++  ("RO_SPACE", 0x083a1): (171, "StackFrameInfoMap"),
++  ("RO_SPACE", 0x08409): (173, "Tuple3Map"),
++  ("RO_SPACE", 0x08471): (174, "WasmCompiledModuleMap"),
++  ("RO_SPACE", 0x084d9): (175, "WasmDebugInfoMap"),
++  ("RO_SPACE", 0x08541): (176, "WasmExportedFunctionDataMap"),
++  ("RO_SPACE", 0x085a9): (177, "WasmSharedModuleDataMap"),
++  ("RO_SPACE", 0x08611): (178, "CallableTaskMap"),
++  ("RO_SPACE", 0x08679): (179, "CallbackTaskMap"),
++  ("RO_SPACE", 0x086e1): (180, "PromiseFulfillReactionJobTaskMap"),
++  ("RO_SPACE", 0x08749): (181, "PromiseRejectReactionJobTaskMap"),
++  ("RO_SPACE", 0x087b1): (182, "PromiseResolveThenableJobTaskMap"),
+   ("MAP_SPACE", 0x02201): (1057, "ExternalMap"),
+   ("MAP_SPACE", 0x02259): (1072, "JSMessageObjectMap"),
+ }

--- a/patches/common/v8/backport_91ddb65d.patch
+++ b/patches/common/v8/backport_91ddb65d.patch
@@ -956,7 +956,7 @@ index 5c3842761e..c1bf7df2ec 100644
 +                      SloppyTNode<HeapObject> promise_or_capability);
 
    TNode<Object> GetPendingException() {
-     auto ref = ExternalReference::Create(kPendingExceptionAddress, isolate());
+     auto ref = ExternalReference(kPendingExceptionAddress, isolate());
 @@ -790,12 +790,20 @@ void InternalBuiltinsAssembler::LeaveMicrotaskContext() {
 
  void InternalBuiltinsAssembler::RunPromiseHook(
@@ -1410,7 +1410,7 @@ diff --git a/src/contexts.h b/src/contexts.h
 index 4cfbb29f06..763f30f193 100644
 --- a/src/contexts.h
 +++ b/src/contexts.h
-@@ -32,35 +32,44 @@ enum ContextLookupFlags {
+@@ -32,37 +32,44 @@ enum ContextLookupFlags {
  // must always be allocated via Heap::AllocateContext() or
  // Factory::NewContext.
 
@@ -1430,6 +1430,8 @@ index 4cfbb29f06..763f30f193 100644
 -  V(OBJECT_DEFINE_PROPERTIES, JSFunction, object_define_properties)     \
 -  V(OBJECT_DEFINE_PROPERTY, JSFunction, object_define_property)         \
 -  V(OBJECT_GET_PROTOTYPE_OF, JSFunction, object_get_prototype_of)       \
+-  V(OBJECT_IS_EXTENSIBLE, JSFunction, object_is_extensible)             \
+-  V(OBJECT_IS_FROZEN, JSFunction, object_is_frozen)                     \
 -  V(OBJECT_IS_SEALED, JSFunction, object_is_sealed)                     \
 -  V(OBJECT_KEYS, JSFunction, object_keys)                               \
 -  V(REGEXP_INTERNAL_MATCH, JSFunction, regexp_internal_match)           \
@@ -1787,18 +1789,6 @@ index ba33edb3ab..e12fc75230 100644
  }
 
  void JSPromise::JSPromiseVerify() {
-diff --git a/src/objects-inl.h b/src/objects-inl.h
-index ef84df43c4..d9fe22e187 100644
---- a/src/objects-inl.h
-+++ b/src/objects-inl.h
-@@ -2291,7 +2291,6 @@ ACCESSORS(JSGlobalObject, global_proxy, JSObject, kGlobalProxyOffset)
-
- ACCESSORS(JSGlobalProxy, native_context, Object, kNativeContextOffset)
-
--
- ACCESSORS(AsyncGeneratorRequest, next, Object, kNextOffset)
- SMI_ACCESSORS(AsyncGeneratorRequest, resume_mode, kResumeModeOffset)
- ACCESSORS(AsyncGeneratorRequest, value, Object, kValueOffset)
 diff --git a/src/objects-printer.cc b/src/objects-printer.cc
 index 5c14eb7828..99eafbb83f 100644
 --- a/src/objects-printer.cc
@@ -2275,64 +2265,22 @@ diff --git a/tools/v8heapconst.py b/tools/v8heapconst.py
 index 3fa1889848..da284eb927 100644
 --- a/tools/v8heapconst.py
 +++ b/tools/v8heapconst.py
-@@ -265,33 +265,33 @@ KNOWN_MAPS = {
-   ("RO_SPACE", 0x05019): (172, "Tuple2Map"),
-   ("RO_SPACE", 0x05211): (170, "ScriptMap"),
-   ("RO_SPACE", 0x053d9): (162, "InterceptorInfoMap"),
--  ("RO_SPACE", 0x07b99): (154, "AccessorInfoMap"),
--  ("RO_SPACE", 0x07da9): (153, "AccessCheckInfoMap"),
--  ("RO_SPACE", 0x07e11): (155, "AccessorPairMap"),
--  ("RO_SPACE", 0x07e79): (156, "AliasedArgumentsEntryMap"),
--  ("RO_SPACE", 0x07ee1): (157, "AllocationMementoMap"),
--  ("RO_SPACE", 0x07f49): (158, "AllocationSiteMap"),
--  ("RO_SPACE", 0x07fb1): (159, "AsyncGeneratorRequestMap"),
--  ("RO_SPACE", 0x08019): (160, "DebugInfoMap"),
--  ("RO_SPACE", 0x08081): (161, "FunctionTemplateInfoMap"),
--  ("RO_SPACE", 0x080e9): (163, "InterpreterDataMap"),
--  ("RO_SPACE", 0x08151): (164, "ModuleInfoEntryMap"),
--  ("RO_SPACE", 0x081b9): (165, "ModuleMap"),
--  ("RO_SPACE", 0x08221): (166, "ObjectTemplateInfoMap"),
--  ("RO_SPACE", 0x08289): (167, "PromiseCapabilityMap"),
--  ("RO_SPACE", 0x082f1): (168, "PromiseReactionMap"),
--  ("RO_SPACE", 0x08359): (169, "PrototypeInfoMap"),
--  ("RO_SPACE", 0x083c1): (171, "StackFrameInfoMap"),
--  ("RO_SPACE", 0x08429): (173, "Tuple3Map"),
--  ("RO_SPACE", 0x08491): (174, "WasmCompiledModuleMap"),
--  ("RO_SPACE", 0x084f9): (175, "WasmDebugInfoMap"),
--  ("RO_SPACE", 0x08561): (176, "WasmExportedFunctionDataMap"),
--  ("RO_SPACE", 0x085c9): (177, "WasmSharedModuleDataMap"),
--  ("RO_SPACE", 0x08631): (178, "CallableTaskMap"),
--  ("RO_SPACE", 0x08699): (179, "CallbackTaskMap"),
--  ("RO_SPACE", 0x08701): (180, "PromiseFulfillReactionJobTaskMap"),
--  ("RO_SPACE", 0x08769): (181, "PromiseRejectReactionJobTaskMap"),
--  ("RO_SPACE", 0x087d1): (182, "PromiseResolveThenableJobTaskMap"),
-+  ("RO_SPACE", 0x07b79): (154, "AccessorInfoMap"),
-+  ("RO_SPACE", 0x07d89): (153, "AccessCheckInfoMap"),
-+  ("RO_SPACE", 0x07df1): (155, "AccessorPairMap"),
-+  ("RO_SPACE", 0x07e59): (156, "AliasedArgumentsEntryMap"),
-+  ("RO_SPACE", 0x07ec1): (157, "AllocationMementoMap"),
-+  ("RO_SPACE", 0x07f29): (158, "AllocationSiteMap"),
-+  ("RO_SPACE", 0x07f91): (159, "AsyncGeneratorRequestMap"),
-+  ("RO_SPACE", 0x07ff9): (160, "DebugInfoMap"),
-+  ("RO_SPACE", 0x08061): (161, "FunctionTemplateInfoMap"),
-+  ("RO_SPACE", 0x080c9): (163, "InterpreterDataMap"),
-+  ("RO_SPACE", 0x08131): (164, "ModuleInfoEntryMap"),
-+  ("RO_SPACE", 0x08199): (165, "ModuleMap"),
-+  ("RO_SPACE", 0x08201): (166, "ObjectTemplateInfoMap"),
-+  ("RO_SPACE", 0x08269): (167, "PromiseCapabilityMap"),
-+  ("RO_SPACE", 0x082d1): (168, "PromiseReactionMap"),
-+  ("RO_SPACE", 0x08339): (169, "PrototypeInfoMap"),
-+  ("RO_SPACE", 0x083a1): (171, "StackFrameInfoMap"),
-+  ("RO_SPACE", 0x08409): (173, "Tuple3Map"),
-+  ("RO_SPACE", 0x08471): (174, "WasmCompiledModuleMap"),
-+  ("RO_SPACE", 0x084d9): (175, "WasmDebugInfoMap"),
-+  ("RO_SPACE", 0x08541): (176, "WasmExportedFunctionDataMap"),
-+  ("RO_SPACE", 0x085a9): (177, "WasmSharedModuleDataMap"),
-+  ("RO_SPACE", 0x08611): (178, "CallableTaskMap"),
-+  ("RO_SPACE", 0x08679): (179, "CallbackTaskMap"),
-+  ("RO_SPACE", 0x086e1): (180, "PromiseFulfillReactionJobTaskMap"),
-+  ("RO_SPACE", 0x08749): (181, "PromiseRejectReactionJobTaskMap"),
-+  ("RO_SPACE", 0x087b1): (182, "PromiseResolveThenableJobTaskMap"),
-   ("MAP_SPACE", 0x02201): (1057, "ExternalMap"),
-   ("MAP_SPACE", 0x02259): (1072, "JSMessageObjectMap"),
- }
+@@ -263,12 +263,12 @@ KNOWN_MAPS = {
+   ("MAP_SPACE", 0x04511): (173, "Tuple2Map"),
+   ("MAP_SPACE", 0x04569): (171, "ScriptMap"),
+   ("MAP_SPACE", 0x045c1): (163, "InterceptorInfoMap"),
+-  ("MAP_SPACE", 0x04619): (154, "AccessorInfoMap"),
+-  ("MAP_SPACE", 0x04671): (153, "AccessCheckInfoMap"),
+-  ("MAP_SPACE", 0x046c9): (155, "AccessorPairMap"),
+-  ("MAP_SPACE", 0x04721): (156, "AliasedArgumentsEntryMap"),
+-  ("MAP_SPACE", 0x04779): (157, "AllocationMementoMap"),
+-  ("MAP_SPACE", 0x047d1): (158, "AllocationSiteMap"),
++  ("MAP_SPACE", 0x04619): (158, "AllocationSiteMap"),
++  ("MAP_SPACE", 0x04671): (154, "AccessorInfoMap"),
++  ("MAP_SPACE", 0x046c9): (153, "AccessCheckInfoMap"),
++  ("MAP_SPACE", 0x04721): (155, "AccessorPairMap"),
++  ("MAP_SPACE", 0x04779): (156, "AliasedArgumentsEntryMap"),
++  ("MAP_SPACE", 0x047d1): (157, "AllocationMementoMap"),
+   ("MAP_SPACE", 0x04829): (159, "AsyncGeneratorRequestMap"),
+   ("MAP_SPACE", 0x04881): (160, "ContextExtensionMap"),
+   ("MAP_SPACE", 0x048d9): (161, "DebugInfoMap"),

--- a/patches/common/v8/backport_91ddb65d.patch
+++ b/patches/common/v8/backport_91ddb65d.patch
@@ -1,11 +1,11 @@
 diff --git a/src/bootstrapper.cc b/src/bootstrapper.cc
-index 0eec2c6d09..8b272d0576 100644
+index 43c7527de98..2138b9c73d7 100644
 --- a/src/bootstrapper.cc
 +++ b/src/bootstrapper.cc
-@@ -1587,6 +1587,50 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
+@@ -1584,6 +1584,50 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
      native_context()->set_async_iterator_value_unwrap_shared_fun(*info);
    }
-
+ 
 +  {  // --- A s y n c G e n e r a t o r ---
 +    Handle<JSFunction> await_caught =
 +        SimpleCreateFunction(isolate, factory->empty_string(),
@@ -53,10 +53,10 @@ index 0eec2c6d09..8b272d0576 100644
    {  // --- A r r a y ---
      Handle<JSFunction> array_function = InstallFunction(
          global, "Array", JS_ARRAY_TYPE, JSArray::kSize, 0,
-@@ -4025,6 +4069,34 @@ void Bootstrapper::ExportFromRuntime(Isolate* isolate,
+@@ -3998,6 +4042,34 @@ void Bootstrapper::ExportFromRuntime(Isolate* isolate,
      JSFunction::SetPrototype(async_function_constructor,
                               async_function_prototype);
-
+ 
 +    {
 +      Handle<JSFunction> function =
 +          SimpleCreateFunction(isolate, factory->empty_string(),
@@ -89,13 +89,13 @@ index 0eec2c6d09..8b272d0576 100644
        Handle<JSFunction> function =
            SimpleCreateFunction(isolate, factory->empty_string(),
 diff --git a/src/builtins/builtins-async-function-gen.cc b/src/builtins/builtins-async-function-gen.cc
-index 0db53c687e..0d0e34ee0d 100644
+index 0db53c687e6..0d0e34ee0da 100644
 --- a/src/builtins/builtins-async-function-gen.cc
 +++ b/src/builtins/builtins-async-function-gen.cc
 @@ -21,18 +21,37 @@ class AsyncFunctionBuiltinsAssembler : public AsyncBuiltinsAssembler {
                            Node* const awaited, Node* const outer_promise,
                            const bool is_predicted_as_caught);
-
+ 
 -  void AsyncFunctionAwaitResume(Node* const context, Node* const argument,
 -                                Node* const generator,
 -                                JSGeneratorObject::ResumeMode resume_mode);
@@ -103,7 +103,7 @@ index 0db53c687e..0d0e34ee0d 100644
 +      Node* const context, Node* const sent_value,
 +      JSGeneratorObject::ResumeMode resume_mode);
  };
-
+ 
 -void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwaitResume(
 -    Node* const context, Node* const argument, Node* const generator,
 +namespace {
@@ -124,7 +124,7 @@ index 0db53c687e..0d0e34ee0d 100644
 -  CSA_ASSERT(this, IsJSGeneratorObject(generator));
    DCHECK(resume_mode == JSGeneratorObject::kNext ||
           resume_mode == JSGeneratorObject::kThrow);
-
+ 
 +  Node* const generator =
 +      LoadContextElement(context, AwaitContext::kGeneratorSlot);
 +  CSA_SLOW_ASSERT(this, HasInstanceType(generator, JS_GENERATOR_OBJECT_TYPE));
@@ -137,7 +137,7 @@ index 0db53c687e..0d0e34ee0d 100644
    CSA_SLOW_ASSERT(
        this,
 @@ -47,23 +66,31 @@ void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwaitResume(
-
+ 
    // Resume the {receiver} using our trampoline.
    Callable callable = CodeFactory::ResumeGenerator(isolate());
 -  TailCallStub(callable, context, argument, generator);
@@ -148,7 +148,7 @@ index 0db53c687e..0d0e34ee0d 100644
 +  // whole chain of intermediate Promises alive by returning the return value
 +  // of ResumeGenerator, as that would create a memory leak.
  }
-
+ 
 -TF_BUILTIN(AsyncFunctionAwaitFulfill, AsyncFunctionBuiltinsAssembler) {
 -  Node* const argument = Parameter(Descriptor::kArgument);
 -  Node* const generator = Parameter(Descriptor::kGenerator);
@@ -163,7 +163,7 @@ index 0db53c687e..0d0e34ee0d 100644
 +                                  JSGeneratorObject::kThrow);
 +  Return(UndefinedConstant());
  }
-
+ 
 -TF_BUILTIN(AsyncFunctionAwaitReject, AsyncFunctionBuiltinsAssembler) {
 -  Node* const argument = Parameter(Descriptor::kArgument);
 -  Node* const generator = Parameter(Descriptor::kGenerator);
@@ -177,7 +177,7 @@ index 0db53c687e..0d0e34ee0d 100644
 +  AsyncFunctionAwaitResumeClosure(context, sentValue, JSGeneratorObject::kNext);
 +  Return(UndefinedConstant());
  }
-
+ 
  // ES#abstract-ops-async-function-await
 @@ -78,12 +105,25 @@ TF_BUILTIN(AsyncFunctionAwaitReject, AsyncFunctionBuiltinsAssembler) {
  void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwait(
@@ -208,7 +208,7 @@ index 0db53c687e..0d0e34ee0d 100644
 +        init_closure_context, Context::ASYNC_FUNCTION_AWAIT_RESOLVE_SHARED_FUN,
 +        Context::ASYNC_FUNCTION_AWAIT_REJECT_SHARED_FUN,
 +        is_predicted_as_caught);
-
+ 
    // Return outer promise to avoid adding an load of the outer promise before
    // suspending in BytecodeGenerator.
 @@ -93,28 +133,30 @@ void AsyncFunctionBuiltinsAssembler::AsyncFunctionAwait(
@@ -221,14 +221,14 @@ index 0db53c687e..0d0e34ee0d 100644
 +  Node* const awaited = Parameter(Descriptor::kAwaited);
    Node* const outer_promise = Parameter(Descriptor::kOuterPromise);
    Node* const context = Parameter(Descriptor::kContext);
-
+ 
    static const bool kIsPredictedAsCaught = true;
-
+ 
 -  AsyncFunctionAwait(context, generator, value, outer_promise,
 +  AsyncFunctionAwait(context, generator, awaited, outer_promise,
                       kIsPredictedAsCaught);
  }
-
+ 
  // Called by the parser from the desugaring of 'await' when catch
  // prediction indicates no locally surrounding catch block.
  TF_BUILTIN(AsyncFunctionAwaitUncaught, AsyncFunctionBuiltinsAssembler) {
@@ -238,22 +238,22 @@ index 0db53c687e..0d0e34ee0d 100644
 +  Node* const awaited = Parameter(Descriptor::kAwaited);
    Node* const outer_promise = Parameter(Descriptor::kOuterPromise);
    Node* const context = Parameter(Descriptor::kContext);
-
+ 
    static const bool kIsPredictedAsCaught = false;
-
+ 
 -  AsyncFunctionAwait(context, generator, value, outer_promise,
 +  AsyncFunctionAwait(context, generator, awaited, outer_promise,
                       kIsPredictedAsCaught);
  }
-
+ 
 diff --git a/src/builtins/builtins-async-gen.cc b/src/builtins/builtins-async-gen.cc
-index 073c96a2e0..ba0226d7b3 100644
+index 073c96a2e09..ba0226d7b3a 100644
 --- a/src/builtins/builtins-async-gen.cc
 +++ b/src/builtins/builtins-async-gen.cc
 @@ -13,58 +13,6 @@ namespace internal {
-
+ 
  using compiler::Node;
-
+ 
 -void AsyncBuiltinsAssembler::Await(Node* context, Node* generator, Node* value,
 -                                   Node* outer_promise,
 -                                   Builtins::Name fulfill_builtin,
@@ -310,9 +310,9 @@ index 073c96a2e0..ba0226d7b3 100644
  // Describe fields of Context associated with the AsyncIterator unwrap closure.
  class ValueUnwrapContext {
 @@ -74,6 +22,161 @@ class ValueUnwrapContext {
-
+ 
  }  // namespace
-
+ 
 +Node* AsyncBuiltinsAssembler::Await(
 +    Node* context, Node* generator, Node* value, Node* outer_promise,
 +    int context_length, const ContextInitializer& init_closure_context,
@@ -472,12 +472,12 @@ index 073c96a2e0..ba0226d7b3 100644
                                                    Node* done) {
    Node* const map = LoadContextElement(
 diff --git a/src/builtins/builtins-async-gen.h b/src/builtins/builtins-async-gen.h
-index 70f68a498b..45d7c8689a 100644
+index 70f68a498b7..45d7c8689a9 100644
 --- a/src/builtins/builtins-async-gen.h
 +++ b/src/builtins/builtins-async-gen.h
 @@ -16,23 +16,48 @@ class AsyncBuiltinsAssembler : public PromiseBuiltinsAssembler {
        : PromiseBuiltinsAssembler(state) {}
-
+ 
   protected:
 -  void Await(Node* context, Node* generator, Node* value, Node* outer_promise,
 -             Builtins::Name fulfill_builtin, Builtins::Name reject_builtin,
@@ -517,11 +517,11 @@ index 70f68a498b..45d7c8689a 100644
 +                 on_reject_context_index,
 +                 BooleanConstant(is_predicted_as_caught));
 +  }
-
+ 
    // Return a new built-in function object as defined in
    // Async Iterator Value Unwrap Functions
    Node* CreateUnwrapClosure(Node* const native_context, Node* const done);
-
+ 
   private:
 +  void InitializeNativeClosure(Node* context, Node* native_context,
 +                               Node* function, Node* context_index);
@@ -531,10 +531,10 @@ index 70f68a498b..45d7c8689a 100644
 -                                    Node* reject_handler, Node* promise,
 -                                    Node* context);
  };
-
+ 
  }  // namespace internal
 diff --git a/src/builtins/builtins-async-generator-gen.cc b/src/builtins/builtins-async-generator-gen.cc
-index 290252da62..dd6c644196 100644
+index 290252da624..dd6c6441964 100644
 --- a/src/builtins/builtins-async-generator-gen.cc
 +++ b/src/builtins/builtins-async-generator-gen.cc
 @@ -140,8 +140,8 @@ class AsyncGeneratorBuiltinsAssembler : public AsyncBuiltinsAssembler {
@@ -547,11 +547,11 @@ index 290252da62..dd6c644196 100644
 +      Node* context, Node* value,
        JSAsyncGeneratorObject::ResumeMode resume_mode);
  };
-
+ 
 @@ -219,9 +219,11 @@ Node* AsyncGeneratorBuiltinsAssembler::AllocateAsyncGeneratorRequest(
    return request;
  }
-
+ 
 -void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwaitResume(
 -    Node* context, Node* generator, Node* argument,
 +void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwaitResumeClosure(
@@ -560,19 +560,19 @@ index 290252da62..dd6c644196 100644
 +  Node* const generator =
 +      LoadContextElement(context, AwaitContext::kGeneratorSlot);
    CSA_SLOW_ASSERT(this, TaggedIsAsyncGenerator(generator));
-
+ 
    SetGeneratorNotAwaiting(generator);
 @@ -233,30 +235,36 @@ void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwaitResume(
                                   JSGeneratorObject::kResumeModeOffset,
                                   SmiConstant(resume_mode));
-
+ 
 -  CallStub(CodeFactory::ResumeGenerator(isolate()), context, argument,
 -           generator);
 +  CallStub(CodeFactory::ResumeGenerator(isolate()), context, value, generator);
-
+ 
    TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
  }
-
+ 
  template <typename Descriptor>
  void AsyncGeneratorBuiltinsAssembler::AsyncGeneratorAwait(bool is_catchable) {
 -  Node* const generator = Parameter(Descriptor::kGenerator);
@@ -581,12 +581,12 @@ index 290252da62..dd6c644196 100644
 +  Node* generator = Parameter(Descriptor::kGenerator);
 +  Node* value = Parameter(Descriptor::kAwaited);
 +  Node* context = Parameter(Descriptor::kContext);
-
+ 
    CSA_SLOW_ASSERT(this, TaggedIsAsyncGenerator(generator));
-
+ 
    Node* const request = LoadFirstAsyncGeneratorRequestFromQueue(generator);
    CSA_ASSERT(this, IsNotUndefined(request));
-
+ 
 +  ContextInitializer init_closure_context = [&](Node* context) {
 +    StoreContextElementNoWriteBarrier(context, AwaitContext::kGeneratorSlot,
 +                                      generator);
@@ -594,7 +594,7 @@ index 290252da62..dd6c644196 100644
 +
    Node* outer_promise =
        LoadObjectField(request, AsyncGeneratorRequest::kPromiseOffset);
-
+ 
 +  const int resolve_index = Context::ASYNC_GENERATOR_AWAIT_RESOLVE_SHARED_FUN;
 +  const int reject_index = Context::ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN;
 +
@@ -606,11 +606,11 @@ index 290252da62..dd6c644196 100644
 +        init_closure_context, resolve_index, reject_index, is_catchable);
    Return(UndefinedConstant());
  }
-
+ 
 @@ -367,20 +375,18 @@ TF_BUILTIN(AsyncGeneratorPrototypeThrow, AsyncGeneratorBuiltinsAssembler) {
                          "[AsyncGenerator].prototype.throw");
  }
-
+ 
 -TF_BUILTIN(AsyncGeneratorAwaitFulfill, AsyncGeneratorBuiltinsAssembler) {
 -  Node* const generator = Parameter(Descriptor::kGenerator);
 -  Node* const argument = Parameter(Descriptor::kArgument);
@@ -623,7 +623,7 @@ index 290252da62..dd6c644196 100644
 +  AsyncGeneratorAwaitResumeClosure(context, value,
 +                                   JSAsyncGeneratorObject::kNext);
  }
-
+ 
 -TF_BUILTIN(AsyncGeneratorAwaitReject, AsyncGeneratorBuiltinsAssembler) {
 -  Node* const generator = Parameter(Descriptor::kGenerator);
 -  Node* const argument = Parameter(Descriptor::kArgument);
@@ -636,12 +636,12 @@ index 290252da62..dd6c644196 100644
 +  AsyncGeneratorAwaitResumeClosure(context, value,
 +                                   JSAsyncGeneratorObject::kThrow);
  }
-
+ 
  TF_BUILTIN(AsyncGeneratorAwaitUncaught, AsyncGeneratorBuiltinsAssembler) {
 @@ -518,34 +524,11 @@ TF_BUILTIN(AsyncGeneratorResolve, AsyncGeneratorBuiltinsAssembler) {
                                     done);
    }
-
+ 
 -  // We know that {iter_result} itself doesn't have any "then" property and
 -  // we also know that the [[Prototype]] of {iter_result} is the intrinsic
 -  // %ObjectPrototype%. So we can skip the [[Resolve]] logic here completely
@@ -668,24 +668,24 @@ index 290252da62..dd6c644196 100644
 -  }
 +  // Perform Call(promiseCapability.[[Resolve]], undefined, «iteratorResult»).
 +  CallBuiltin(Builtins::kResolvePromise, context, promise, iter_result);
-
+ 
    // Per spec, AsyncGeneratorResolve() returns undefined. However, for the
    // benefit of %TraceExit(), return the Promise.
 -  BIND(&return_promise);
    Return(promise);
  }
-
+ 
 @@ -571,54 +554,31 @@ TF_BUILTIN(AsyncGeneratorYield, AsyncGeneratorBuiltinsAssembler) {
    Node* const request = LoadFirstAsyncGeneratorRequestFromQueue(generator);
    Node* const outer_promise = LoadPromiseFromAsyncGeneratorRequest(request);
-
+ 
 -  // Mark the generator as "awaiting".
 -  SetGeneratorAwaiting(generator);
 +  ContextInitializer init_closure_context = [&](Node* context) {
 +    StoreContextElementNoWriteBarrier(context, AwaitContext::kGeneratorSlot,
 +                                      generator);
 +  };
-
+ 
 -  // We can skip the creation of a temporary promise and the whole
 -  // [[Resolve]] logic if we already know that the {value} that's
 -  // being yielded is a primitive, as in that case we would immediately
@@ -707,7 +707,7 @@ index 290252da62..dd6c644196 100644
 -  }
 +  const int on_resolve = Context::ASYNC_GENERATOR_YIELD_RESOLVE_SHARED_FUN;
 +  const int on_reject = Context::ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN;
-
+ 
 -  BIND(&if_primitive);
 -  {
 -    // For primitive {value}s we can skip the allocation of the temporary
@@ -726,7 +726,7 @@ index 290252da62..dd6c644196 100644
 +        init_closure_context, on_resolve, on_reject, is_caught);
 +  Return(UndefinedConstant());
  }
-
+ 
 -TF_BUILTIN(AsyncGeneratorYieldFulfill, AsyncGeneratorBuiltinsAssembler) {
 +TF_BUILTIN(AsyncGeneratorYieldResolveClosure, AsyncGeneratorBuiltinsAssembler) {
    Node* const context = Parameter(Descriptor::kContext);
@@ -735,15 +735,15 @@ index 290252da62..dd6c644196 100644
 +  Node* const value = Parameter(Descriptor::kValue);
 +  Node* const generator =
 +      LoadContextElement(context, AwaitContext::kGeneratorSlot);
-
+ 
    SetGeneratorNotAwaiting(generator);
-
+ 
    // Per proposal-async-iteration/#sec-asyncgeneratoryield step 9
    // Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *false*).
 -  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, argument,
 +  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, value,
                FalseConstant());
-
+ 
    TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
 @@ -644,33 +604,39 @@ TF_BUILTIN(AsyncGeneratorReturn, AsyncGeneratorBuiltinsAssembler) {
    Node* const generator = Parameter(Descriptor::kGenerator);
@@ -753,7 +753,7 @@ index 290252da62..dd6c644196 100644
    Node* const req = LoadFirstAsyncGeneratorRequestFromQueue(generator);
 -  Node* const outer_promise = LoadPromiseFromAsyncGeneratorRequest(req);
    CSA_ASSERT(this, IsNotUndefined(req));
-
+ 
 -  Label if_closed(this, Label::kDeferred), if_not_closed(this), done(this);
 +  Label perform_await(this);
 +  VARIABLE(var_on_resolve, MachineType::PointerRepresentation(),
@@ -772,7 +772,7 @@ index 290252da62..dd6c644196 100644
 +  var_on_reject.Bind(
 +      IntPtrConstant(Context::ASYNC_GENERATOR_AWAIT_REJECT_SHARED_FUN));
 +  Goto(&perform_await);
-
+ 
 -  BIND(&if_closed);
 -  {
 -    Await(context, generator, value, outer_promise,
@@ -781,7 +781,7 @@ index 290252da62..dd6c644196 100644
 -    Goto(&done);
 -  }
 +  BIND(&perform_await);
-
+ 
 -  BIND(&if_not_closed);
 -  {
 -    Await(context, generator, value, outer_promise,
@@ -800,11 +800,11 @@ index 290252da62..dd6c644196 100644
 +  Await(context, generator, value, outer_promise, AwaitContext::kLength,
 +        init_closure_context, var_on_resolve.value(), var_on_reject.value(),
 +        is_caught);
-
+ 
 -  BIND(&done);
    Return(UndefinedConstant());
  }
-
+ 
 @@ -678,44 +644,47 @@ TF_BUILTIN(AsyncGeneratorReturn, AsyncGeneratorBuiltinsAssembler) {
  // Resume the generator with "return" resume_mode, and finally perform
  // AsyncGeneratorResumeNext. Per
@@ -820,7 +820,7 @@ index 290252da62..dd6c644196 100644
 +  Node* const value = Parameter(Descriptor::kValue);
 +  AsyncGeneratorAwaitResumeClosure(context, value, JSGeneratorObject::kReturn);
  }
-
+ 
  // On-resolve closure for Await in AsyncGeneratorReturn
  // Perform AsyncGeneratorResolve({awaited_value}, true) and finally perform
  // AsyncGeneratorResumeNext.
@@ -833,19 +833,19 @@ index 290252da62..dd6c644196 100644
 +  Node* const value = Parameter(Descriptor::kValue);
 +  Node* const generator =
 +      LoadContextElement(context, AwaitContext::kGeneratorSlot);
-
+ 
    SetGeneratorNotAwaiting(generator);
-
+ 
    // https://tc39.github.io/proposal-async-iteration/
    //    #async-generator-resume-next-return-processor-fulfilled step 2:
    //  Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
 -  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, argument,
 +  CallBuiltin(Builtins::kAsyncGeneratorResolve, context, generator, value,
                TrueConstant());
-
+ 
    TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
  }
-
+ 
 -TF_BUILTIN(AsyncGeneratorReturnClosedReject, AsyncGeneratorBuiltinsAssembler) {
 -  Node* const generator = Parameter(Descriptor::kGenerator);
 -  Node* const argument = Parameter(Descriptor::kArgument);
@@ -855,22 +855,22 @@ index 290252da62..dd6c644196 100644
 +  Node* const value = Parameter(Descriptor::kValue);
 +  Node* const generator =
 +      LoadContextElement(context, AwaitContext::kGeneratorSlot);
-
+ 
    SetGeneratorNotAwaiting(generator);
-
+ 
    // https://tc39.github.io/proposal-async-iteration/
    //    #async-generator-resume-next-return-processor-rejected step 2:
    // Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
 -  CallBuiltin(Builtins::kAsyncGeneratorReject, context, generator, argument);
 +  CallBuiltin(Builtins::kAsyncGeneratorReject, context, generator, value);
-
+ 
    TailCallBuiltin(Builtins::kAsyncGeneratorResumeNext, context, generator);
  }
 diff --git a/src/builtins/builtins-definitions.h b/src/builtins/builtins-definitions.h
-index d0ef062903..7daaa69f8d 100644
+index 0f60dfd97e8..5f06abeceb0 100644
 --- a/src/builtins/builtins-definitions.h
 +++ b/src/builtins/builtins-definitions.h
-@@ -375,10 +375,10 @@ namespace internal {
+@@ -381,10 +381,10 @@ namespace internal {
    CPP(ArrayBufferPrototypeSlice)                                               \
                                                                                 \
    /* AsyncFunction */                                                          \
@@ -885,7 +885,7 @@ index d0ef062903..7daaa69f8d 100644
    TFJ(AsyncFunctionPromiseCreate, 0)                                           \
    TFJ(AsyncFunctionPromiseRelease, 1, kPromise)                                \
                                                                                 \
-@@ -835,8 +835,8 @@ namespace internal {
+@@ -838,8 +838,8 @@ namespace internal {
    /* ES #sec-promise.prototype.catch */                                        \
    TFJ(PromisePrototypeCatch, 1, kOnRejected)                                   \
    /* ES #sec-promisereactionjob */                                             \
@@ -932,7 +932,7 @@ index d0ef062903..7daaa69f8d 100644
    /* Async-from-Sync Iterator */                                               \
                                                                                 \
    /* %AsyncFromSyncIteratorPrototype% */                                       \
-@@ -1311,7 +1311,11 @@ namespace internal {
+@@ -1284,7 +1284,11 @@ namespace internal {
    V(AsyncFromSyncIteratorPrototypeNext)              \
    V(AsyncFromSyncIteratorPrototypeReturn)            \
    V(AsyncFromSyncIteratorPrototypeThrow)             \
@@ -945,20 +945,20 @@ index d0ef062903..7daaa69f8d 100644
    V(PromiseConstructor)                              \
    V(PromiseConstructorLazyDeoptContinuation)         \
 diff --git a/src/builtins/builtins-internal-gen.cc b/src/builtins/builtins-internal-gen.cc
-index 5c3842761e..c1bf7df2ec 100644
+index e1f4aea4052..4e533ad1c4c 100644
 --- a/src/builtins/builtins-internal-gen.cc
 +++ b/src/builtins/builtins-internal-gen.cc
 @@ -669,7 +669,7 @@ class InternalBuiltinsAssembler : public CodeStubAssembler {
    void LeaveMicrotaskContext();
-
+ 
    void RunPromiseHook(Runtime::FunctionId id, TNode<Context> context,
 -                      SloppyTNode<HeapObject> payload);
 +                      SloppyTNode<HeapObject> promise_or_capability);
-
+ 
    TNode<Object> GetPendingException() {
      auto ref = ExternalReference(kPendingExceptionAddress, isolate());
 @@ -790,12 +790,20 @@ void InternalBuiltinsAssembler::LeaveMicrotaskContext() {
-
+ 
  void InternalBuiltinsAssembler::RunPromiseHook(
      Runtime::FunctionId id, TNode<Context> context,
 -    SloppyTNode<HeapObject> payload) {
@@ -988,23 +988,23 @@ index 5c3842761e..c1bf7df2ec 100644
 -            LoadObjectField(microtask, PromiseReactionJobTask::kPayloadOffset);
 +        Node* const promise_or_capability = LoadObjectField(
 +            microtask, PromiseReactionJobTask::kPromiseOrCapabilityOffset);
-
+ 
          // Run the promise before/debug hook if enabled.
 -        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context, payload);
 +        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context,
 +                       promise_or_capability);
-
+ 
          Node* const result =
              CallBuiltin(Builtins::kPromiseFulfillReactionJob, microtask_context,
 -                        argument, handler, payload);
 +                        argument, handler, promise_or_capability);
          GotoIfException(result, &if_exception, &var_exception);
-
+ 
          // Run the promise after/debug hook if enabled.
 -        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context, payload);
 +        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context,
 +                       promise_or_capability);
-
+ 
          LeaveMicrotaskContext();
          SetCurrentContext(current_context);
 @@ -1041,19 +1051,21 @@ TF_BUILTIN(RunMicrotasks, InternalBuiltinsAssembler) {
@@ -1015,33 +1015,33 @@ index 5c3842761e..c1bf7df2ec 100644
 -            LoadObjectField(microtask, PromiseReactionJobTask::kPayloadOffset);
 +        Node* const promise_or_capability = LoadObjectField(
 +            microtask, PromiseReactionJobTask::kPromiseOrCapabilityOffset);
-
+ 
          // Run the promise before/debug hook if enabled.
 -        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context, payload);
 +        RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context,
 +                       promise_or_capability);
-
+ 
          Node* const result =
              CallBuiltin(Builtins::kPromiseRejectReactionJob, microtask_context,
 -                        argument, handler, payload);
 +                        argument, handler, promise_or_capability);
          GotoIfException(result, &if_exception, &var_exception);
-
+ 
          // Run the promise after/debug hook if enabled.
 -        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context, payload);
 +        RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context,
 +                       promise_or_capability);
-
+ 
          LeaveMicrotaskContext();
          SetCurrentContext(current_context);
 diff --git a/src/builtins/builtins-promise-gen.cc b/src/builtins/builtins-promise-gen.cc
-index dd38dbc543..868b45a831 100644
+index dd38dbc5435..868b45a8316 100644
 --- a/src/builtins/builtins-promise-gen.cc
 +++ b/src/builtins/builtins-promise-gen.cc
 @@ -391,15 +391,15 @@ TF_BUILTIN(PerformPromiseThen, PromiseBuiltinsAssembler) {
    Return(result_promise);
  }
-
+ 
 -Node* PromiseBuiltinsAssembler::AllocatePromiseReaction(Node* next,
 -                                                        Node* payload,
 -                                                        Node* fulfill_handler,
@@ -1062,7 +1062,7 @@ index dd38dbc543..868b45a831 100644
    StoreObjectFieldNoWriteBarrier(
 @@ -408,7 +408,8 @@ Node* PromiseBuiltinsAssembler::AllocatePromiseReaction(Node* next,
  }
-
+ 
  Node* PromiseBuiltinsAssembler::AllocatePromiseReactionJobTask(
 -    Node* map, Node* context, Node* argument, Node* handler, Node* payload) {
 +    Node* map, Node* context, Node* argument, Node* handler,
@@ -1079,7 +1079,7 @@ index dd38dbc543..868b45a831 100644
 +      promise_or_capability);
    return microtask;
  }
-
+ 
  Node* PromiseBuiltinsAssembler::AllocatePromiseReactionJobTask(
      Heap::RootListIndex map_root_index, Node* context, Node* argument,
 -    Node* handler, Node* payload) {
@@ -1091,7 +1091,7 @@ index dd38dbc543..868b45a831 100644
 -                                        payload);
 +                                        promise_or_capability);
  }
-
+ 
  Node* PromiseBuiltinsAssembler::AllocatePromiseResolveThenableJobTask(
 @@ -502,8 +504,8 @@ Node* PromiseBuiltinsAssembler::TriggerPromiseReactions(
                           context);
@@ -1116,7 +1116,7 @@ index dd38dbc543..868b45a831 100644
        CallBuiltin(Builtins::kEnqueueMicrotask, NoContextConstant(), current);
        Goto(&loop);
 @@ -1118,28 +1120,20 @@ TF_BUILTIN(PromiseResolveThenableJob, PromiseBuiltinsAssembler) {
-
+ 
  // ES #sec-promisereactionjob
  void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
 -                                                  Node* handler, Node* payload,
@@ -1131,7 +1131,7 @@ index dd38dbc543..868b45a831 100644
 +  CSA_ASSERT(this, TaggedIsNotSmi(promise_or_capability));
 +  CSA_ASSERT(this, Word32Or(IsJSPromise(promise_or_capability),
 +                            IsPromiseCapability(promise_or_capability)));
-
+ 
    VARIABLE(var_handler_result, MachineRepresentation::kTagged, argument);
 -  Label if_handler_callable(this), if_fulfill(this), if_reject(this),
 -      if_code_handler(this);
@@ -1151,7 +1151,7 @@ index dd38dbc543..868b45a831 100644
 +  Branch(IsUndefined(handler),
 +         type == PromiseReaction::kFulfill ? &if_fulfill : &if_reject,
 +         &if_handler_callable);
-
+ 
    BIND(&if_handler_callable);
    {
 @@ -1155,22 +1149,24 @@ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
@@ -1161,7 +1161,7 @@ index dd38dbc543..868b45a831 100644
 -    Branch(IsPromiseCapability(payload), &if_promise_capability, &if_promise);
 +    Branch(IsPromiseCapability(promise_or_capability), &if_promise_capability,
 +           &if_promise);
-
+ 
      BIND(&if_promise);
      {
        // For fast native promises we can skip the indirection
@@ -1171,7 +1171,7 @@ index dd38dbc543..868b45a831 100644
 +      TailCallBuiltin(Builtins::kResolvePromise, context, promise_or_capability,
 +                      value);
      }
-
+ 
      BIND(&if_promise_capability);
      {
        // In the general case we need to call the (user provided)
@@ -1190,7 +1190,7 @@ index dd38dbc543..868b45a831 100644
 -    Branch(IsPromiseCapability(payload), &if_promise_capability, &if_promise);
 +    Branch(IsPromiseCapability(promise_or_capability), &if_promise_capability,
 +           &if_promise);
-
+ 
      BIND(&if_promise);
      {
        // For fast native promises we can skip the indirection
@@ -1201,7 +1201,7 @@ index dd38dbc543..868b45a831 100644
 +      TailCallBuiltin(Builtins::kRejectPromise, context, promise_or_capability,
 +                      reason, FalseConstant());
      }
-
+ 
      BIND(&if_promise_capability);
 @@ -1201,8 +1198,8 @@ void PromiseBuiltinsAssembler::PromiseReactionJob(Node* context, Node* argument,
        Label if_exception(this, Label::kDeferred);
@@ -1223,7 +1223,7 @@ index dd38dbc543..868b45a831 100644
 +                    promise_or_capability);
    }
  }
-
+ 
 @@ -1228,9 +1226,10 @@ TF_BUILTIN(PromiseFulfillReactionJob, PromiseBuiltinsAssembler) {
    Node* const context = Parameter(Descriptor::kContext);
    Node* const value = Parameter(Descriptor::kValue);
@@ -1231,12 +1231,12 @@ index dd38dbc543..868b45a831 100644
 -  Node* const payload = Parameter(Descriptor::kPayload);
 +  Node* const promise_or_capability =
 +      Parameter(Descriptor::kPromiseOrCapability);
-
+ 
 -  PromiseReactionJob(context, value, handler, payload,
 +  PromiseReactionJob(context, value, handler, promise_or_capability,
                       PromiseReaction::kFulfill);
  }
-
+ 
 @@ -1239,9 +1238,10 @@ TF_BUILTIN(PromiseRejectReactionJob, PromiseBuiltinsAssembler) {
    Node* const context = Parameter(Descriptor::kContext);
    Node* const reason = Parameter(Descriptor::kReason);
@@ -1244,21 +1244,21 @@ index dd38dbc543..868b45a831 100644
 -  Node* const payload = Parameter(Descriptor::kPayload);
 +  Node* const promise_or_capability =
 +      Parameter(Descriptor::kPromiseOrCapability);
-
+ 
 -  PromiseReactionJob(context, reason, handler, payload,
 +  PromiseReactionJob(context, reason, handler, promise_or_capability,
                       PromiseReaction::kReject);
  }
-
+ 
 @@ -1717,23 +1717,21 @@ TF_BUILTIN(ResolvePromise, PromiseBuiltinsAssembler) {
-
+ 
    // 7. If Type(resolution) is not Object, then
    GotoIf(TaggedIsSmi(resolution), &if_fulfill);
 -  Node* const resolution_map = LoadMap(resolution);
 -  GotoIfNot(IsJSReceiverMap(resolution_map), &if_fulfill);
 +  Node* const result_map = LoadMap(resolution);
 +  GotoIfNot(IsJSReceiverMap(result_map), &if_fulfill);
-
+ 
    // We can skip the "then" lookup on {resolution} if its [[Prototype]]
    // is the (initial) Promise.prototype and the Promise#then protector
    // is intact, as that guards the lookup path for the "then" property
@@ -1275,7 +1275,7 @@ index dd38dbc543..868b45a831 100644
 -         &if_fast, &if_slow);
 +  BranchIfPromiseThenLookupChainIntact(native_context, result_map, &if_fast,
 +                                       &if_slow);
-
+ 
 +  // Resolution is a native promise and if it's already resolved or
 +  // rejected, shortcircuit the resolution procedure by directly
 +  // reusing the value from the promise.
@@ -1285,7 +1285,7 @@ index dd38dbc543..868b45a831 100644
 @@ -1742,21 +1740,6 @@ TF_BUILTIN(ResolvePromise, PromiseBuiltinsAssembler) {
      Goto(&do_enqueue);
    }
-
+ 
 -  BIND(&if_generic);
 -  {
 -    // We can skip the lookup of "then" if the {resolution} is a (newly
@@ -1305,17 +1305,17 @@ index dd38dbc543..868b45a831 100644
    {
      // 8. Let then be Get(resolution, "then").
 diff --git a/src/builtins/builtins-promise-gen.h b/src/builtins/builtins-promise-gen.h
-index f21d86a141..694cea28c0 100644
+index f21d86a141a..694cea28c06 100644
 --- a/src/builtins/builtins-promise-gen.h
 +++ b/src/builtins/builtins-promise-gen.h
 @@ -85,14 +85,16 @@ class PromiseBuiltinsAssembler : public CodeStubAssembler {
    Node* AllocateAndSetJSPromise(Node* context, v8::Promise::PromiseState status,
                                  Node* result);
-
+ 
 -  Node* AllocatePromiseReaction(Node* next, Node* payload,
 +  Node* AllocatePromiseReaction(Node* next, Node* promise_or_capability,
                                  Node* fulfill_handler, Node* reject_handler);
-
+ 
    Node* AllocatePromiseReactionJobTask(Heap::RootListIndex map_root_index,
                                         Node* context, Node* argument,
 -                                       Node* handler, Node* payload);
@@ -1330,16 +1330,41 @@ index f21d86a141..694cea28c0 100644
                                                Node* context);
 @@ -192,7 +194,8 @@ class PromiseBuiltinsAssembler : public CodeStubAssembler {
    Node* PromiseStatus(Node* promise);
-
+ 
    void PromiseReactionJob(Node* context, Node* argument, Node* handler,
 -                          Node* payload, PromiseReaction::Type type);
 +                          Node* promise_or_capability,
 +                          PromiseReaction::Type type);
-
+ 
    Node* IsPromiseStatus(Node* actual, v8::Promise::PromiseState expected);
    void PromiseSetStatus(Node* promise, v8::Promise::PromiseState status);
+diff --git a/src/builtins/builtins.cc b/src/builtins/builtins.cc
+index c348248fffb..7e6a0459a7d 100644
+--- a/src/builtins/builtins.cc
++++ b/src/builtins/builtins.cc
+@@ -364,17 +364,12 @@ bool Builtins::IsIsolateIndependent(int index) {
+     case kAsyncFromSyncIteratorPrototypeNext:
+     case kAsyncFromSyncIteratorPrototypeReturn:
+     case kAsyncFromSyncIteratorPrototypeThrow:
+-    case kAsyncFunctionAwaitFulfill:
+-    case kAsyncFunctionAwaitReject:
++    case kAsyncFunctionAwaitCaught:
+     case kAsyncFunctionPromiseCreate:
+     case kAsyncFunctionPromiseRelease:
+-    case kAsyncGeneratorAwaitFulfill:
+-    case kAsyncGeneratorAwaitReject:
+     case kAsyncGeneratorResumeNext:
+-    case kAsyncGeneratorReturnClosedFulfill:
+-    case kAsyncGeneratorReturnClosedReject:
+-    case kAsyncGeneratorReturnFulfill:
+-    case kAsyncGeneratorYieldFulfill:
++    case kAsyncGeneratorReturnClosedRejectClosure:
++    case kAsyncGeneratorReturn:
+     case kAsyncIteratorValueUnwrap:
+     case kBitwiseNot:
+     case kBooleanPrototypeToString:
 diff --git a/src/compiler/js-intrinsic-lowering.cc b/src/compiler/js-intrinsic-lowering.cc
-index c570a1f8dd..d9742e47d9 100644
+index c570a1f8ddc..d9742e47d9f 100644
 --- a/src/compiler/js-intrinsic-lowering.cc
 +++ b/src/compiler/js-intrinsic-lowering.cc
 @@ -41,14 +41,6 @@ Reduction JSIntrinsicLowering::Reduce(Node* node) {
@@ -1360,7 +1385,7 @@ index c570a1f8dd..d9742e47d9 100644
 @@ -185,33 +177,6 @@ Reduction JSIntrinsicLowering::ReduceGeneratorGetInputOrDebugPos(Node* node) {
    return Change(node, op, generator, effect, control);
  }
-
+ 
 -Reduction JSIntrinsicLowering::ReduceAsyncFunctionAwaitCaught(Node* node) {
 -  return Change(
 -      node,
@@ -1392,7 +1417,7 @@ index c570a1f8dd..d9742e47d9 100644
    return Change(
        node, Builtins::CallableFor(isolate(), Builtins::kAsyncGeneratorReject),
 diff --git a/src/compiler/js-intrinsic-lowering.h b/src/compiler/js-intrinsic-lowering.h
-index fb745986a6..18fe1248c7 100644
+index fb745986a60..18fe1248c7a 100644
 --- a/src/compiler/js-intrinsic-lowering.h
 +++ b/src/compiler/js-intrinsic-lowering.h
 @@ -45,10 +45,6 @@ class V8_EXPORT_PRIVATE JSIntrinsicLowering final
@@ -1407,13 +1432,13 @@ index fb745986a6..18fe1248c7 100644
    Reduction ReduceAsyncGeneratorResolve(Node* node);
    Reduction ReduceAsyncGeneratorYield(Node* node);
 diff --git a/src/contexts.h b/src/contexts.h
-index 4cfbb29f06..763f30f193 100644
+index 6fc6f2d1c32..fcfeccdc44e 100644
 --- a/src/contexts.h
 +++ b/src/contexts.h
 @@ -32,37 +32,44 @@ enum ContextLookupFlags {
  // must always be allocated via Heap::AllocateContext() or
  // Factory::NewContext.
-
+ 
 -#define NATIVE_CONTEXT_INTRINSIC_FUNCTIONS(V)                           \
 -  V(ASYNC_FUNCTION_PROMISE_CREATE_INDEX, JSFunction,                    \
 -    async_function_promise_create)                                      \
@@ -1483,10 +1508,10 @@ index 4cfbb29f06..763f30f193 100644
 +  V(PROMISE_THEN_INDEX, JSFunction, promise_then)                           \
 +  V(ASYNC_GENERATOR_AWAIT_CAUGHT, JSFunction, async_generator_await_caught) \
 +  V(ASYNC_GENERATOR_AWAIT_UNCAUGHT, JSFunction, async_generator_await_uncaught)
-
+ 
  #define NATIVE_CONTEXT_IMPORTED_FIELDS(V)                                 \
    V(ARRAY_POP_INDEX, JSFunction, array_pop)                               \
-@@ -114,11 +123,27 @@ enum ContextLookupFlags {
+@@ -116,11 +123,27 @@ enum ContextLookupFlags {
    V(ARRAY_BUFFER_NOINIT_FUN_INDEX, JSFunction, array_buffer_noinit_fun)        \
    V(ARRAY_FUNCTION_INDEX, JSFunction, array_function)                          \
    V(ASYNC_FROM_SYNC_ITERATOR_MAP_INDEX, Map, async_from_sync_iterator_map)     \
@@ -1515,7 +1540,7 @@ index 4cfbb29f06..763f30f193 100644
    V(BIGINT_FUNCTION_INDEX, JSFunction, bigint_function)                        \
    V(BIGINT64_ARRAY_FUN_INDEX, JSFunction, bigint64_array_fun)                  \
 diff --git a/src/heap-symbols.h b/src/heap-symbols.h
-index a6f80f4175..df4923c06a 100644
+index 82ecd766575..c15aa9ba138 100644
 --- a/src/heap-symbols.h
 +++ b/src/heap-symbols.h
 @@ -237,7 +237,6 @@
@@ -1527,21 +1552,21 @@ index a6f80f4175..df4923c06a 100644
    V(home_object_symbol)                \
    V(intl_initialized_marker_symbol)    \
 diff --git a/src/interface-descriptors.h b/src/interface-descriptors.h
-index e31abca1b0..3f047098b1 100644
+index 61da0c3f4ea..8375ea11971 100644
 --- a/src/interface-descriptors.h
 +++ b/src/interface-descriptors.h
-@@ -79,7 +79,6 @@ class PlatformInterfaceDescriptor;
+@@ -81,7 +81,6 @@ class PlatformInterfaceDescriptor;
    V(FrameDropperTrampoline)           \
    V(WasmRuntimeCall)                  \
    V(RunMicrotasks)                    \
 -  V(PromiseReactionHandler)           \
    BUILTIN_LIST_TFS(V)
-
+ 
  class V8_EXPORT_PRIVATE CallInterfaceDescriptorData {
-@@ -868,13 +867,6 @@ class RunMicrotasksDescriptor final : public CallInterfaceDescriptor {
+@@ -889,13 +888,6 @@ class RunMicrotasksDescriptor final : public CallInterfaceDescriptor {
                               0)
  };
-
+ 
 -class PromiseReactionHandlerDescriptor final : public CallInterfaceDescriptor {
 - public:
 -  DEFINE_PARAMETERS(kArgument, kGenerator)
@@ -1553,13 +1578,13 @@ index e31abca1b0..3f047098b1 100644
    class Name##Descriptor : public CallInterfaceDescriptor {               \
     public:                                                                \
 diff --git a/src/interpreter/bytecode-generator.cc b/src/interpreter/bytecode-generator.cc
-index 5a2248edf1..5f8ebb5896 100644
+index 29ad2c2a82f..744c6614f7a 100644
 --- a/src/interpreter/bytecode-generator.cc
 +++ b/src/interpreter/bytecode-generator.cc
-@@ -3251,20 +3251,22 @@ void BytecodeGenerator::BuildAwait(Expression* await_expr) {
+@@ -3239,20 +3239,22 @@ void BytecodeGenerator::BuildAwait(Expression* await_expr) {
      // Await(operand) and suspend.
      RegisterAllocationScope register_scope(this);
-
+ 
 -    Runtime::FunctionId id;
 +    int await_builtin_context_index;
      RegisterList args;
@@ -1586,23 +1611,23 @@ index 5a2248edf1..5f8ebb5896 100644
        args = register_allocator()->NewRegisterList(3);
        builder()
            ->MoveRegister(generator_object(), args[0])
-@@ -3277,7 +3279,7 @@ void BytecodeGenerator::BuildAwait(Expression* await_expr) {
+@@ -3265,7 +3267,7 @@ void BytecodeGenerator::BuildAwait(Expression* await_expr) {
        builder()->StoreAccumulatorInRegister(args[2]);
      }
-
+ 
 -    builder()->CallRuntime(id, args);
 +    builder()->CallJSRuntime(await_builtin_context_index, args);
    }
-
+ 
    BuildSuspendPoint(await_expr);
 diff --git a/src/interpreter/interpreter-intrinsics-generator.cc b/src/interpreter/interpreter-intrinsics-generator.cc
-index 675a8bcccc..0480dec6cc 100644
+index 675a8bcccc7..0480dec6cc6 100644
 --- a/src/interpreter/interpreter-intrinsics-generator.cc
 +++ b/src/interpreter/interpreter-intrinsics-generator.cc
 @@ -402,30 +402,6 @@ Node* IntrinsicsGenerator::GetImportMetaObject(
    return return_value.value();
  }
-
+ 
 -Node* IntrinsicsGenerator::AsyncFunctionAwaitCaught(
 -    const InterpreterAssembler::RegListNodePair& args, Node* context) {
 -  return IntrinsicAsBuiltinCall(args, context,
@@ -1631,7 +1656,7 @@ index 675a8bcccc..0480dec6cc 100644
      const InterpreterAssembler::RegListNodePair& args, Node* context) {
    return IntrinsicAsBuiltinCall(args, context, Builtins::kAsyncGeneratorReject);
 diff --git a/src/interpreter/interpreter-intrinsics.h b/src/interpreter/interpreter-intrinsics.h
-index 6cdfec2d04..3016183c0b 100644
+index 6cdfec2d04f..3016183c0b9 100644
 --- a/src/interpreter/interpreter-intrinsics.h
 +++ b/src/interpreter/interpreter-intrinsics.h
 @@ -14,10 +14,6 @@ namespace interpreter {
@@ -1646,20 +1671,20 @@ index 6cdfec2d04..3016183c0b 100644
    V(AsyncGeneratorResolve, async_generator_resolve, 3)                \
    V(AsyncGeneratorYield, async_generator_yield, 3)                    \
 diff --git a/src/isolate.cc b/src/isolate.cc
-index 8254e60a19..c97ece3ba4 100644
+index adb30b12ace..2c4e22726d7 100644
 --- a/src/isolate.cc
 +++ b/src/isolate.cc
-@@ -2059,7 +2059,6 @@ void Isolate::PopPromise() {
+@@ -2048,7 +2048,6 @@ void Isolate::PopPromise() {
  }
-
+ 
  namespace {
 -
  bool InternalPromiseHasUserDefinedRejectHandler(Isolate* isolate,
                                                  Handle<JSPromise> promise);
-
-@@ -2106,27 +2105,29 @@ bool InternalPromiseHasUserDefinedRejectHandler(Isolate* isolate,
+ 
+@@ -2095,27 +2094,29 @@ bool InternalPromiseHasUserDefinedRejectHandler(Isolate* isolate,
    }
-
+ 
    if (promise->status() == Promise::kPending) {
 -    Handle<Object> current(promise->reactions(), isolate);
 -    while (!current->IsSmi()) {
@@ -1705,14 +1730,14 @@ index 8254e60a19..c97ece3ba4 100644
 +      current = handle(reaction->next(), isolate);
      }
    }
-
+ 
 diff --git a/src/isolate.h b/src/isolate.h
-index 7c0153f74a..929403e134 100644
+index 75b447f1629..82d33033737 100644
 --- a/src/isolate.h
 +++ b/src/isolate.h
-@@ -1104,10 +1104,7 @@ class Isolate : private HiddenFactory {
+@@ -1096,10 +1096,7 @@ class Isolate {
    bool IsPromiseResolveLookupChainIntact();
-
+ 
    // Make sure a lookup of "then" on any JSPromise whose [[Prototype]] is the
 -  // initial %PromisePrototype% yields the initial method. In addition this
 -  // protector also guards the negative lookup of "then" on the intrinsic
@@ -1721,9 +1746,9 @@ index 7c0153f74a..929403e134 100644
 +  // initial %PromisePrototype% yields the initial method.
    bool IsPromiseThenLookupChainIntact();
    bool IsPromiseThenLookupChainIntact(Handle<JSReceiver> receiver);
-
+ 
 diff --git a/src/lookup.cc b/src/lookup.cc
-index 2050114994..a4cca33d6c 100644
+index 20501149947..a4cca33d6c3 100644
 --- a/src/lookup.cc
 +++ b/src/lookup.cc
 @@ -364,14 +364,7 @@ void LookupIterator::InternalUpdateProtector() {
@@ -1742,10 +1767,10 @@ index 2050114994..a4cca33d6c 100644
        isolate_->InvalidatePromiseThenProtector();
      }
 diff --git a/src/objects-debug.cc b/src/objects-debug.cc
-index ba33edb3ab..e12fc75230 100644
+index c735cc0813c..086078bb251 100644
 --- a/src/objects-debug.cc
 +++ b/src/objects-debug.cc
-@@ -1224,13 +1224,10 @@ void PromiseReactionJobTask::PromiseReactionJobTaskVerify() {
+@@ -1172,13 +1172,10 @@ void PromiseReactionJobTask::PromiseReactionJobTaskVerify() {
    VerifyHeapPointer(context());
    CHECK(context()->IsContext());
    VerifyHeapPointer(handler());
@@ -1761,9 +1786,9 @@ index ba33edb3ab..e12fc75230 100644
 +  CHECK(promise_or_capability()->IsJSPromise() ||
 +        promise_or_capability()->IsPromiseCapability());
  }
-
+ 
  void PromiseFulfillReactionJobTask::PromiseFulfillReactionJobTaskVerify() {
-@@ -1272,18 +1269,14 @@ void PromiseReaction::PromiseReactionVerify() {
+@@ -1220,18 +1217,14 @@ void PromiseReaction::PromiseReactionVerify() {
    VerifyPointer(next());
    CHECK(next()->IsSmi() || next()->IsPromiseReaction());
    VerifyHeapPointer(reject_handler());
@@ -1787,13 +1812,26 @@ index ba33edb3ab..e12fc75230 100644
 +  CHECK(promise_or_capability()->IsJSPromise() ||
 +        promise_or_capability()->IsPromiseCapability());
  }
-
+ 
  void JSPromise::JSPromiseVerify() {
+diff --git a/src/objects-inl.h b/src/objects-inl.h
+index bda031e0637..297e9fc836d 100644
+--- a/src/objects-inl.h
++++ b/src/objects-inl.h
+@@ -2278,7 +2278,7 @@ ACCESSORS(JSGlobalProxy, native_context, Object, kNativeContextOffset)
+ ACCESSORS(AccessorInfo, name, Name, kNameOffset)
+ SMI_ACCESSORS(AccessorInfo, flags, kFlagsOffset)
+ ACCESSORS(AccessorInfo, expected_receiver_type, Object,
+-          kExpectedReceiverTypeOffset)
++           kExpectedReceiverTypeOffset)
+ 
+ ACCESSORS_CHECKED2(AccessorInfo, getter, Object, kGetterOffset, true,
+                    Foreign::IsNormalized(value))
 diff --git a/src/objects-printer.cc b/src/objects-printer.cc
-index 5c14eb7828..99eafbb83f 100644
+index 942b9de0ba2..8d20279b2f1 100644
 --- a/src/objects-printer.cc
 +++ b/src/objects-printer.cc
-@@ -1472,7 +1472,7 @@ void PromiseFulfillReactionJobTask::PromiseFulfillReactionJobTaskPrint(
+@@ -1441,7 +1441,7 @@ void PromiseFulfillReactionJobTask::PromiseFulfillReactionJobTaskPrint(
    os << "\n - argument: " << Brief(argument());
    os << "\n - context: " << Brief(context());
    os << "\n - handler: " << Brief(handler());
@@ -1801,8 +1839,8 @@ index 5c14eb7828..99eafbb83f 100644
 +  os << "\n - promise_or_capability: " << Brief(promise_or_capability());
    os << "\n";
  }
-
-@@ -1482,7 +1482,7 @@ void PromiseRejectReactionJobTask::PromiseRejectReactionJobTaskPrint(
+ 
+@@ -1451,7 +1451,7 @@ void PromiseRejectReactionJobTask::PromiseRejectReactionJobTaskPrint(
    os << "\n - argument: " << Brief(argument());
    os << "\n - context: " << Brief(context());
    os << "\n - handler: " << Brief(handler());
@@ -1810,8 +1848,8 @@ index 5c14eb7828..99eafbb83f 100644
 +  os << "\n - promise_or_capability: " << Brief(promise_or_capability());
    os << "\n";
  }
-
-@@ -1509,7 +1509,7 @@ void PromiseReaction::PromiseReactionPrint(std::ostream& os) {  // NOLINT
+ 
+@@ -1478,7 +1478,7 @@ void PromiseReaction::PromiseReactionPrint(std::ostream& os) {  // NOLINT
    os << "\n - next: " << Brief(next());
    os << "\n - reject_handler: " << Brief(reject_handler());
    os << "\n - fulfill_handler: " << Brief(fulfill_handler());
@@ -1819,15 +1857,15 @@ index 5c14eb7828..99eafbb83f 100644
 +  os << "\n - promise_or_capability: " << Brief(promise_or_capability());
    os << "\n";
  }
-
+ 
 diff --git a/src/objects.cc b/src/objects.cc
-index d21f59c412..16c5c5b294 100644
+index 8057cb837b1..6565910fd3f 100644
 --- a/src/objects.cc
 +++ b/src/objects.cc
-@@ -16118,27 +16118,6 @@ MaybeHandle<Object> JSPromise::Resolve(Handle<JSPromise> promise,
+@@ -16054,27 +16054,6 @@ MaybeHandle<Object> JSPromise::Resolve(Handle<JSPromise> promise,
    return isolate->factory()->undefined_value();
  }
-
+ 
 -// static
 -MaybeHandle<JSPromise> JSPromise::From(Handle<HeapObject> object) {
 -  Isolate* const isolate = object->GetIsolate();
@@ -1852,7 +1890,7 @@ index d21f59c412..16c5c5b294 100644
  // static
  Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
                                                    Handle<Object> reactions,
-@@ -16178,8 +16157,8 @@ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
+@@ -16114,8 +16093,8 @@ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
            *isolate->native_context());
        STATIC_ASSERT(PromiseReaction::kFulfillHandlerOffset ==
                      PromiseFulfillReactionJobTask::kHandlerOffset);
@@ -1863,7 +1901,7 @@ index d21f59c412..16c5c5b294 100644
      } else {
        DisallowHeapAllocation no_gc;
        HeapObject* handler = reaction->reject_handler();
-@@ -16189,8 +16168,8 @@ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
+@@ -16125,8 +16104,8 @@ Handle<Object> JSPromise::TriggerPromiseReactions(Isolate* isolate,
        Handle<PromiseRejectReactionJobTask>::cast(task)->set_context(
            *isolate->native_context());
        Handle<PromiseRejectReactionJobTask>::cast(task)->set_handler(handler);
@@ -1872,16 +1910,16 @@ index d21f59c412..16c5c5b294 100644
 +      STATIC_ASSERT(PromiseReaction::kPromiseOrCapabilityOffset ==
 +                    PromiseRejectReactionJobTask::kPromiseOrCapabilityOffset);
      }
-
+ 
      isolate->EnqueueMicrotask(Handle<PromiseReactionJobTask>::cast(task));
 diff --git a/src/objects/js-promise.h b/src/objects/js-promise.h
-index 20a0a90131..434bae8933 100644
+index 20a0a90131a..434bae89338 100644
 --- a/src/objects/js-promise.h
 +++ b/src/objects/js-promise.h
 @@ -59,12 +59,6 @@ class JSPromise : public JSObject {
    V8_WARN_UNUSED_RESULT static MaybeHandle<Object> Resolve(
        Handle<JSPromise> promise, Handle<Object> resolution);
-
+ 
 -  // This is a helper that extracts the JSPromise from the input
 -  // {object}, which is used as a payload for PromiseReaction and
 -  // PromiseReactionJobTask.
@@ -1889,10 +1927,10 @@ index 20a0a90131..434bae8933 100644
 -      Handle<HeapObject> object);
 -
    DECL_CAST(JSPromise)
-
+ 
    // Dispatched behavior.
 diff --git a/src/objects/promise-inl.h b/src/objects/promise-inl.h
-index 4283f0aa19..f9fb6110f3 100644
+index 4283f0aa194..f9fb6110f34 100644
 --- a/src/objects/promise-inl.h
 +++ b/src/objects/promise-inl.h
 @@ -23,7 +23,8 @@ CAST_ACCESSOR(PromiseResolveThenableJobTask)
@@ -1902,7 +1940,7 @@ index 4283f0aa19..f9fb6110f3 100644
 -ACCESSORS(PromiseReaction, payload, HeapObject, kPayloadOffset)
 +ACCESSORS(PromiseReaction, promise_or_capability, HeapObject,
 +          kPromiseOrCapabilityOffset)
-
+ 
  ACCESSORS(PromiseResolveThenableJobTask, context, Context, kContextOffset)
  ACCESSORS(PromiseResolveThenableJobTask, promise_to_resolve, JSPromise,
 @@ -34,7 +35,8 @@ ACCESSORS(PromiseResolveThenableJobTask, thenable, JSReceiver, kThenableOffset)
@@ -1912,11 +1950,11 @@ index 4283f0aa19..f9fb6110f3 100644
 -ACCESSORS(PromiseReactionJobTask, payload, HeapObject, kPayloadOffset);
 +ACCESSORS(PromiseReactionJobTask, promise_or_capability, HeapObject,
 +          kPromiseOrCapabilityOffset);
-
+ 
  ACCESSORS(PromiseCapability, promise, HeapObject, kPromiseOffset)
  ACCESSORS(PromiseCapability, resolve, Object, kResolveOffset)
 diff --git a/src/objects/promise.h b/src/objects/promise.h
-index 36ef4afe1d..5ff5dac6f3 100644
+index 36ef4afe1d6..5ff5dac6f37 100644
 --- a/src/objects/promise.h
 +++ b/src/objects/promise.h
 @@ -26,16 +26,15 @@ class PromiseReactionJobTask : public Microtask {
@@ -1929,7 +1967,7 @@ index 36ef4afe1d..5ff5dac6f3 100644
 -  DECL_ACCESSORS(payload, HeapObject)
 +  // [promise_or_capability]: Either a JSPromise or a PromiseCapability.
 +  DECL_ACCESSORS(promise_or_capability, HeapObject)
-
+ 
    static const int kArgumentOffset = Microtask::kHeaderSize;
    static const int kContextOffset = kArgumentOffset + kPointerSize;
    static const int kHandlerOffset = kContextOffset + kPointerSize;
@@ -1937,7 +1975,7 @@ index 36ef4afe1d..5ff5dac6f3 100644
 -  static const int kSize = kPayloadOffset + kPointerSize;
 +  static const int kPromiseOrCapabilityOffset = kHandlerOffset + kPointerSize;
 +  static const int kSize = kPromiseOrCapabilityOffset + kPointerSize;
-
+ 
    // Dispatched behavior.
    DECL_CAST(PromiseReactionJobTask)
 @@ -121,10 +120,9 @@ class PromiseCapability : public Struct {
@@ -1956,7 +1994,7 @@ index 36ef4afe1d..5ff5dac6f3 100644
  // the default handlers (in case they are undefined) in the proper context.
 @@ -138,18 +136,16 @@ class PromiseReaction : public Struct {
    enum Type { kFulfill, kReject };
-
+ 
    DECL_ACCESSORS(next, Object)
 -  // [reject_handler]: This is either a Code object, a Callable or Undefined.
    DECL_ACCESSORS(reject_handler, HeapObject)
@@ -1965,7 +2003,7 @@ index 36ef4afe1d..5ff5dac6f3 100644
 -  // [payload]: Usually a JSPromise or a PromiseCapability.
 -  DECL_ACCESSORS(payload, HeapObject)
 +  DECL_ACCESSORS(promise_or_capability, HeapObject)
-
+ 
    static const int kNextOffset = Struct::kHeaderSize;
    static const int kRejectHandlerOffset = kNextOffset + kPointerSize;
    static const int kFulfillHandlerOffset = kRejectHandlerOffset + kPointerSize;
@@ -1974,17 +2012,17 @@ index 36ef4afe1d..5ff5dac6f3 100644
 +  static const int kPromiseOrCapabilityOffset =
 +      kFulfillHandlerOffset + kPointerSize;
 +  static const int kSize = kPromiseOrCapabilityOffset + kPointerSize;
-
+ 
    // Dispatched behavior.
    DECL_CAST(PromiseReaction)
 diff --git a/src/runtime/runtime-generator.cc b/src/runtime/runtime-generator.cc
-index e69d334042..3c7c808c30 100644
+index e69d3340426..3c7c808c30b 100644
 --- a/src/runtime/runtime-generator.cc
 +++ b/src/runtime/runtime-generator.cc
 @@ -70,30 +70,6 @@ RUNTIME_FUNCTION(Runtime_GeneratorGetInputOrDebugPos) {
    UNREACHABLE();
  }
-
+ 
 -RUNTIME_FUNCTION(Runtime_AsyncFunctionAwaitCaught) {
 -  // Runtime call is implemented in InterpreterIntrinsics and lowered in
 -  // JSIntrinsicLowering
@@ -2013,7 +2051,7 @@ index e69d334042..3c7c808c30 100644
    // Runtime call is implemented in InterpreterIntrinsics and lowered in
    // JSIntrinsicLowering
 diff --git a/src/runtime/runtime-promise.cc b/src/runtime/runtime-promise.cc
-index b2a7e8bae1..f5b9db3c02 100644
+index b2a7e8bae1b..f5b9db3c028 100644
 --- a/src/runtime/runtime-promise.cc
 +++ b/src/runtime/runtime-promise.cc
 @@ -114,14 +114,13 @@ RUNTIME_FUNCTION(Runtime_PromiseHookInit) {
@@ -2061,12 +2099,12 @@ index b2a7e8bae1..f5b9db3c02 100644
    return isolate->heap()->undefined_value();
  }
 diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
-index b7ef0d0af1..846e82782c 100644
+index 48a63d500da..37ce74e8250 100644
 --- a/src/runtime/runtime.h
 +++ b/src/runtime/runtime.h
-@@ -224,10 +224,6 @@ namespace internal {
+@@ -222,10 +222,6 @@ namespace internal {
    F(SetNativeFlag, 1, 1)
-
+ 
  #define FOR_EACH_INTRINSIC_GENERATOR(F)       \
 -  F(AsyncFunctionAwaitCaught, 3, 1)           \
 -  F(AsyncFunctionAwaitUncaught, 3, 1)         \
@@ -2076,7 +2114,7 @@ index b7ef0d0af1..846e82782c 100644
    F(AsyncGeneratorReject, 2, 1)               \
    F(AsyncGeneratorResolve, 3, 1)              \
 diff --git a/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden b/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden
-index 6d63516b77..8c3c29f71f 100644
+index df6b3723586..2b4eb6b2cc5 100644
 --- a/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden
 +++ b/test/cctest/interpreter/bytecode_expectations/AsyncGenerators.golden
 @@ -39,7 +39,7 @@ bytecodes: [
@@ -2088,7 +2126,7 @@ index 6d63516b77..8c3c29f71f 100644
                  B(SuspendGenerator), R(0), R(0), U8(5), U8(1),
                  B(ResumeGenerator), R(0), R(0), U8(5),
                  B(Star), R(5),
-@@ -164,7 +164,7 @@ bytecodes: [
+@@ -166,7 +166,7 @@ bytecodes: [
                  B(LdaUndefined),
                  B(Star), R(6),
                  B(Mov), R(0), R(5),
@@ -2097,7 +2135,7 @@ index 6d63516b77..8c3c29f71f 100644
                  B(SuspendGenerator), R(0), R(0), U8(5), U8(2),
                  B(ResumeGenerator), R(0), R(0), U8(5),
                  B(Star), R(5),
-@@ -399,7 +399,7 @@ bytecodes: [
+@@ -404,7 +404,7 @@ bytecodes: [
                  B(LdaUndefined),
                  B(Star), R(16),
                  B(Mov), R(2), R(15),
@@ -2106,7 +2144,7 @@ index 6d63516b77..8c3c29f71f 100644
                  B(SuspendGenerator), R(2), R(0), U8(15), U8(2),
                  B(ResumeGenerator), R(2), R(0), U8(15),
                  B(Star), R(15),
-@@ -573,7 +573,7 @@ bytecodes: [
+@@ -580,7 +580,7 @@ bytecodes: [
                  B(Jump), U8(2),
                  B(Star), R(13),
                  B(Mov), R(0), R(12),
@@ -2115,7 +2153,7 @@ index 6d63516b77..8c3c29f71f 100644
    /*   49 E> */ B(SuspendGenerator), R(0), R(0), U8(12), U8(1),
                  B(ResumeGenerator), R(0), R(0), U8(12),
                  B(Star), R(12),
-@@ -591,7 +591,7 @@ bytecodes: [
+@@ -598,7 +598,7 @@ bytecodes: [
                  B(CallRuntime), U16(Runtime::kThrowThrowMethodMissing), R(0), U8(0),
                  B(Star), R(13),
                  B(Mov), R(0), R(12),
@@ -2124,7 +2162,7 @@ index 6d63516b77..8c3c29f71f 100644
    /*   49 E> */ B(SuspendGenerator), R(0), R(0), U8(12), U8(2),
                  B(ResumeGenerator), R(0), R(0), U8(12),
                  B(Star), R(12),
-@@ -632,7 +632,7 @@ bytecodes: [
+@@ -639,7 +639,7 @@ bytecodes: [
                  B(LdaUndefined),
                  B(Star), R(6),
                  B(Mov), R(0), R(5),
@@ -2134,7 +2172,7 @@ index 6d63516b77..8c3c29f71f 100644
                  B(ResumeGenerator), R(0), R(0), U8(5),
                  B(Star), R(5),
 diff --git a/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden b/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden
-index 867e09d6ca..47bcb4aa32 100644
+index 95400dacf80..4d36315f027 100644
 --- a/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden
 +++ b/test/cctest/interpreter/bytecode_expectations/ForAwaitOf.golden
 @@ -53,7 +53,7 @@ bytecodes: [
@@ -2146,7 +2184,7 @@ index 867e09d6ca..47bcb4aa32 100644
    /*   40 E> */ B(SuspendGenerator), R(2), R(0), U8(20), U8(0),
                  B(ResumeGenerator), R(2), R(0), U8(20),
                  B(Star), R(20),
-@@ -136,7 +136,7 @@ bytecodes: [
+@@ -137,7 +137,7 @@ bytecodes: [
                  B(Star), R(21),
                  B(Mov), R(2), R(20),
                  B(Mov), R(11), R(22),
@@ -2155,7 +2193,7 @@ index 867e09d6ca..47bcb4aa32 100644
                  B(SuspendGenerator), R(2), R(0), U8(20), U8(1),
                  B(ResumeGenerator), R(2), R(0), U8(20),
                  B(Star), R(20),
-@@ -159,7 +159,7 @@ bytecodes: [
+@@ -160,7 +160,7 @@ bytecodes: [
                  B(Star), R(20),
                  B(Mov), R(2), R(19),
                  B(Mov), R(11), R(21),
@@ -2164,7 +2202,7 @@ index 867e09d6ca..47bcb4aa32 100644
                  B(SuspendGenerator), R(2), R(0), U8(19), U8(2),
                  B(ResumeGenerator), R(2), R(0), U8(19),
                  B(Star), R(19),
-@@ -303,7 +303,7 @@ bytecodes: [
+@@ -306,7 +306,7 @@ bytecodes: [
                  B(Star), R(21),
                  B(Mov), R(2), R(20),
                  B(Mov), R(11), R(22),
@@ -2173,7 +2211,7 @@ index 867e09d6ca..47bcb4aa32 100644
    /*   40 E> */ B(SuspendGenerator), R(2), R(0), U8(20), U8(0),
                  B(ResumeGenerator), R(2), R(0), U8(20),
                  B(Star), R(20),
-@@ -387,7 +387,7 @@ bytecodes: [
+@@ -391,7 +391,7 @@ bytecodes: [
                  B(Star), R(21),
                  B(Mov), R(2), R(20),
                  B(Mov), R(11), R(22),
@@ -2182,7 +2220,7 @@ index 867e09d6ca..47bcb4aa32 100644
                  B(SuspendGenerator), R(2), R(0), U8(20), U8(1),
                  B(ResumeGenerator), R(2), R(0), U8(20),
                  B(Star), R(20),
-@@ -410,7 +410,7 @@ bytecodes: [
+@@ -414,7 +414,7 @@ bytecodes: [
                  B(Star), R(20),
                  B(Mov), R(2), R(19),
                  B(Mov), R(11), R(21),
@@ -2191,7 +2229,7 @@ index 867e09d6ca..47bcb4aa32 100644
                  B(SuspendGenerator), R(2), R(0), U8(19), U8(2),
                  B(ResumeGenerator), R(2), R(0), U8(19),
                  B(Star), R(19),
-@@ -569,7 +569,7 @@ bytecodes: [
+@@ -575,7 +575,7 @@ bytecodes: [
                  B(Star), R(21),
                  B(Mov), R(2), R(20),
                  B(Mov), R(11), R(22),
@@ -2200,7 +2238,7 @@ index 867e09d6ca..47bcb4aa32 100644
    /*   40 E> */ B(SuspendGenerator), R(2), R(0), U8(20), U8(0),
                  B(ResumeGenerator), R(2), R(0), U8(20),
                  B(Star), R(20),
-@@ -660,7 +660,7 @@ bytecodes: [
+@@ -667,7 +667,7 @@ bytecodes: [
                  B(Star), R(21),
                  B(Mov), R(2), R(20),
                  B(Mov), R(11), R(22),
@@ -2209,7 +2247,7 @@ index 867e09d6ca..47bcb4aa32 100644
                  B(SuspendGenerator), R(2), R(0), U8(20), U8(1),
                  B(ResumeGenerator), R(2), R(0), U8(20),
                  B(Star), R(20),
-@@ -683,7 +683,7 @@ bytecodes: [
+@@ -690,7 +690,7 @@ bytecodes: [
                  B(Star), R(20),
                  B(Mov), R(2), R(19),
                  B(Mov), R(11), R(21),
@@ -2219,10 +2257,10 @@ index 867e09d6ca..47bcb4aa32 100644
                  B(ResumeGenerator), R(2), R(0), U8(19),
                  B(Star), R(19),
 diff --git a/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden b/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden
-index 882f61943a..ed0ef4048e 100644
+index 1a0155da79c..f92076e6e65 100644
 --- a/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden
 +++ b/test/cctest/interpreter/bytecode_expectations/ForOfLoop.golden
-@@ -1182,7 +1182,7 @@ bytecodes: [
+@@ -1196,7 +1196,7 @@ bytecodes: [
    /*   45 S> */ B(Mov), R(2), R(21),
                  B(Mov), R(0), R(22),
                  B(Mov), R(11), R(23),
@@ -2232,10 +2270,10 @@ index 882f61943a..ed0ef4048e 100644
                  B(ResumeGenerator), R(2), R(0), U8(21),
                  B(Star), R(21),
 diff --git a/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden b/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden
-index 8be761df37..226fa55039 100644
+index 80609db7b80..7edf446ce33 100644
 --- a/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden
 +++ b/test/cctest/interpreter/bytecode_expectations/StandardForLoop.golden
-@@ -489,7 +489,7 @@ bytecodes: [
+@@ -493,7 +493,7 @@ bytecodes: [
    /*   52 S> */ B(Mov), R(1), R(7),
                  B(Mov), R(0), R(8),
                  B(Mov), R(2), R(9),
@@ -2245,13 +2283,13 @@ index 8be761df37..226fa55039 100644
                  B(ResumeGenerator), R(1), R(0), U8(7),
                  B(Star), R(7),
 diff --git a/test/cctest/test-api.cc b/test/cctest/test-api.cc
-index b1d2aced5e..0cc24b1cbd 100644
+index 2f552a9d9d9..8b93944d933 100644
 --- a/test/cctest/test-api.cc
 +++ b/test/cctest/test-api.cc
-@@ -18432,12 +18432,6 @@ TEST(PromiseHook) {
+@@ -18358,12 +18358,6 @@ TEST(PromiseHook) {
    CHECK_EQ(v8::Promise::kFulfilled, GetPromise("p")->State());
    CHECK_EQ(9, promise_hook_data->promise_hook_count);
-
+ 
 -  promise_hook_data->Reset();
 -  source = "(async() => await p)();\n";
 -
@@ -2262,10 +2300,10 @@ index b1d2aced5e..0cc24b1cbd 100644
    isolate->SetPromiseHook(nullptr);
  }
 diff --git a/tools/v8heapconst.py b/tools/v8heapconst.py
-index 3fa1889848..da284eb927 100644
+index 1e57ce64a9e..e3b29f82042 100644
 --- a/tools/v8heapconst.py
 +++ b/tools/v8heapconst.py
-@@ -263,12 +263,12 @@ KNOWN_MAPS = {
+@@ -263,12 +263,12 @@
    ("MAP_SPACE", 0x04511): (173, "Tuple2Map"),
    ("MAP_SPACE", 0x04569): (171, "ScriptMap"),
    ("MAP_SPACE", 0x045c1): (163, "InterceptorInfoMap"),
@@ -2284,3 +2322,9 @@ index 3fa1889848..da284eb927 100644
    ("MAP_SPACE", 0x04829): (159, "AsyncGeneratorRequestMap"),
    ("MAP_SPACE", 0x04881): (160, "ContextExtensionMap"),
    ("MAP_SPACE", 0x048d9): (161, "DebugInfoMap"),
+@@ -366,4 +366,4 @@
+   "NATIVE",
+ )
+ 
+-# This set of constants is generated from a shipping build.
++# This set of constants is generated from a non-shipping build.

--- a/patches/common/v8/backport_aa6ce3e.patch
+++ b/patches/common/v8/backport_aa6ce3e.patch
@@ -1,0 +1,1243 @@
+diff --git a/include/v8-profiler.h b/include/v8-profiler.h
+index cbd988e9e9..37ff09a0dd 100644
+--- a/include/v8-profiler.h
++++ b/include/v8-profiler.h
+@@ -1009,6 +1009,76 @@ struct HeapStatsUpdate {
+   uint32_t size;  // New value of size field for the interval with this index.
+ };
+
++#define CODE_EVENTS_LIST(V) \
++  V(Builtin)                \
++  V(Callback)               \
++  V(Eval)                   \
++  V(Function)               \
++  V(InterpretedFunction)    \
++  V(Handler)                \
++  V(BytecodeHandler)        \
++  V(LazyCompile)            \
++  V(RegExp)                 \
++  V(Script)                 \
++  V(Stub)
++
++/**
++ * Note that this enum may be extended in the future. Please include a default
++ * case if this enum is used in a switch statement.
++ */
++enum CodeEventType {
++  kUnknownType = 0
++#define V(Name) , k##Name##Type
++  CODE_EVENTS_LIST(V)
++#undef V
++};
++
++/**
++ * Representation of a code creation event
++ */
++class V8_EXPORT CodeEvent {
++ public:
++  uintptr_t GetCodeStartAddress();
++  size_t GetCodeSize();
++  Local<String> GetFunctionName();
++  Local<String> GetScriptName();
++  int GetScriptLine();
++  int GetScriptColumn();
++  /**
++   * NOTE (mmarchini): We can't allocate objects in the heap when we collect
++   * existing code, and both the code type and the comment are not stored in the
++   * heap, so we return those as const char*.
++   */
++  CodeEventType GetCodeType();
++  const char* GetComment();
++
++  static const char* GetCodeEventTypeName(CodeEventType code_event_type);
++};
++
++/**
++ * Interface to listen to code creation events.
++ */
++class V8_EXPORT CodeEventHandler {
++ public:
++  /**
++   * Creates a new listener for the |isolate|. The isolate must be initialized.
++   * The listener object must be disposed after use by calling |Dispose| method.
++   * Multiple listeners can be created for the same isolate.
++   */
++  explicit CodeEventHandler(Isolate* isolate);
++  virtual ~CodeEventHandler();
++
++  virtual void Handle(CodeEvent* code_event) = 0;
++
++  void Enable();
++  void Disable();
++
++ private:
++  CodeEventHandler();
++  CodeEventHandler(const CodeEventHandler&);
++  CodeEventHandler& operator=(const CodeEventHandler&);
++  void* internal_listener_;
++};
+
+ }  // namespace v8
+
+diff --git a/src/api.cc b/src/api.cc
+index 2943703e74..c6bcc8165b 100644
+--- a/src/api.cc
++++ b/src/api.cc
+@@ -10162,6 +10162,70 @@ void CpuProfiler::SetIdle(bool is_idle) {
+   isolate->SetIdle(is_idle);
+ }
+
++uintptr_t CodeEvent::GetCodeStartAddress() {
++  return reinterpret_cast<i::CodeEvent*>(this)->code_start_address;
++}
++
++size_t CodeEvent::GetCodeSize() {
++  return reinterpret_cast<i::CodeEvent*>(this)->code_size;
++}
++
++Local<String> CodeEvent::GetFunctionName() {
++  return ToApiHandle<String>(
++      reinterpret_cast<i::CodeEvent*>(this)->function_name);
++}
++
++Local<String> CodeEvent::GetScriptName() {
++  return ToApiHandle<String>(
++      reinterpret_cast<i::CodeEvent*>(this)->script_name);
++}
++
++int CodeEvent::GetScriptLine() {
++  return reinterpret_cast<i::CodeEvent*>(this)->script_line;
++}
++
++int CodeEvent::GetScriptColumn() {
++  return reinterpret_cast<i::CodeEvent*>(this)->script_column;
++}
++
++CodeEventType CodeEvent::GetCodeType() {
++  return reinterpret_cast<i::CodeEvent*>(this)->code_type;
++}
++
++const char* CodeEvent::GetComment() {
++  return reinterpret_cast<i::CodeEvent*>(this)->comment;
++}
++
++const char* CodeEvent::GetCodeEventTypeName(CodeEventType code_event_type) {
++  switch (code_event_type) {
++    case kUnknownType:
++      return "Unknown";
++#define V(Name)       \
++  case k##Name##Type: \
++    return #Name;
++      CODE_EVENTS_LIST(V)
++#undef V
++  }
++}
++
++CodeEventHandler::CodeEventHandler(Isolate* isolate) {
++  internal_listener_ =
++      new i::ExternalCodeEventListener(reinterpret_cast<i::Isolate*>(isolate));
++}
++
++CodeEventHandler::~CodeEventHandler() {
++  delete reinterpret_cast<i::ExternalCodeEventListener*>(internal_listener_);
++}
++
++void CodeEventHandler::Enable() {
++  reinterpret_cast<i::ExternalCodeEventListener*>(internal_listener_)
++      ->StartListening(this);
++}
++
++void CodeEventHandler::Disable() {
++  reinterpret_cast<i::ExternalCodeEventListener*>(internal_listener_)
++      ->StopListening();
++}
+
+ static i::HeapGraphEdge* ToInternal(const HeapGraphEdge* edge) {
+   return const_cast<i::HeapGraphEdge*>(
+diff --git a/src/code-events.h b/src/code-events.h
+index 439cb54dca..caed5160f4 100644
+--- a/src/code-events.h
++++ b/src/code-events.h
+@@ -24,32 +24,38 @@ class WasmCode;
+ using WasmName = Vector<const char>;
+ }  // namespace wasm
+
+-#define LOG_EVENTS_AND_TAGS_LIST(V)                      \
+-  V(CODE_CREATION_EVENT, "code-creation")                \
+-  V(CODE_DISABLE_OPT_EVENT, "code-disable-optimization") \
+-  V(CODE_MOVE_EVENT, "code-move")                        \
+-  V(CODE_DELETE_EVENT, "code-delete")                    \
+-  V(CODE_MOVING_GC, "code-moving-gc")                    \
+-  V(SHARED_FUNC_MOVE_EVENT, "sfi-move")                  \
+-  V(SNAPSHOT_CODE_NAME_EVENT, "snapshot-code-name")      \
+-  V(TICK_EVENT, "tick")                                  \
+-  V(BUILTIN_TAG, "Builtin")                              \
+-  V(CALLBACK_TAG, "Callback")                            \
+-  V(EVAL_TAG, "Eval")                                    \
+-  V(FUNCTION_TAG, "Function")                            \
+-  V(INTERPRETED_FUNCTION_TAG, "InterpretedFunction")     \
+-  V(HANDLER_TAG, "Handler")                              \
+-  V(BYTECODE_HANDLER_TAG, "BytecodeHandler")             \
+-  V(LAZY_COMPILE_TAG, "LazyCompile")                     \
+-  V(REG_EXP_TAG, "RegExp")                               \
+-  V(SCRIPT_TAG, "Script")                                \
+-  V(STUB_TAG, "Stub")                                    \
+-  V(NATIVE_FUNCTION_TAG, "Function")                     \
+-  V(NATIVE_LAZY_COMPILE_TAG, "LazyCompile")              \
+-  V(NATIVE_SCRIPT_TAG, "Script")
++#define LOG_EVENTS_LIST(V)                             \
++  V(CODE_CREATION_EVENT, code-creation)                \
++  V(CODE_DISABLE_OPT_EVENT, code-disable-optimization) \
++  V(CODE_MOVE_EVENT, code-move)                        \
++  V(CODE_DELETE_EVENT, code-delete)                    \
++  V(CODE_MOVING_GC, code-moving-gc)                    \
++  V(SHARED_FUNC_MOVE_EVENT, sfi-move)                  \
++  V(SNAPSHOT_CODE_NAME_EVENT, snapshot-code-name)      \
++  V(TICK_EVENT, tick)
++
++#define TAGS_LIST(V)                               \
++  V(BUILTIN_TAG, Builtin)                          \
++  V(CALLBACK_TAG, Callback)                        \
++  V(EVAL_TAG, Eval)                                \
++  V(FUNCTION_TAG, Function)                        \
++  V(INTERPRETED_FUNCTION_TAG, InterpretedFunction) \
++  V(HANDLER_TAG, Handler)                          \
++  V(BYTECODE_HANDLER_TAG, BytecodeHandler)         \
++  V(LAZY_COMPILE_TAG, LazyCompile)                 \
++  V(REG_EXP_TAG, RegExp)                           \
++  V(SCRIPT_TAG, Script)                            \
++  V(STUB_TAG, Stub)                                \
++  V(NATIVE_FUNCTION_TAG, Function)                 \
++  V(NATIVE_LAZY_COMPILE_TAG, LazyCompile)          \
++  V(NATIVE_SCRIPT_TAG, Script)
+ // Note that 'NATIVE_' cases for functions and scripts are mapped onto
+ // original tags when writing to the log.
+
++#define LOG_EVENTS_AND_TAGS_LIST(V) \
++  LOG_EVENTS_LIST(V)                \
++  TAGS_LIST(V)
++
+ #define PROFILE(the_isolate, Call) (the_isolate)->code_event_dispatcher()->Call;
+
+ class CodeEventListener {
+@@ -85,6 +91,8 @@ class CodeEventListener {
+   enum DeoptKind { kSoft, kLazy, kEager };
+   virtual void CodeDeoptEvent(Code* code, DeoptKind kind, Address pc,
+                               int fp_to_sp_delta) = 0;
++
++  virtual bool is_listening_to_code_events() { return false; }
+ };
+
+ class CodeEventDispatcher {
+@@ -101,6 +109,14 @@ class CodeEventDispatcher {
+     base::LockGuard<base::Mutex> guard(&mutex_);
+     listeners_.erase(listener);
+   }
++  bool IsListeningToCodeEvents() {
++    for (auto it : listeners_) {
++      if (it->is_listening_to_code_events()) {
++        return true;
++      }
++    }
++    return false;
++  }
+
+ #define CODE_EVENT_DISPATCH(code)              \
+   base::LockGuard<base::Mutex> guard(&mutex_); \
+diff --git a/src/compiler.cc b/src/compiler.cc
+index ae6bc9c4fa..a01750b23a 100644
+--- a/src/compiler.cc
++++ b/src/compiler.cc
+@@ -84,8 +84,9 @@ void LogFunctionCompilation(CodeEventListener::LogEventsAndTags tag,
+   // Log the code generation. If source information is available include
+   // script name and line number. Check explicitly whether logging is
+   // enabled as finding the line number is not free.
+-  if (!isolate->logger()->is_logging_code_events() &&
+-      !isolate->is_profiling() && !FLAG_log_function_events) {
++  if (!isolate->logger()->is_listening_to_code_events() &&
++      !isolate->is_profiling() && !FLAG_log_function_events &&
++      !isolate->code_event_dispatcher()->IsListeningToCodeEvents()) {
+     return;
+   }
+
+diff --git a/src/compiler/wasm-compiler.cc b/src/compiler/wasm-compiler.cc
+index 7cc26321b6..ad2600eecc 100644
+--- a/src/compiler/wasm-compiler.cc
++++ b/src/compiler/wasm-compiler.cc
+@@ -3948,7 +3948,8 @@ Node* WasmGraphBuilder::AtomicOp(wasm::WasmOpcode opcode, Node* const* inputs,
+
+ namespace {
+ bool must_record_function_compilation(Isolate* isolate) {
+-  return isolate->logger()->is_logging_code_events() || isolate->is_profiling();
++  return isolate->logger()->is_listening_to_code_events() ||
++         isolate->is_profiling();
+ }
+
+ PRINTF_FORMAT(4, 5)
+diff --git a/src/heap/mark-compact.cc b/src/heap/mark-compact.cc
+index 53aa615e47..c84fa2f69c 100644
+--- a/src/heap/mark-compact.cc
++++ b/src/heap/mark-compact.cc
+@@ -2414,7 +2414,7 @@ void MarkCompactCollectorBase::CreateAndExecuteEvacuationTasks(
+
+   const bool profiling =
+       heap()->isolate()->is_profiling() ||
+-      heap()->isolate()->logger()->is_logging_code_events() ||
++      heap()->isolate()->logger()->is_listening_to_code_events() ||
+       heap()->isolate()->heap_profiler()->is_tracking_object_moves() ||
+       heap()->has_heap_object_allocation_tracker();
+   ProfilingMigrationObserver profiling_observer(heap());
+diff --git a/src/isolate.cc b/src/isolate.cc
+index c4036784a6..9ac61a6bea 100644
+--- a/src/isolate.cc
++++ b/src/isolate.cc
+@@ -2893,7 +2893,7 @@ void CreateOffHeapTrampolines(Isolate* isolate) {
+     // thus collected by the GC.
+     builtins->set_builtin(i, *trampoline);
+
+-    if (isolate->logger()->is_logging_code_events() ||
++    if (isolate->logger()->is_listening_to_code_events() ||
+         isolate->is_profiling()) {
+       isolate->logger()->LogCodeObject(*trampoline);
+     }
+diff --git a/src/isolate.h b/src/isolate.h
+index 50aab84487..4f7b550bfa 100644
+--- a/src/isolate.h
++++ b/src/isolate.h
+@@ -57,6 +57,7 @@ class BuiltinsConstantsTableBuilder;
+ class CallInterfaceDescriptorData;
+ class CancelableTaskManager;
+ class CodeEventDispatcher;
++class ExternalCodeEventListener;
+ class CodeGenerator;
+ class CodeRange;
+ class CodeStubDescriptor;
+diff --git a/src/log.cc b/src/log.cc
+index 953216aef7..563fe3c5f0 100644
+--- a/src/log.cc
++++ b/src/log.cc
+@@ -40,11 +40,33 @@
+ namespace v8 {
+ namespace internal {
+
+-#define DECLARE_EVENT(ignore1, name) name,
++#define DECLARE_EVENT(ignore1, name) #name,
+ static const char* kLogEventsNames[CodeEventListener::NUMBER_OF_LOG_EVENTS] = {
+     LOG_EVENTS_AND_TAGS_LIST(DECLARE_EVENT)};
+ #undef DECLARE_EVENT
+
++static v8::CodeEventType GetCodeEventTypeForTag(
++    CodeEventListener::LogEventsAndTags tag) {
++  switch (tag) {
++    case CodeEventListener::NUMBER_OF_LOG_EVENTS:
++#define V(Event, _) case CodeEventListener::Event:
++      LOG_EVENTS_LIST(V)
++#undef V
++      return v8::CodeEventType::kUnknownType;
++#define V(From, To)             \
++  case CodeEventListener::From: \
++    return v8::CodeEventType::k##To##Type;
++      TAGS_LIST(V)
++#undef V
++  }
++}
++#define CALL_CODE_EVENT_HANDLER(Call) \
++  if (listener_) {                    \
++    listener_->Call;                  \
++  } else {                            \
++    PROFILE(isolate_, Call);          \
++  }
++
+ static const char* ComputeMarker(SharedFunctionInfo* shared,
+                                  AbstractCode* code) {
+   switch (code->kind()) {
+@@ -319,9 +341,147 @@ void PerfBasicLogger::LogRecordedBuffer(const wasm::WasmCode* code,
+                          code->instructions().length(), name, length);
+ }
+
+-// Low-level logging support.
+-#define LL_LOG(Call) if (ll_logger_) ll_logger_->Call;
++// External CodeEventListener
++ExternalCodeEventListener::ExternalCodeEventListener(Isolate* isolate)
++    : is_listening_(false), isolate_(isolate), code_event_handler_(nullptr) {}
++
++ExternalCodeEventListener::~ExternalCodeEventListener() {
++  if (is_listening_) {
++    StopListening();
++  }
++}
++
++void ExternalCodeEventListener::LogExistingCode() {
++  HandleScope scope(isolate_);
++  ExistingCodeLogger logger(isolate_, this);
++  logger.LogCodeObjects();
++  logger.LogBytecodeHandlers();
++  logger.LogCompiledFunctions();
++}
++
++void ExternalCodeEventListener::StartListening(
++    CodeEventHandler* code_event_handler) {
++  if (is_listening_ || code_event_handler == nullptr) {
++    return;
++  }
++  code_event_handler_ = code_event_handler;
++  is_listening_ = isolate_->code_event_dispatcher()->AddListener(this);
++  if (is_listening_) {
++    LogExistingCode();
++  }
++}
+
++void ExternalCodeEventListener::StopListening() {
++  if (!is_listening_) {
++    return;
++  }
++
++  isolate_->code_event_dispatcher()->RemoveListener(this);
++  is_listening_ = false;
++}
++
++void ExternalCodeEventListener::CodeCreateEvent(
++    CodeEventListener::LogEventsAndTags tag, AbstractCode* code,
++    const char* comment) {
++  CodeEvent code_event;
++  code_event.code_start_address =
++      static_cast<uintptr_t>(code->InstructionStart());
++  code_event.code_size = static_cast<size_t>(code->InstructionSize());
++  code_event.function_name = isolate_->factory()->empty_string();
++  code_event.script_name = isolate_->factory()->empty_string();
++  code_event.script_line = 0;
++  code_event.script_column = 0;
++  code_event.code_type = GetCodeEventTypeForTag(tag);
++  code_event.comment = comment;
++
++  code_event_handler_->Handle(reinterpret_cast<v8::CodeEvent*>(&code_event));
++}
++
++void ExternalCodeEventListener::CodeCreateEvent(
++    CodeEventListener::LogEventsAndTags tag, AbstractCode* code, Name* name) {
++  Handle<String> name_string =
++      Name::ToFunctionName(Handle<Name>(name, isolate_)).ToHandleChecked();
++
++  CodeEvent code_event;
++  code_event.code_start_address =
++      static_cast<uintptr_t>(code->InstructionStart());
++  code_event.code_size = static_cast<size_t>(code->InstructionSize());
++  code_event.function_name = name_string;
++  code_event.script_name = isolate_->factory()->empty_string();
++  code_event.script_line = 0;
++  code_event.script_column = 0;
++  code_event.code_type = GetCodeEventTypeForTag(tag);
++  code_event.comment = "";
++
++  code_event_handler_->Handle(reinterpret_cast<v8::CodeEvent*>(&code_event));
++}
++
++void ExternalCodeEventListener::CodeCreateEvent(
++    CodeEventListener::LogEventsAndTags tag, AbstractCode* code,
++    SharedFunctionInfo* shared, Name* name) {
++  Handle<String> name_string =
++      Name::ToFunctionName(Handle<Name>(name, isolate_)).ToHandleChecked();
++
++  CodeEvent code_event;
++  code_event.code_start_address =
++      static_cast<uintptr_t>(code->InstructionStart());
++  code_event.code_size = static_cast<size_t>(code->InstructionSize());
++  code_event.function_name = name_string;
++  code_event.script_name = isolate_->factory()->empty_string();
++  code_event.script_line = 0;
++  code_event.script_column = 0;
++  code_event.code_type = GetCodeEventTypeForTag(tag);
++  code_event.comment = "";
++
++  code_event_handler_->Handle(reinterpret_cast<v8::CodeEvent*>(&code_event));
++}
++
++void ExternalCodeEventListener::CodeCreateEvent(
++    CodeEventListener::LogEventsAndTags tag, AbstractCode* code,
++    SharedFunctionInfo* shared, Name* source, int line, int column) {
++  Handle<String> name_string =
++      Name::ToFunctionName(Handle<Name>(shared->Name(), isolate_))
++          .ToHandleChecked();
++  Handle<String> source_string =
++      Name::ToFunctionName(Handle<Name>(source, isolate_)).ToHandleChecked();
++
++  CodeEvent code_event;
++  code_event.code_start_address =
++      static_cast<uintptr_t>(code->InstructionStart());
++  code_event.code_size = static_cast<size_t>(code->InstructionSize());
++  code_event.function_name = name_string;
++  code_event.script_name = source_string;
++  code_event.script_line = line;
++  code_event.script_column = column;
++  code_event.code_type = GetCodeEventTypeForTag(tag);
++  code_event.comment = "";
++
++  code_event_handler_->Handle(reinterpret_cast<v8::CodeEvent*>(&code_event));
++}
++
++void ExternalCodeEventListener::CodeCreateEvent(LogEventsAndTags tag,
++                                                const wasm::WasmCode* code,
++                                                wasm::WasmName name) {
++  // TODO(mmarchini): handle later
++}
++
++void ExternalCodeEventListener::RegExpCodeCreateEvent(AbstractCode* code,
++                                                      String* source) {
++  CodeEvent code_event;
++  code_event.code_start_address =
++      static_cast<uintptr_t>(code->InstructionStart());
++  code_event.code_size = static_cast<size_t>(code->InstructionSize());
++  code_event.function_name = Handle<String>(source, isolate_);
++  code_event.script_name = isolate_->factory()->empty_string();
++  code_event.script_line = 0;
++  code_event.script_column = 0;
++  code_event.code_type = GetCodeEventTypeForTag(CodeEventListener::REG_EXP_TAG);
++  code_event.comment = "";
++
++  code_event_handler_->Handle(reinterpret_cast<v8::CodeEvent*>(&code_event));
++}
++
++// Low-level logging support.
+ class LowLevelLogger : public CodeEventLogger {
+  public:
+   explicit LowLevelLogger(const char* file_name);
+@@ -808,7 +968,8 @@ Logger::Logger(Isolate* isolate)
+       perf_jit_logger_(nullptr),
+       ll_logger_(nullptr),
+       jit_logger_(nullptr),
+-      is_initialized_(false) {}
++      is_initialized_(false),
++      existing_code_logger_(isolate) {}
+
+ Logger::~Logger() {
+   delete log_;
+@@ -1077,7 +1238,7 @@ void AppendCodeCreateHeader(Log::MessageBuilder& msg,
+
+ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+                              AbstractCode* code, const char* comment) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+   Log::MessageBuilder msg(log_);
+   AppendCodeCreateHeader(msg, tag, code, &timer_);
+@@ -1087,7 +1248,7 @@ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+
+ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+                              AbstractCode* code, Name* name) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+   Log::MessageBuilder msg(log_);
+   AppendCodeCreateHeader(msg, tag, code, &timer_);
+@@ -1098,7 +1259,7 @@ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+                              AbstractCode* code, SharedFunctionInfo* shared,
+                              Name* name) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+   if (code == AbstractCode::cast(
+                   isolate_->builtins()->builtin(Builtins::kCompileLazy))) {
+@@ -1114,7 +1275,7 @@ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+
+ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+                              const wasm::WasmCode* code, wasm::WasmName name) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+   Log::MessageBuilder msg(log_);
+   AppendCodeCreateHeader(msg, tag, AbstractCode::Kind::WASM_FUNCTION,
+@@ -1142,7 +1303,7 @@ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+                              AbstractCode* code, SharedFunctionInfo* shared,
+                              Name* source, int line, int column) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+
+   Log::MessageBuilder msg(log_);
+@@ -1259,7 +1420,7 @@ void Logger::CodeCreateEvent(CodeEventListener::LogEventsAndTags tag,
+
+ void Logger::CodeDisableOptEvent(AbstractCode* code,
+                                  SharedFunctionInfo* shared) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+   Log::MessageBuilder msg(log_);
+   msg << kLogEventsNames[CodeEventListener::CODE_DISABLE_OPT_EVENT] << kNext
+@@ -1270,13 +1431,13 @@ void Logger::CodeDisableOptEvent(AbstractCode* code,
+
+
+ void Logger::CodeMovingGCEvent() {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!log_->IsEnabled() || !FLAG_ll_prof) return;
+   base::OS::SignalCodeMovingGC();
+ }
+
+ void Logger::RegExpCodeCreateEvent(AbstractCode* code, String* source) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   if (!FLAG_log_code || !log_->IsEnabled()) return;
+   Log::MessageBuilder msg(log_);
+   AppendCodeCreateHeader(msg, CodeEventListener::REG_EXP_TAG, code, &timer_);
+@@ -1285,7 +1446,7 @@ void Logger::RegExpCodeCreateEvent(AbstractCode* code, String* source) {
+ }
+
+ void Logger::CodeMoveEvent(AbstractCode* from, Address to) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   MoveEventInternal(CodeEventListener::CODE_MOVE_EVENT, from->address(), to);
+ }
+
+@@ -1334,7 +1495,7 @@ void Logger::CodeNameEvent(Address addr, int pos, const char* code_name) {
+
+
+ void Logger::SharedFunctionInfoMoveEvent(Address from, Address to) {
+-  if (!is_logging_code_events()) return;
++  if (!is_listening_to_code_events()) return;
+   MoveEventInternal(CodeEventListener::SHARED_FUNC_MOVE_EVENT, from, to);
+ }
+
+@@ -1624,170 +1785,28 @@ static int EnumerateWasmModules(Heap* heap,
+ }
+
+ void Logger::LogCodeObject(Object* object) {
+-  AbstractCode* code_object = AbstractCode::cast(object);
+-  CodeEventListener::LogEventsAndTags tag = CodeEventListener::STUB_TAG;
+-  const char* description = "Unknown code from the snapshot";
+-  switch (code_object->kind()) {
+-    case AbstractCode::INTERPRETED_FUNCTION:
+-    case AbstractCode::OPTIMIZED_FUNCTION:
+-      return;  // We log this later using LogCompiledFunctions.
+-    case AbstractCode::BYTECODE_HANDLER:
+-      return;  // We log it later by walking the dispatch table.
+-    case AbstractCode::STUB:
+-      description =
+-          CodeStub::MajorName(CodeStub::GetMajorKey(code_object->GetCode()));
+-      if (description == nullptr) description = "A stub from the snapshot";
+-      tag = CodeEventListener::STUB_TAG;
+-      break;
+-    case AbstractCode::REGEXP:
+-      description = "Regular expression code";
+-      tag = CodeEventListener::REG_EXP_TAG;
+-      break;
+-    case AbstractCode::BUILTIN:
+-      description =
+-          isolate_->builtins()->name(code_object->GetCode()->builtin_index());
+-      tag = CodeEventListener::BUILTIN_TAG;
+-      break;
+-    case AbstractCode::WASM_FUNCTION:
+-      description = "A Wasm function";
+-      tag = CodeEventListener::FUNCTION_TAG;
+-      break;
+-    case AbstractCode::JS_TO_WASM_FUNCTION:
+-      description = "A JavaScript to Wasm adapter";
+-      tag = CodeEventListener::STUB_TAG;
+-      break;
+-    case AbstractCode::WASM_TO_JS_FUNCTION:
+-      description = "A Wasm to JavaScript adapter";
+-      tag = CodeEventListener::STUB_TAG;
+-      break;
+-    case AbstractCode::WASM_INTERPRETER_ENTRY:
+-      description = "A Wasm to Interpreter adapter";
+-      tag = CodeEventListener::STUB_TAG;
+-      break;
+-    case AbstractCode::C_WASM_ENTRY:
+-      description = "A C to Wasm entry stub";
+-      tag = CodeEventListener::STUB_TAG;
+-      break;
+-    case AbstractCode::NUMBER_OF_KINDS:
+-      UNIMPLEMENTED();
+-  }
+-  PROFILE(isolate_, CodeCreateEvent(tag, code_object, description));
++  existing_code_logger_.LogCodeObject(object);
+ }
+
+-void Logger::LogCodeObjects() {
+-  Heap* heap = isolate_->heap();
+-  HeapIterator iterator(heap);
+-  DisallowHeapAllocation no_gc;
+-  for (HeapObject* obj = iterator.next(); obj != nullptr;
+-       obj = iterator.next()) {
+-    if (obj->IsCode()) LogCodeObject(obj);
+-    if (obj->IsBytecodeArray()) LogCodeObject(obj);
+-  }
+-}
++void Logger::LogCodeObjects() { existing_code_logger_.LogCodeObjects(); }
+
+ void Logger::LogBytecodeHandler(interpreter::Bytecode bytecode,
+                                 interpreter::OperandScale operand_scale,
+                                 Code* code) {
+-  std::string bytecode_name =
+-      interpreter::Bytecodes::ToString(bytecode, operand_scale);
+-  PROFILE(isolate_,
+-          CodeCreateEvent(CodeEventListener::BYTECODE_HANDLER_TAG,
+-                          AbstractCode::cast(code), bytecode_name.c_str()));
++  existing_code_logger_.LogBytecodeHandler(bytecode, operand_scale, code);
+ }
+
+ void Logger::LogBytecodeHandlers() {
+-  const interpreter::OperandScale kOperandScales[] = {
+-#define VALUE(Name, _) interpreter::OperandScale::k##Name,
+-      OPERAND_SCALE_LIST(VALUE)
+-#undef VALUE
+-  };
+-
+-  const int last_index = static_cast<int>(interpreter::Bytecode::kLast);
+-  interpreter::Interpreter* interpreter = isolate_->interpreter();
+-  for (auto operand_scale : kOperandScales) {
+-    for (int index = 0; index <= last_index; ++index) {
+-      interpreter::Bytecode bytecode = interpreter::Bytecodes::FromByte(index);
+-      if (interpreter::Bytecodes::BytecodeHasHandler(bytecode, operand_scale)) {
+-        Code* code = interpreter->GetBytecodeHandler(bytecode, operand_scale);
+-        if (isolate_->heap()->IsDeserializeLazyHandler(code)) continue;
+-        LogBytecodeHandler(bytecode, operand_scale, code);
+-      }
+-    }
+-  }
++  existing_code_logger_.LogBytecodeHandlers();
+ }
+
+ void Logger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
+                                  Handle<AbstractCode> code) {
+-  if (shared->script()->IsScript()) {
+-    Handle<Script> script(Script::cast(shared->script()));
+-    int line_num = Script::GetLineNumber(script, shared->StartPosition()) + 1;
+-    int column_num =
+-        Script::GetColumnNumber(script, shared->StartPosition()) + 1;
+-    if (script->name()->IsString()) {
+-      Handle<String> script_name(String::cast(script->name()));
+-      if (line_num > 0) {
+-        PROFILE(isolate_,
+-                CodeCreateEvent(
+-                    Logger::ToNativeByScript(
+-                        CodeEventListener::LAZY_COMPILE_TAG, *script),
+-                    *code, *shared, *script_name, line_num, column_num));
+-      } else {
+-        // Can't distinguish eval and script here, so always use Script.
+-        PROFILE(isolate_,
+-                CodeCreateEvent(Logger::ToNativeByScript(
+-                                    CodeEventListener::SCRIPT_TAG, *script),
+-                                *code, *shared, *script_name));
+-      }
+-    } else {
+-      PROFILE(isolate_,
+-              CodeCreateEvent(Logger::ToNativeByScript(
+-                                  CodeEventListener::LAZY_COMPILE_TAG, *script),
+-                              *code, *shared, isolate_->heap()->empty_string(),
+-                              line_num, column_num));
+-    }
+-  } else if (shared->IsApiFunction()) {
+-    // API function.
+-    FunctionTemplateInfo* fun_data = shared->get_api_func_data();
+-    Object* raw_call_data = fun_data->call_code();
+-    if (!raw_call_data->IsUndefined(isolate_)) {
+-      CallHandlerInfo* call_data = CallHandlerInfo::cast(raw_call_data);
+-      Object* callback_obj = call_data->callback();
+-      Address entry_point = v8::ToCData<Address>(callback_obj);
+-#if USES_FUNCTION_DESCRIPTORS
+-      entry_point = *FUNCTION_ENTRYPOINT_ADDRESS(entry_point);
+-#endif
+-      PROFILE(isolate_, CallbackEvent(shared->DebugName(), entry_point));
+-    }
+-  } else {
+-    PROFILE(isolate_,
+-            CodeCreateEvent(CodeEventListener::LAZY_COMPILE_TAG, *code, *shared,
+-                            isolate_->heap()->empty_string()));
+-  }
++  existing_code_logger_.LogExistingFunction(shared, code);
+ }
+
+ void Logger::LogCompiledFunctions() {
+-  Heap* heap = isolate_->heap();
+-  HandleScope scope(isolate_);
+-  const int compiled_funcs_count =
+-      EnumerateCompiledFunctions(heap, nullptr, nullptr);
+-  ScopedVector<Handle<SharedFunctionInfo>> sfis(compiled_funcs_count);
+-  ScopedVector<Handle<AbstractCode> > code_objects(compiled_funcs_count);
+-  EnumerateCompiledFunctions(heap, sfis.start(), code_objects.start());
+-
+-  // During iteration, there can be heap allocation due to
+-  // GetScriptLineNumber call.
+-  for (int i = 0; i < compiled_funcs_count; ++i) {
+-    if (code_objects[i].is_identical_to(BUILTIN_CODE(isolate_, CompileLazy)))
+-      continue;
+-    LogExistingFunction(sfis[i], code_objects[i]);
+-  }
+-
+-  const int compiled_wasm_modules_count = EnumerateWasmModules(heap, nullptr);
+-  ScopedVector<Handle<WasmCompiledModule>> modules(compiled_wasm_modules_count);
+-  EnumerateWasmModules(heap, modules.start());
+-  for (int i = 0; i < compiled_wasm_modules_count; ++i) {
+-    modules[i]->LogWasmCodes(isolate_);
+-  }
++  existing_code_logger_.LogCompiledFunctions();
+ }
+
+ void Logger::LogAccessorCallbacks() {
+@@ -1991,5 +2010,172 @@ FILE* Logger::TearDown() {
+   return log_->Close();
+ }
+
++void ExistingCodeLogger::LogCodeObject(Object* object) {
++  AbstractCode* code_object = AbstractCode::cast(object);
++  CodeEventListener::LogEventsAndTags tag = CodeEventListener::STUB_TAG;
++  const char* description = "Unknown code from before profiling";
++  switch (code_object->kind()) {
++    case AbstractCode::INTERPRETED_FUNCTION:
++    case AbstractCode::OPTIMIZED_FUNCTION:
++      return;  // We log this later using LogCompiledFunctions.
++    case AbstractCode::BYTECODE_HANDLER:
++      return;  // We log it later by walking the dispatch table.
++    case AbstractCode::STUB:
++      description =
++          CodeStub::MajorName(CodeStub::GetMajorKey(code_object->GetCode()));
++      if (description == nullptr) description = "A stub from before profiling";
++      tag = CodeEventListener::STUB_TAG;
++      break;
++    case AbstractCode::REGEXP:
++      description = "Regular expression code";
++      tag = CodeEventListener::REG_EXP_TAG;
++      break;
++    case AbstractCode::BUILTIN:
++      description =
++          isolate_->builtins()->name(code_object->GetCode()->builtin_index());
++      tag = CodeEventListener::BUILTIN_TAG;
++      break;
++    case AbstractCode::WASM_FUNCTION:
++      description = "A Wasm function";
++      tag = CodeEventListener::FUNCTION_TAG;
++      break;
++    case AbstractCode::JS_TO_WASM_FUNCTION:
++      description = "A JavaScript to Wasm adapter";
++      tag = CodeEventListener::STUB_TAG;
++      break;
++    case AbstractCode::WASM_TO_JS_FUNCTION:
++      description = "A Wasm to JavaScript adapter";
++      tag = CodeEventListener::STUB_TAG;
++      break;
++    case AbstractCode::WASM_INTERPRETER_ENTRY:
++      description = "A Wasm to Interpreter adapter";
++      tag = CodeEventListener::STUB_TAG;
++      break;
++    case AbstractCode::C_WASM_ENTRY:
++      description = "A C to Wasm entry stub";
++      tag = CodeEventListener::STUB_TAG;
++      break;
++    case AbstractCode::NUMBER_OF_KINDS:
++      UNIMPLEMENTED();
++  }
++  CALL_CODE_EVENT_HANDLER(CodeCreateEvent(tag, code_object, description))
++}
++
++void ExistingCodeLogger::LogCodeObjects() {
++  Heap* heap = isolate_->heap();
++  HeapIterator iterator(heap);
++  DisallowHeapAllocation no_gc;
++  for (HeapObject* obj = iterator.next(); obj != nullptr;
++       obj = iterator.next()) {
++    if (obj->IsCode()) LogCodeObject(obj);
++    if (obj->IsBytecodeArray()) LogCodeObject(obj);
++  }
++}
++
++void ExistingCodeLogger::LogCompiledFunctions() {
++  Heap* heap = isolate_->heap();
++  HandleScope scope(isolate_);
++  const int compiled_funcs_count =
++      EnumerateCompiledFunctions(heap, nullptr, nullptr);
++  ScopedVector<Handle<SharedFunctionInfo>> sfis(compiled_funcs_count);
++  ScopedVector<Handle<AbstractCode>> code_objects(compiled_funcs_count);
++  EnumerateCompiledFunctions(heap, sfis.start(), code_objects.start());
++
++  // During iteration, there can be heap allocation due to
++  // GetScriptLineNumber call.
++  for (int i = 0; i < compiled_funcs_count; ++i) {
++    if (code_objects[i].is_identical_to(BUILTIN_CODE(isolate_, CompileLazy)))
++      continue;
++    LogExistingFunction(sfis[i], code_objects[i]);
++  }
++
++  const int compiled_wasm_modules_count = EnumerateWasmModules(heap, nullptr);
++  ScopedVector<Handle<WasmCompiledModule>> modules(compiled_wasm_modules_count);
++  EnumerateWasmModules(heap, modules.start());
++  for (int i = 0; i < compiled_wasm_modules_count; ++i) {
++    modules[i]->LogWasmCodes(isolate_);
++  }
++}
++
++void ExistingCodeLogger::LogBytecodeHandler(
++    interpreter::Bytecode bytecode, interpreter::OperandScale operand_scale,
++    Code* code) {
++  std::string bytecode_name =
++      interpreter::Bytecodes::ToString(bytecode, operand_scale);
++  CALL_CODE_EVENT_HANDLER(
++      CodeCreateEvent(CodeEventListener::BYTECODE_HANDLER_TAG,
++                      AbstractCode::cast(code), bytecode_name.c_str()))
++}
++
++void ExistingCodeLogger::LogBytecodeHandlers() {
++  const interpreter::OperandScale kOperandScales[] = {
++#define VALUE(Name, _) interpreter::OperandScale::k##Name,
++      OPERAND_SCALE_LIST(VALUE)
++#undef VALUE
++  };
++
++  const int last_index = static_cast<int>(interpreter::Bytecode::kLast);
++  interpreter::Interpreter* interpreter = isolate_->interpreter();
++  for (auto operand_scale : kOperandScales) {
++    for (int index = 0; index <= last_index; ++index) {
++      interpreter::Bytecode bytecode = interpreter::Bytecodes::FromByte(index);
++      if (interpreter::Bytecodes::BytecodeHasHandler(bytecode, operand_scale)) {
++        Code* code = interpreter->GetBytecodeHandler(bytecode, operand_scale);
++        if (isolate_->heap()->IsDeserializeLazyHandler(code)) continue;
++        LogBytecodeHandler(bytecode, operand_scale, code);
++      }
++    }
++  }
++}
++
++void ExistingCodeLogger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
++                                             Handle<AbstractCode> code) {
++  if (shared->script()->IsScript()) {
++    Handle<Script> script(Script::cast(shared->script()));
++    int line_num = Script::GetLineNumber(script, shared->StartPosition()) + 1;
++    int column_num =
++        Script::GetColumnNumber(script, shared->StartPosition()) + 1;
++    if (script->name()->IsString()) {
++      Handle<String> script_name(String::cast(script->name()));
++      if (line_num > 0) {
++        CALL_CODE_EVENT_HANDLER(
++            CodeCreateEvent(Logger::ToNativeByScript(
++                                CodeEventListener::LAZY_COMPILE_TAG, *script),
++                            *code, *shared, *script_name, line_num, column_num))
++      } else {
++        // Can't distinguish eval and script here, so always use Script.
++        CALL_CODE_EVENT_HANDLER(CodeCreateEvent(
++            Logger::ToNativeByScript(CodeEventListener::SCRIPT_TAG, *script),
++            *code, *shared, *script_name))
++      }
++    } else {
++      CALL_CODE_EVENT_HANDLER(
++          CodeCreateEvent(Logger::ToNativeByScript(
++                              CodeEventListener::LAZY_COMPILE_TAG, *script),
++                          *code, *shared, isolate_->heap()->empty_string(),
++                          line_num, column_num))
++    }
++  } else if (shared->IsApiFunction()) {
++    // API function.
++    FunctionTemplateInfo* fun_data = shared->get_api_func_data();
++    Object* raw_call_data = fun_data->call_code();
++    if (!raw_call_data->IsUndefined(isolate_)) {
++      CallHandlerInfo* call_data = CallHandlerInfo::cast(raw_call_data);
++      Object* callback_obj = call_data->callback();
++      Address entry_point = v8::ToCData<Address>(callback_obj);
++#if USES_FUNCTION_DESCRIPTORS
++      entry_point = *FUNCTION_ENTRYPOINT_ADDRESS(entry_point);
++#endif
++      CALL_CODE_EVENT_HANDLER(CallbackEvent(shared->DebugName(), entry_point))
++    }
++  } else {
++    CALL_CODE_EVENT_HANDLER(CodeCreateEvent(CodeEventListener::LAZY_COMPILE_TAG,
++                                            *code, *shared,
++                                            isolate_->heap()->empty_string()))
++  }
++}
++
++#undef CALL_CODE_EVENT_HANDLER
++
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/log.h b/src/log.h
+index 9943d8ca9b..738aef4d73 100644
+--- a/src/log.h
++++ b/src/log.h
+@@ -8,6 +8,7 @@
+ #include <set>
+ #include <string>
+
++#include "include/v8-profiler.h"
+ #include "src/allocation.h"
+ #include "src/base/compiler-specific.h"
+ #include "src/base/platform/elapsed-timer.h"
+@@ -91,12 +92,33 @@ class WasmCode;
+     if (logger->is_logging()) logger->Call;             \
+   } while (false)
+
+-#define LOG_CODE_EVENT(isolate, Call)                   \
+-  do {                                                  \
+-    v8::internal::Logger* logger = (isolate)->logger(); \
+-    if (logger->is_logging_code_events()) logger->Call; \
++#define LOG_CODE_EVENT(isolate, Call)                        \
++  do {                                                       \
++    v8::internal::Logger* logger = (isolate)->logger();      \
++    if (logger->is_listening_to_code_events()) logger->Call; \
+   } while (false)
+
++class ExistingCodeLogger {
++ public:
++  explicit ExistingCodeLogger(Isolate* isolate,
++                              CodeEventListener* listener = nullptr)
++      : isolate_(isolate), listener_(listener) {}
++
++  void LogCodeObjects();
++  void LogBytecodeHandlers();
++
++  void LogCompiledFunctions();
++  void LogExistingFunction(Handle<SharedFunctionInfo> shared,
++                           Handle<AbstractCode> code);
++  void LogCodeObject(Object* object);
++  void LogBytecodeHandler(interpreter::Bytecode bytecode,
++                          interpreter::OperandScale operand_scale, Code* code);
++
++ private:
++  Isolate* isolate_;
++  CodeEventListener* listener_;
++};
++
+ class Logger : public CodeEventListener {
+  public:
+   enum StartEnd { START = 0, END = 1, STAMP = 2 };
+@@ -229,7 +251,7 @@ class Logger : public CodeEventListener {
+     return is_logging_;
+   }
+
+-  bool is_logging_code_events() {
++  bool is_listening_to_code_events() {
+     return is_logging() || jit_logger_ != nullptr;
+   }
+
+@@ -327,6 +349,8 @@ class Logger : public CodeEventListener {
+   // 'true' between SetUp() and TearDown().
+   bool is_initialized_;
+
++  ExistingCodeLogger existing_code_logger_;
++
+   base::ElapsedTimer timer_;
+
+   friend class CpuProfiler;
+@@ -407,6 +431,58 @@ class CodeEventLogger : public CodeEventListener {
+   NameBuffer* name_buffer_;
+ };
+
++struct CodeEvent {
++  uintptr_t code_start_address;
++  size_t code_size;
++  Handle<String> function_name;
++  Handle<String> script_name;
++  int script_line;
++  int script_column;
++  CodeEventType code_type;
++  const char* comment;
++};
++
++class ExternalCodeEventListener : public CodeEventListener {
++ public:
++  explicit ExternalCodeEventListener(Isolate* isolate);
++  ~ExternalCodeEventListener() override;
++
++  void CodeCreateEvent(LogEventsAndTags tag, AbstractCode* code,
++                       const char* comment) override;
++  void CodeCreateEvent(LogEventsAndTags tag, AbstractCode* code,
++                       Name* name) override;
++  void CodeCreateEvent(LogEventsAndTags tag, AbstractCode* code,
++                       SharedFunctionInfo* shared, Name* name) override;
++  void CodeCreateEvent(LogEventsAndTags tag, AbstractCode* code,
++                       SharedFunctionInfo* shared, Name* source, int line,
++                       int column) override;
++  void CodeCreateEvent(LogEventsAndTags tag, const wasm::WasmCode* code,
++                       wasm::WasmName name) override;
++
++  void RegExpCodeCreateEvent(AbstractCode* code, String* source) override;
++  void CallbackEvent(Name* name, Address entry_point) override {}
++  void GetterCallbackEvent(Name* name, Address entry_point) override {}
++  void SetterCallbackEvent(Name* name, Address entry_point) override {}
++  void SharedFunctionInfoMoveEvent(Address from, Address to) override {}
++  void CodeMoveEvent(AbstractCode* from, Address to) override {}
++  void CodeDisableOptEvent(AbstractCode* code,
++                           SharedFunctionInfo* shared) override {}
++  void CodeMovingGCEvent() override {}
++  void CodeDeoptEvent(Code* code, DeoptKind kind, Address pc,
++                      int fp_to_sp_delta) override {}
++
++  void StartListening(CodeEventHandler* code_event_handler);
++  void StopListening();
++
++  bool is_listening_to_code_events() override { return true; }
++
++ private:
++  void LogExistingCode();
++
++  bool is_listening_;
++  Isolate* isolate_;
++  v8::CodeEventHandler* code_event_handler_;
++};
+
+ }  // namespace internal
+ }  // namespace v8
+diff --git a/src/runtime/runtime-function.cc b/src/runtime/runtime-function.cc
+index 5dcb4115e5..9f1cbc00e9 100644
+--- a/src/runtime/runtime-function.cc
++++ b/src/runtime/runtime-function.cc
+@@ -147,7 +147,8 @@ RUNTIME_FUNCTION(Runtime_SetCode) {
+   // the target_shared optimized code map.
+   JSFunction::EnsureFeedbackVector(target);
+
+-  if (isolate->logger()->is_logging_code_events() || isolate->is_profiling()) {
++  if (isolate->logger()->is_listening_to_code_events() ||
++      isolate->is_profiling()) {
+     isolate->logger()->LogExistingFunction(
+         source_shared, Handle<AbstractCode>(source_shared->abstract_code()));
+   }
+diff --git a/src/snapshot/code-serializer.cc b/src/snapshot/code-serializer.cc
+index 8dc98d836b..0ff35abc5d 100644
+--- a/src/snapshot/code-serializer.cc
++++ b/src/snapshot/code-serializer.cc
+@@ -287,7 +287,8 @@ MaybeHandle<SharedFunctionInfo> CodeSerializer::Deserialize(
+     PrintF("[Deserializing from %d bytes took %0.3f ms]\n", length, ms);
+   }
+
+-  if (isolate->logger()->is_logging_code_events() || isolate->is_profiling()) {
++  if (isolate->logger()->is_listening_to_code_events() ||
++      isolate->is_profiling()) {
+     String* name = isolate->heap()->empty_string();
+     if (result->script()->IsScript()) {
+       Script* script = Script::cast(result->script());
+diff --git a/src/snapshot/snapshot-common.cc b/src/snapshot/snapshot-common.cc
+index 4fe1871125..bf0ae3678b 100644
+--- a/src/snapshot/snapshot-common.cc
++++ b/src/snapshot/snapshot-common.cc
+@@ -115,7 +115,8 @@ Code* Snapshot::DeserializeBuiltin(Isolate* isolate, int builtin_id) {
+            Builtins::name(builtin_id), bytes, ms);
+   }
+
+-  if (isolate->logger()->is_logging_code_events() || isolate->is_profiling()) {
++  if (isolate->logger()->is_listening_to_code_events() ||
++      isolate->is_profiling()) {
+     isolate->logger()->LogCodeObject(code);
+   }
+
+@@ -196,7 +197,8 @@ Code* Snapshot::DeserializeHandler(Isolate* isolate,
+            bytes, ms);
+   }
+
+-  if (isolate->logger()->is_logging_code_events() || isolate->is_profiling()) {
++  if (isolate->logger()->is_listening_to_code_events() ||
++      isolate->is_profiling()) {
+     isolate->logger()->LogBytecodeHandler(bytecode, operand_scale, code);
+   }
+
+diff --git a/src/wasm/wasm-code-manager.cc b/src/wasm/wasm-code-manager.cc
+index ac9f6261b5..e4d1de0dcf 100644
+--- a/src/wasm/wasm-code-manager.cc
++++ b/src/wasm/wasm-code-manager.cc
+@@ -217,7 +217,7 @@ bool WasmCode::HasTrapHandlerIndex() const { return trap_handler_index_ >= 0; }
+ void WasmCode::ResetTrapHandlerIndex() { trap_handler_index_ = -1; }
+
+ bool WasmCode::ShouldBeLogged(Isolate* isolate) {
+-  return isolate->logger()->is_logging_code_events() ||
++  return isolate->logger()->is_listening_to_code_events() ||
+          isolate->is_profiling() || FLAG_print_wasm_code || FLAG_print_code;
+ }
+
+diff --git a/test/cctest/test-log.cc b/test/cctest/test-log.cc
+index 27d363d5a4..97071a63f5 100644
+--- a/test/cctest/test-log.cc
++++ b/test/cctest/test-log.cc
+@@ -35,6 +35,7 @@
+ #endif  // __linux__
+
+ #include <unordered_set>
++#include <vector>
+ #include "src/api.h"
+ #include "src/log-utils.h"
+ #include "src/log.h"
+@@ -251,6 +252,38 @@ class ScopedLoggerInitializer {
+   DISALLOW_COPY_AND_ASSIGN(ScopedLoggerInitializer);
+ };
+
++class TestCodeEventHandler : public v8::CodeEventHandler {
++ public:
++  explicit TestCodeEventHandler(v8::Isolate* isolate)
++      : v8::CodeEventHandler(isolate) {}
++
++  const char* FindLine(const char* prefix, const char* suffix = nullptr,
++                       const char* start = nullptr) {
++    if (!log_.length()) return NULL;
++    const char* c_log = log_.c_str();
++    if (start == nullptr) start = c_log;
++    const char* end = c_log + log_.length();
++    return FindLogLine(start, end, prefix, suffix);
++  }
++
++  void Handle(v8::CodeEvent* code_event) override {
++    const char* code_type =
++        v8::CodeEvent::GetCodeEventTypeName(code_event->GetCodeType());
++    char function_name[1000];
++    strncpy(function_name, code_type, 1000);
++    function_name[strlen(code_type)] = ' ';
++    code_event->GetFunctionName()->WriteUtf8(
++        function_name + strlen(code_type) + 1, 1000);
++    function_name[strlen(function_name) + 1] = '\0';
++    function_name[strlen(function_name)] = '\n';
++
++    log_ += std::string(function_name);
++  }
++
++ private:
++  std::string log_;
++};
++
+ }  // namespace
+
+ TEST(FindLogLine) {
+@@ -800,6 +833,48 @@ TEST(LogInterpretedFramesNativeStack) {
+   isolate->Dispose();
+ }
+
++TEST(ExternalCodeEventListener) {
++  i::FLAG_log = false;
++  i::FLAG_prof = false;
++
++  v8::Isolate::CreateParams create_params;
++  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
++  v8::Isolate* isolate = v8::Isolate::New(create_params);
++
++  {
++    v8::HandleScope scope(isolate);
++    v8::Isolate::Scope isolate_scope(isolate);
++    v8::Local<v8::Context> context = v8::Context::New(isolate);
++    context->Enter();
++
++    TestCodeEventHandler code_event_handler(isolate);
++
++    const char* source_text_before_start =
++        "function testCodeEventListenerBeforeStart(a,b) { return a + b };"
++        "testCodeEventListenerBeforeStart('1', 1);";
++    CompileRun(source_text_before_start);
++
++    CHECK_NULL(code_event_handler.FindLine("LazyCompile",
++                                           "testCodeEventListenerBeforeStart"));
++
++    code_event_handler.Enable();
++
++    CHECK_NOT_NULL(code_event_handler.FindLine(
++        "LazyCompile", "testCodeEventListenerBeforeStart"));
++
++    const char* source_text_after_start =
++        "function testCodeEventListenerAfterStart(a,b) { return a + b };"
++        "testCodeEventListenerAfterStart('1', 1);";
++    CompileRun(source_text_after_start);
++
++    CHECK_NOT_NULL(code_event_handler.FindLine(
++        "LazyCompile", "testCodeEventListenerAfterStart"));
++
++    context->Exit();
++  }
++  isolate->Dispose();
++}
++
+ TEST(TraceMaps) {
+   SETUP_FLAGS();
+   i::FLAG_trace_maps = true;

--- a/patches/common/v8/backport_aa6ce3e.patch
+++ b/patches/common/v8/backport_aa6ce3e.patch
@@ -401,7 +401,7 @@ index 953216aef7..563fe3c5f0 100644
 +    const char* comment) {
 +  CodeEvent code_event;
 +  code_event.code_start_address =
-+      static_cast<uintptr_t>(code->InstructionStart());
++      reinterpret_cast<uintptr_t>(code->InstructionStart());
 +  code_event.code_size = static_cast<size_t>(code->InstructionSize());
 +  code_event.function_name = isolate_->factory()->empty_string();
 +  code_event.script_name = isolate_->factory()->empty_string();
@@ -420,7 +420,7 @@ index 953216aef7..563fe3c5f0 100644
 +
 +  CodeEvent code_event;
 +  code_event.code_start_address =
-+      static_cast<uintptr_t>(code->InstructionStart());
++      reinterpret_cast<uintptr_t>(code->InstructionStart());
 +  code_event.code_size = static_cast<size_t>(code->InstructionSize());
 +  code_event.function_name = name_string;
 +  code_event.script_name = isolate_->factory()->empty_string();
@@ -440,7 +440,7 @@ index 953216aef7..563fe3c5f0 100644
 +
 +  CodeEvent code_event;
 +  code_event.code_start_address =
-+      static_cast<uintptr_t>(code->InstructionStart());
++      reinterpret_cast<uintptr_t>(code->InstructionStart());
 +  code_event.code_size = static_cast<size_t>(code->InstructionSize());
 +  code_event.function_name = name_string;
 +  code_event.script_name = isolate_->factory()->empty_string();
@@ -463,7 +463,7 @@ index 953216aef7..563fe3c5f0 100644
 +
 +  CodeEvent code_event;
 +  code_event.code_start_address =
-+      static_cast<uintptr_t>(code->InstructionStart());
++      reinterpret_cast<uintptr_t>(code->InstructionStart());
 +  code_event.code_size = static_cast<size_t>(code->InstructionSize());
 +  code_event.function_name = name_string;
 +  code_event.script_name = source_string;
@@ -485,7 +485,7 @@ index 953216aef7..563fe3c5f0 100644
 +                                                      String* source) {
 +  CodeEvent code_event;
 +  code_event.code_start_address =
-+      static_cast<uintptr_t>(code->InstructionStart());
++      reinterpret_cast<uintptr_t>(code->InstructionStart());
 +  code_event.code_size = static_cast<size_t>(code->InstructionSize());
 +  code_event.function_name = Handle<String>(source, isolate_);
 +  code_event.script_name = isolate_->factory()->empty_string();

--- a/patches/common/v8/cherry-pick_5dd3395.patch
+++ b/patches/common/v8/cherry-pick_5dd3395.patch
@@ -1,0 +1,12 @@
+diff --git a/src/log.cc b/src/log.cc
+index 903cc8e2e6..ce917b0be1 100644
+--- a/src/log.cc
++++ b/src/log.cc
+@@ -327,6 +327,7 @@ void PerfBasicLogger::LogRecordedBuffer(AbstractCode* code, SharedFunctionInfo*,
+                                         const char* name, int length) {
+   if (FLAG_perf_basic_prof_only_functions &&
+       (code->kind() != AbstractCode::INTERPRETED_FUNCTION &&
++       code->kind() != AbstractCode::BUILTIN &&
+        code->kind() != AbstractCode::OPTIMIZED_FUNCTION)) {
+     return;
+   }

--- a/patches/common/v8/cherry-pick_6989b3f6d7.patch
+++ b/patches/common/v8/cherry-pick_6989b3f6d7.patch
@@ -1,0 +1,300 @@
+diff --git a/src/js/intl.js b/src/js/intl.js
+index 53fbe1f947..3c7112716c 100644
+--- a/src/js/intl.js
++++ b/src/js/intl.js
+@@ -152,18 +152,11 @@ var AVAILABLE_LOCALES = {
+  */
+ var DEFAULT_ICU_LOCALE = UNDEFINED;
+
+-function GetDefaultICULocaleJS(service) {
++function GetDefaultICULocaleJS() {
+   if (IS_UNDEFINED(DEFAULT_ICU_LOCALE)) {
+     DEFAULT_ICU_LOCALE = %GetDefaultICULocale();
+   }
+-  // Check that this is a valid default for this service,
+-  // otherwise fall back to "und"
+-  // TODO(littledan,jshin): AvailableLocalesOf sometimes excludes locales
+-  // which don't require tailoring, but work fine with root data. Look into
+-  // exposing this fact in ICU or the way Chrome bundles data.
+-  return (IS_UNDEFINED(service) ||
+-          HAS_OWN_PROPERTY(getAvailableLocalesOf(service), DEFAULT_ICU_LOCALE))
+-         ? DEFAULT_ICU_LOCALE : "und";
++  return DEFAULT_ICU_LOCALE;
+ }
+
+ /**
+@@ -434,6 +427,48 @@ function resolveLocale(service, requestedLocales, options) {
+ }
+
+
++/**
++ * Look up the longest non-empty prefix of |locale| that is an element of
++ * |availableLocales|. Returns undefined when the |locale| is completely
++ * unsupported by |availableLocales|.
++ */
++function bestAvailableLocale(availableLocales, locale) {
++  do {
++    if (!IS_UNDEFINED(availableLocales[locale])) {
++      return locale;
++    }
++    // Truncate locale if possible.
++    var pos = %StringLastIndexOf(locale, '-');
++    if (pos === -1) {
++      break;
++    }
++    locale = %_Call(StringSubstring, locale, 0, pos);
++  } while (true);
++
++  return UNDEFINED;
++}
++
++
++/**
++ * Try to match any mutation of |requestedLocale| against |availableLocales|.
++ */
++function attemptSingleLookup(availableLocales, requestedLocale) {
++  // Remove all extensions.
++  var noExtensionsLocale = %RegExpInternalReplace(
++      GetAnyExtensionRE(), requestedLocale, '');
++  var availableLocale = bestAvailableLocale(
++      availableLocales, requestedLocale);
++  if (!IS_UNDEFINED(availableLocale)) {
++    // Return the resolved locale and extension.
++    var extensionMatch = %regexp_internal_match(
++        GetUnicodeExtensionRE(), requestedLocale);
++    var extension = IS_NULL(extensionMatch) ? '' : extensionMatch[0];
++    return {locale: availableLocale, extension: extension};
++  }
++  return UNDEFINED;
++}
++
++
+ /**
+  * Returns best matched supported locale and extension info using basic
+  * lookup algorithm.
+@@ -446,31 +481,25 @@ function lookupMatcher(service, requestedLocales) {
+   var availableLocales = getAvailableLocalesOf(service);
+
+   for (var i = 0; i < requestedLocales.length; ++i) {
+-    // Remove all extensions.
+-    var locale = %RegExpInternalReplace(
+-        GetAnyExtensionRE(), requestedLocales[i], '');
+-    do {
+-      if (!IS_UNDEFINED(availableLocales[locale])) {
+-        // Return the resolved locale and extension.
+-        var extensionMatch = %regexp_internal_match(
+-            GetUnicodeExtensionRE(), requestedLocales[i]);
+-        var extension = IS_NULL(extensionMatch) ? '' : extensionMatch[0];
+-        return {locale: locale, extension: extension, position: i};
+-      }
+-      // Truncate locale if possible.
+-      var pos = %StringLastIndexOf(locale, '-');
+-      if (pos === -1) {
+-        break;
+-      }
+-      locale = %_Call(StringSubstring, locale, 0, pos);
+-    } while (true);
++    var result = attemptSingleLookup(availableLocales, requestedLocales[i]);
++    if (!IS_UNDEFINED(result)) {
++      return result;
++    }
++  }
++
++  var defLocale = GetDefaultICULocaleJS();
++
++  // While ECMA-402 returns defLocale directly, we have to check if it is
++  // supported, as such support is not guaranteed.
++  var result = attemptSingleLookup(availableLocales, defLocale);
++  if (!IS_UNDEFINED(result)) {
++    return result;
+   }
+
+   // Didn't find a match, return default.
+   return {
+-    locale: GetDefaultICULocaleJS(service),
+-    extension: '',
+-    position: -1
++    locale: 'und',
++    extension: ''
+   };
+ }
+
+diff --git a/test/intl/assert.js b/test/intl/assert.js
+index d8cc85849f..c11e7c0bbf 100644
+--- a/test/intl/assert.js
++++ b/test/intl/assert.js
+@@ -132,6 +132,16 @@ function assertFalse(value, user_message = '') {
+ }
+
+
++/**
++ * Throws if value is null.
++ */
++function assertNotNull(value, user_message = '') {
++  if (value === null) {
++    fail("not null", value, user_message);
++  }
++}
++
++
+ /**
+  * Runs code() and asserts that it throws the specified exception.
+  */
+@@ -189,3 +199,34 @@ function assertInstanceof(obj, type) {
+                     (actualTypeName ? ' but of < ' + actualTypeName + '>' : ''));
+   }
+ }
++
++
++/**
++ * Split a BCP 47 language tag into locale and extension.
++ */
++function splitLanguageTag(tag) {
++  var extRe = /(-[0-9A-Za-z](-[0-9A-Za-z]{2,8})+)+$/;
++  var match = %regexp_internal_match(extRe, tag);
++  if (match) {
++    return { locale: tag.slice(0, match.index), extension: match[0] };
++  }
++
++  return { locale: tag, extension: '' };
++}
++
++
++/**
++ * Throw if |parent| is not a more general language tag of |child|, nor |child|
++ * itself, per BCP 47 rules.
++ */
++function assertLanguageTag(child, parent) {
++  var childSplit = splitLanguageTag(child);
++  var parentSplit = splitLanguageTag(parent);
++
++  // Do not compare extensions at this moment, as %GetDefaultICULocale()
++  // doesn't always output something we support.
++  if (childSplit.locale !== parentSplit.locale &&
++      !childSplit.locale.startsWith(parentSplit.locale + '-')) {
++    fail(child, parent, 'language tag comparison');
++  }
++}
+diff --git a/test/intl/break-iterator/default-locale.js b/test/intl/break-iterator/default-locale.js
+index d8d5aeadb2..e1a42a100a 100644
+--- a/test/intl/break-iterator/default-locale.js
++++ b/test/intl/break-iterator/default-locale.js
+@@ -37,8 +37,8 @@ assertFalse(options.locale === 'und');
+ assertFalse(options.locale === '');
+ assertFalse(options.locale === undefined);
+
+-// Then check for equality.
+-assertEquals(options.locale, %GetDefaultICULocale());
++// Then check for legitimacy.
++assertLanguageTag(%GetDefaultICULocale(), options.locale);
+
+ var iteratorNone = new Intl.v8BreakIterator();
+ assertEquals(options.locale, iteratorNone.resolvedOptions().locale);
+diff --git a/test/intl/break-iterator/wellformed-unsupported-locale.js b/test/intl/break-iterator/wellformed-unsupported-locale.js
+index 5ac8fbcd41..ffa44aef08 100644
+--- a/test/intl/break-iterator/wellformed-unsupported-locale.js
++++ b/test/intl/break-iterator/wellformed-unsupported-locale.js
+@@ -29,4 +29,4 @@
+
+ var iterator = Intl.v8BreakIterator(['xx']);
+
+-assertEquals(iterator.resolvedOptions().locale, %GetDefaultICULocale());
++assertLanguageTag(%GetDefaultICULocale(), iterator.resolvedOptions().locale);
+diff --git a/test/intl/collator/default-locale.js b/test/intl/collator/default-locale.js
+index db9b1e7330..5fc6ff4665 100644
+--- a/test/intl/collator/default-locale.js
++++ b/test/intl/collator/default-locale.js
+@@ -37,8 +37,8 @@ assertFalse(options.locale === 'und');
+ assertFalse(options.locale === '');
+ assertFalse(options.locale === undefined);
+
+-// Then check for equality.
+-assertEquals(options.locale, %GetDefaultICULocale());
++// Then check for legitimacy.
++assertLanguageTag(%GetDefaultICULocale(), options.locale);
+
+ var collatorNone = new Intl.Collator();
+ assertEquals(options.locale, collatorNone.resolvedOptions().locale);
+@@ -48,5 +48,8 @@ var collatorBraket = new Intl.Collator({});
+ assertEquals(options.locale, collatorBraket.resolvedOptions().locale);
+
+ var collatorWithOptions = new Intl.Collator(undefined, {usage: 'search'});
+-assertEquals(%GetDefaultICULocale() + '-u-co-search',
+-             collatorWithOptions.resolvedOptions().locale);
++assertLanguageTag(%GetDefaultICULocale(),
++                  collatorWithOptions.resolvedOptions().locale);
++assertNotNull(
++    %regexp_internal_match(/-u(-[a-zA-Z]+-[a-zA-Z]+)*-co-search/,
++        collatorWithOptions.resolvedOptions().locale));
+diff --git a/test/intl/collator/wellformed-unsupported-locale.js b/test/intl/collator/wellformed-unsupported-locale.js
+index 3963d47a61..ad89e3e220 100644
+--- a/test/intl/collator/wellformed-unsupported-locale.js
++++ b/test/intl/collator/wellformed-unsupported-locale.js
+@@ -29,4 +29,4 @@
+
+ var collator = Intl.Collator(['xx']);
+
+-assertEquals(collator.resolvedOptions().locale, %GetDefaultICULocale());
++assertLanguageTag(%GetDefaultICULocale(), collator.resolvedOptions().locale);
+diff --git a/test/intl/date-format/default-locale.js b/test/intl/date-format/default-locale.js
+index 8e9b7fcec3..2d79e895b5 100644
+--- a/test/intl/date-format/default-locale.js
++++ b/test/intl/date-format/default-locale.js
+@@ -37,8 +37,8 @@ assertFalse(options.locale === 'und');
+ assertFalse(options.locale === '');
+ assertFalse(options.locale === undefined);
+
+-// Then check for equality.
+-assertEquals(options.locale, %GetDefaultICULocale());
++// Then check for legitimacy.
++assertLanguageTag(%GetDefaultICULocale(), options.locale);
+
+ var dtfNone = new Intl.DateTimeFormat();
+ assertEquals(options.locale, dtfNone.resolvedOptions().locale);
+diff --git a/test/intl/date-format/wellformed-unsupported-locale.js b/test/intl/date-format/wellformed-unsupported-locale.js
+index 6f063abbd1..b812164832 100644
+--- a/test/intl/date-format/wellformed-unsupported-locale.js
++++ b/test/intl/date-format/wellformed-unsupported-locale.js
+@@ -29,4 +29,4 @@
+
+ var dtf = Intl.DateTimeFormat(['xx']);
+
+-assertEquals(dtf.resolvedOptions().locale, %GetDefaultICULocale());
++assertLanguageTag(%GetDefaultICULocale(), dtf.resolvedOptions().locale);
+diff --git a/test/intl/number-format/default-locale.js b/test/intl/number-format/default-locale.js
+index cd67ba724f..a24aec2333 100644
+--- a/test/intl/number-format/default-locale.js
++++ b/test/intl/number-format/default-locale.js
+@@ -37,8 +37,8 @@ assertFalse(options.locale === 'und');
+ assertFalse(options.locale === '');
+ assertFalse(options.locale === undefined);
+
+-// Then check for equality.
+-assertEquals(options.locale, %GetDefaultICULocale());
++// Then check for legitimacy.
++assertLanguageTag(%GetDefaultICULocale(), options.locale);
+
+ var nfNone = new Intl.NumberFormat();
+ assertEquals(options.locale, nfNone.resolvedOptions().locale);
+diff --git a/test/intl/number-format/wellformed-unsupported-locale.js b/test/intl/number-format/wellformed-unsupported-locale.js
+index 195eba4c19..c51753928e 100644
+--- a/test/intl/number-format/wellformed-unsupported-locale.js
++++ b/test/intl/number-format/wellformed-unsupported-locale.js
+@@ -29,4 +29,4 @@
+
+ var nf = Intl.NumberFormat(['xx']);
+
+-assertEquals(nf.resolvedOptions().locale, %GetDefaultICULocale());
++assertLanguageTag(%GetDefaultICULocale(), nf.resolvedOptions().locale);
+diff --git a/test/mjsunit/regress/regress-6288.js b/test/mjsunit/regress/regress-6288.js
+index 337af54c1a..5f550c31c8 100644
+--- a/test/mjsunit/regress/regress-6288.js
++++ b/test/mjsunit/regress/regress-6288.js
+@@ -8,6 +8,6 @@
+ // DateTimeFormat but not Collation
+
+ if (this.Intl) {
+-  assertEquals('und', Intl.Collator().resolvedOptions().locale);
++  assertEquals('pt', Intl.Collator().resolvedOptions().locale);
+   assertEquals('pt-BR', Intl.DateTimeFormat().resolvedOptions().locale);
+ }

--- a/patches/common/v8/cherry-pick_70c4340.patch
+++ b/patches/common/v8/cherry-pick_70c4340.patch
@@ -1,0 +1,30 @@
+diff --git a/src/api.cc b/src/api.cc
+index b46d376837..a97b38d00a 100644
+--- a/src/api.cc
++++ b/src/api.cc
+@@ -10217,6 +10217,10 @@ const char* CodeEvent::GetCodeEventTypeName(CodeEventType code_event_type) {
+       CODE_EVENTS_LIST(V)
+ #undef V
+   }
++  // The execution should never pass here
++  UNREACHABLE();
++  // NOTE(mmarchini): Workaround to fix a compiler failure on GCC 4.9
++  return "Unknown";
+ }
+
+ CodeEventHandler::CodeEventHandler(Isolate* isolate) {
+diff --git a/src/log.cc b/src/log.cc
+index d1673715e5..f70acbd54d 100644
+--- a/src/log.cc
++++ b/src/log.cc
+@@ -59,6 +59,10 @@ static v8::CodeEventType GetCodeEventTypeForTag(
+       TAGS_LIST(V)
+ #undef V
+   }
++  // The execution should never pass here
++  UNREACHABLE();
++  // NOTE(mmarchini): Workaround to fix a compiler failure on GCC 4.9
++  return v8::CodeEventType::kUnknownType;
+ }
+ #define CALL_CODE_EVENT_HANDLER(Call) \
+   if (listener_) {                    \

--- a/patches/common/v8/cherry-pick_a440efb27f.patch
+++ b/patches/common/v8/cherry-pick_a440efb27f.patch
@@ -1,0 +1,225 @@
+diff --git a/include/v8.h b/include/v8.h
+index 29566f4303..07a500f7ff 100644
+--- a/include/v8.h
++++ b/include/v8.h
+@@ -1578,6 +1578,9 @@ class V8_EXPORT ScriptCompiler {
+    * This will return nullptr if the script cannot be serialized. The
+    * CachedData returned by this function should be owned by the caller.
+    */
++  static CachedData* CreateCodeCache(Local<UnboundScript> unbound_script);
++
++  // Deprecated.
+   static CachedData* CreateCodeCache(Local<UnboundScript> unbound_script,
+                                      Local<String> source);
+
+@@ -1587,6 +1590,9 @@ class V8_EXPORT ScriptCompiler {
+    * This will return nullptr if the script cannot be serialized. The
+    * CachedData returned by this function should be owned by the caller.
+    */
++  static CachedData* CreateCodeCacheForFunction(Local<Function> function);
++
++  // Deprecated.
+   static CachedData* CreateCodeCacheForFunction(Local<Function> function,
+                                                 Local<String> source);
+
+diff --git a/src/api.cc b/src/api.cc
+index 27e7598bfa..61b1be1401 100644
+--- a/src/api.cc
++++ b/src/api.cc
+@@ -2628,21 +2628,29 @@ uint32_t ScriptCompiler::CachedDataVersionTag() {
+
+ ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCache(
+     Local<UnboundScript> unbound_script, Local<String> source) {
++  return CreateCodeCache(unbound_script);
++}
++
++ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCache(
++    Local<UnboundScript> unbound_script) {
+   i::Handle<i::SharedFunctionInfo> shared =
+       i::Handle<i::SharedFunctionInfo>::cast(
+           Utils::OpenHandle(*unbound_script));
+-  i::Handle<i::String> source_str = Utils::OpenHandle(*source);
+   DCHECK(shared->is_toplevel());
+-  return i::CodeSerializer::Serialize(shared, source_str);
++  return i::CodeSerializer::Serialize(shared);
+ }
+
+ ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCacheForFunction(
+     Local<Function> function, Local<String> source) {
++  return CreateCodeCacheForFunction(function);
++}
++
++ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCacheForFunction(
++    Local<Function> function) {
+   i::Handle<i::SharedFunctionInfo> shared(
+       i::Handle<i::JSFunction>::cast(Utils::OpenHandle(*function))->shared());
+-  i::Handle<i::String> source_str = Utils::OpenHandle(*source);
+   CHECK(shared->is_wrapped());
+-  return i::CodeSerializer::Serialize(shared, source_str);
++  return i::CodeSerializer::Serialize(shared);
+ }
+
+ MaybeLocal<Script> Script::Compile(Local<Context> context, Local<String> source,
+diff --git a/src/d8.cc b/src/d8.cc
+index b338dfbb2d..e6ba022795 100644
+--- a/src/d8.cc
++++ b/src/d8.cc
+@@ -636,7 +636,7 @@ bool Shell::ExecuteString(Isolate* isolate, Local<String> source,
+         ShellOptions::CodeCacheOptions::kProduceCache) {
+       // Serialize and store it in memory for the next execution.
+       ScriptCompiler::CachedData* cached_data =
+-          ScriptCompiler::CreateCodeCache(script->GetUnboundScript(), source);
++          ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
+       StoreInCodeCache(isolate, source, cached_data);
+       delete cached_data;
+     }
+@@ -645,7 +645,7 @@ bool Shell::ExecuteString(Isolate* isolate, Local<String> source,
+         ShellOptions::CodeCacheOptions::kProduceCacheAfterExecute) {
+       // Serialize and store it in memory for the next execution.
+       ScriptCompiler::CachedData* cached_data =
+-          ScriptCompiler::CreateCodeCache(script->GetUnboundScript(), source);
++          ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
+       StoreInCodeCache(isolate, source, cached_data);
+       delete cached_data;
+     }
+diff --git a/src/snapshot/code-serializer.cc b/src/snapshot/code-serializer.cc
+index 2697e9dce4..823d8dc9af 100644
+--- a/src/snapshot/code-serializer.cc
++++ b/src/snapshot/code-serializer.cc
+@@ -32,7 +32,7 @@ ScriptData::ScriptData(const byte* data, int length)
+
+ // static
+ ScriptCompiler::CachedData* CodeSerializer::Serialize(
+-    Handle<SharedFunctionInfo> info, Handle<String> source) {
++    Handle<SharedFunctionInfo> info) {
+   Isolate* isolate = info->GetIsolate();
+   TRACE_EVENT_CALL_STATS_SCOPED(isolate, "v8", "V8.Execute");
+   HistogramTimerScope histogram_timer(isolate->counters()->compile_serialize());
+@@ -45,8 +45,7 @@ ScriptCompiler::CachedData* CodeSerializer::Serialize(
+   Handle<Script> script(Script::cast(info->script()), isolate);
+   if (FLAG_trace_serializer) {
+     PrintF("[Serializing from");
+-    Object* script = info->script();
+-    Script::cast(script)->name()->ShortPrint();
++    script->name()->ShortPrint();
+     PrintF("]\n");
+   }
+   // TODO(7110): Enable serialization of Asm modules once the AsmWasmData is
+@@ -55,10 +54,11 @@ ScriptCompiler::CachedData* CodeSerializer::Serialize(
+   if (isolate->debug()->is_loaded()) return nullptr;
+
+   // Serialize code object.
++  Handle<String> source(String::cast(script->source()), isolate);
+   CodeSerializer cs(isolate, SerializedCodeData::SourceHash(source));
+   DisallowHeapAllocation no_gc;
+   cs.reference_map()->AddAttachedReference(*source);
+-  ScriptData* script_data = cs.Serialize(info);
++  ScriptData* script_data = cs.SerializeSharedFunctionInfo(info);
+
+   if (FLAG_profile_deserialization) {
+     double ms = timer.Elapsed().InMillisecondsF();
+@@ -75,11 +75,12 @@ ScriptCompiler::CachedData* CodeSerializer::Serialize(
+   return result;
+ }
+
+-ScriptData* CodeSerializer::Serialize(Handle<HeapObject> obj) {
++ScriptData* CodeSerializer::SerializeSharedFunctionInfo(
++    Handle<SharedFunctionInfo> info) {
+   DisallowHeapAllocation no_gc;
+
+   VisitRootPointer(Root::kHandleScope, nullptr,
+-                   Handle<Object>::cast(obj).location());
++                   Handle<Object>::cast(info).location());
+   SerializeDeferredObjects();
+   Pad();
+
+diff --git a/src/snapshot/code-serializer.h b/src/snapshot/code-serializer.h
+index 8e97f47f2f..f6b51bf9b1 100644
+--- a/src/snapshot/code-serializer.h
++++ b/src/snapshot/code-serializer.h
+@@ -45,10 +45,9 @@ class ScriptData {
+
+ class CodeSerializer : public Serializer<> {
+  public:
+-  static ScriptCompiler::CachedData* Serialize(Handle<SharedFunctionInfo> info,
+-                                               Handle<String> source);
++  static ScriptCompiler::CachedData* Serialize(Handle<SharedFunctionInfo> info);
+
+-  ScriptData* Serialize(Handle<HeapObject> obj);
++  ScriptData* SerializeSharedFunctionInfo(Handle<SharedFunctionInfo> info);
+
+   V8_WARN_UNUSED_RESULT static MaybeHandle<SharedFunctionInfo> Deserialize(
+       Isolate* isolate, ScriptData* cached_data, Handle<String> source);
+diff --git a/test/cctest/test-api.cc b/test/cctest/test-api.cc
+index f242262cf0..fbcc12190e 100644
+--- a/test/cctest/test-api.cc
++++ b/test/cctest/test-api.cc
+@@ -25428,8 +25428,7 @@ TEST(CodeCache) {
+         v8::ScriptCompiler::kNoCompileOptions;
+     v8::Local<v8::Script> script =
+         v8::ScriptCompiler::Compile(context, &source, option).ToLocalChecked();
+-    cache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript(),
+-                                                source_string);
++    cache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
+   }
+   isolate1->Dispose();
+
+diff --git a/test/cctest/test-serialize.cc b/test/cctest/test-serialize.cc
+index 370791f6c2..817561c68a 100644
+--- a/test/cctest/test-serialize.cc
++++ b/test/cctest/test-serialize.cc
+@@ -1240,8 +1240,7 @@ static Handle<SharedFunctionInfo> CompileScriptAndProduceCache(
+           NOT_NATIVES_CODE)
+           .ToHandleChecked();
+   std::unique_ptr<ScriptCompiler::CachedData> cached_data(
+-      ScriptCompiler::CreateCodeCache(ToApiHandle<UnboundScript>(sfi),
+-                                      Utils::ToLocal(source)));
++      ScriptCompiler::CreateCodeCache(ToApiHandle<UnboundScript>(sfi)));
+   uint8_t* buffer = NewArray<uint8_t>(cached_data->length);
+   MemCopy(buffer, cached_data->data, cached_data->length);
+   *script_data = new i::ScriptData(buffer, cached_data->length);
+@@ -1895,7 +1894,7 @@ v8::ScriptCompiler::CachedData* CompileRunAndProduceCache(
+             .ToLocalChecked();
+
+     if (cacheType != CodeCacheType::kAfterExecute) {
+-      cache = ScriptCompiler::CreateCodeCache(script, source_str);
++      cache = ScriptCompiler::CreateCodeCache(script);
+     }
+
+     v8::Local<v8::Value> result = script->BindToCurrentContext()
+@@ -1907,7 +1906,7 @@ v8::ScriptCompiler::CachedData* CompileRunAndProduceCache(
+               .FromJust());
+
+     if (cacheType == CodeCacheType::kAfterExecute) {
+-      cache = ScriptCompiler::CreateCodeCache(script, source_str);
++      cache = ScriptCompiler::CreateCodeCache(script);
+     }
+     CHECK(cache);
+   }
+@@ -2153,7 +2152,7 @@ TEST(CodeSerializerWithHarmonyScoping) {
+         v8::ScriptCompiler::CompileUnboundScript(
+             isolate1, &source, v8::ScriptCompiler::kNoCompileOptions)
+             .ToLocalChecked();
+-    cache = v8::ScriptCompiler::CreateCodeCache(script, source_str);
++    cache = v8::ScriptCompiler::CreateCodeCache(script);
+     CHECK(cache);
+
+     v8::Local<v8::Value> result = script->BindToCurrentContext()
+@@ -2218,7 +2217,7 @@ TEST(Regress503552) {
+   heap::SimulateIncrementalMarking(isolate->heap());
+
+   v8::ScriptCompiler::CachedData* cache_data =
+-      CodeSerializer::Serialize(shared, source);
++      CodeSerializer::Serialize(shared);
+   delete cache_data;
+ }
+
+@@ -3447,7 +3446,7 @@ TEST(CachedCompileFunctionInContext) {
+             env.local(), &script_source, 1, &arg_str, 0, nullptr,
+             v8::ScriptCompiler::kEagerCompile)
+             .ToLocalChecked();
+-    cache = v8::ScriptCompiler::CreateCodeCacheForFunction(fun, source);
++    cache = v8::ScriptCompiler::CreateCodeCacheForFunction(fun);
+   }
+
+   {

--- a/patches/common/v8/cherry-pick_acc336c.patch
+++ b/patches/common/v8/cherry-pick_acc336c.patch
@@ -1,0 +1,153 @@
+diff --git a/src/log.cc b/src/log.cc
+index e50b00a320..832ef7519d 100644
+--- a/src/log.cc
++++ b/src/log.cc
+@@ -2023,7 +2023,7 @@ void ExistingCodeLogger::LogCodeObject(Object* object) {
+       break;
+     case AbstractCode::BUILTIN:
+       if (Code::cast(object)->is_interpreter_trampoline_builtin() &&
+-          Code::cast(object) ==
++          Code::cast(object) !=
+               *BUILTIN_CODE(isolate_, InterpreterEntryTrampoline)) {
+         return;
+       }
+diff --git a/test/cctest/test-log.cc b/test/cctest/test-log.cc
+index c7864034c9..767541d4a3 100644
+--- a/test/cctest/test-log.cc
++++ b/test/cctest/test-log.cc
+@@ -36,6 +36,9 @@
+
+ #include <unordered_set>
+ #include <vector>
++// The C++ style guide recommends using <re2> instead of <regex>. However, the
++// former isn't available in V8.
++#include <regex>  // NOLINT(build/c++11)
+ #include "src/api.h"
+ #include "src/log-utils.h"
+ #include "src/log.h"
+@@ -257,30 +260,41 @@ class TestCodeEventHandler : public v8::CodeEventHandler {
+   explicit TestCodeEventHandler(v8::Isolate* isolate)
+       : v8::CodeEventHandler(isolate) {}
+
+-  const char* FindLine(const char* prefix, const char* suffix = nullptr,
+-                       const char* start = nullptr) {
+-    if (!log_.length()) return NULL;
+-    const char* c_log = log_.c_str();
+-    if (start == nullptr) start = c_log;
+-    const char* end = c_log + log_.length();
+-    return FindLogLine(start, end, prefix, suffix);
++  size_t CountLines(std::string prefix, std::string suffix = std::string()) {
++    if (!log_.length()) return 0;
++
++    std::regex expression("(^|\\n)" + prefix + ".*" + suffix + "(?=\\n|$)");
++
++    size_t match_count(std::distance(
++        std::sregex_iterator(log_.begin(), log_.end(), expression),
++        std::sregex_iterator()));
++
++    return match_count;
+   }
+
+   void Handle(v8::CodeEvent* code_event) override {
+-    const char* code_type =
+-        v8::CodeEvent::GetCodeEventTypeName(code_event->GetCodeType());
+-    char function_name[1000];
+-    strncpy(function_name, code_type, 1000);
+-    function_name[strlen(code_type)] = ' ';
+-    code_event->GetFunctionName()->WriteUtf8(
+-        function_name + strlen(code_type) + 1, 1000);
+-    function_name[strlen(function_name) + 1] = '\0';
+-    function_name[strlen(function_name)] = '\n';
+-
+-    log_ += std::string(function_name);
++    std::string log_line = "";
++    log_line += v8::CodeEvent::GetCodeEventTypeName(code_event->GetCodeType());
++    log_line += " ";
++    log_line += FormatName(code_event);
++    log_line += "\n";
++    log_ += log_line;
+   }
+
+  private:
++  std::string FormatName(v8::CodeEvent* code_event) {
++    std::string name = std::string(code_event->GetComment());
++    if (name.empty()) {
++      v8::Local<v8::String> functionName = code_event->GetFunctionName();
++      std::string buffer(functionName->Utf8Length() + 1, 0);
++      functionName->WriteUtf8(&buffer[0], functionName->Utf8Length() + 1);
++      // Sanitize name, removing unwanted \0 resulted from WriteUtf8
++      name = std::string(buffer.c_str());
++    }
++
++    return name;
++  }
++
+   std::string log_;
+ };
+
+@@ -854,21 +868,24 @@ TEST(ExternalCodeEventListener) {
+         "testCodeEventListenerBeforeStart('1', 1);";
+     CompileRun(source_text_before_start);
+
+-    CHECK_NULL(code_event_handler.FindLine("LazyCompile",
+-                                           "testCodeEventListenerBeforeStart"));
++    CHECK_EQ(code_event_handler.CountLines("LazyCompile",
++                                           "testCodeEventListenerBeforeStart"),
++             0);
+
+     code_event_handler.Enable();
+
+-    CHECK_NOT_NULL(code_event_handler.FindLine(
+-        "LazyCompile", "testCodeEventListenerBeforeStart"));
++    CHECK_GE(code_event_handler.CountLines("LazyCompile",
++                                           "testCodeEventListenerBeforeStart"),
++             1);
+
+     const char* source_text_after_start =
+         "function testCodeEventListenerAfterStart(a,b) { return a + b };"
+         "testCodeEventListenerAfterStart('1', 1);";
+     CompileRun(source_text_after_start);
+
+-    CHECK_NOT_NULL(code_event_handler.FindLine(
+-        "LazyCompile", "testCodeEventListenerAfterStart"));
++    CHECK_GE(code_event_handler.CountLines("LazyCompile",
++                                           "testCodeEventListenerAfterStart"),
++             1);
+
+     context->Exit();
+   }
+@@ -897,21 +914,28 @@ TEST(ExternalCodeEventListenerWithInterpretedFramesNativeStack) {
+         "testCodeEventListenerBeforeStart('1', 1);";
+     CompileRun(source_text_before_start);
+
+-    CHECK_NULL(code_event_handler.FindLine("InterpretedFunction",
+-                                           "testCodeEventListenerBeforeStart"));
++    CHECK_EQ(code_event_handler.CountLines("InterpretedFunction",
++                                           "testCodeEventListenerBeforeStart"),
++             0);
+
+     code_event_handler.Enable();
+
+-    CHECK_NOT_NULL(code_event_handler.FindLine(
+-        "InterpretedFunction", "testCodeEventListenerBeforeStart"));
++    CHECK_GE(code_event_handler.CountLines("InterpretedFunction",
++                                           "testCodeEventListenerBeforeStart"),
++             1);
+
+     const char* source_text_after_start =
+         "function testCodeEventListenerAfterStart(a,b) { return a + b };"
+         "testCodeEventListenerAfterStart('1', 1);";
+     CompileRun(source_text_after_start);
+
+-    CHECK_NOT_NULL(code_event_handler.FindLine(
+-        "InterpretedFunction", "testCodeEventListenerAfterStart"));
++    CHECK_GE(code_event_handler.CountLines("InterpretedFunction",
++                                           "testCodeEventListenerAfterStart"),
++             1);
++
++    CHECK_EQ(
++        code_event_handler.CountLines("Builtin", "InterpreterEntryTrampoline"),
++        1);
+
+     context->Exit();
+   }

--- a/patches/common/v8/cherry-pick_b20faff.patch
+++ b/patches/common/v8/cherry-pick_b20faff.patch
@@ -1,0 +1,183 @@
+diff --git a/src/log.cc b/src/log.cc
+index 563fe3c5f0..edd883976d 100644
+--- a/src/log.cc
++++ b/src/log.cc
+@@ -2011,10 +2011,10 @@ FILE* Logger::TearDown() {
+ }
+
+ void ExistingCodeLogger::LogCodeObject(Object* object) {
+-  AbstractCode* code_object = AbstractCode::cast(object);
++  AbstractCode* abstract_code = AbstractCode::cast(object);
+   CodeEventListener::LogEventsAndTags tag = CodeEventListener::STUB_TAG;
+   const char* description = "Unknown code from before profiling";
+-  switch (code_object->kind()) {
++  switch (abstract_code->kind()) {
+     case AbstractCode::INTERPRETED_FUNCTION:
+     case AbstractCode::OPTIMIZED_FUNCTION:
+       return;  // We log this later using LogCompiledFunctions.
+@@ -2022,7 +2022,7 @@ void ExistingCodeLogger::LogCodeObject(Object* object) {
+       return;  // We log it later by walking the dispatch table.
+     case AbstractCode::STUB:
+       description =
+-          CodeStub::MajorName(CodeStub::GetMajorKey(code_object->GetCode()));
++          CodeStub::MajorName(CodeStub::GetMajorKey(abstract_code->GetCode()));
+       if (description == nullptr) description = "A stub from before profiling";
+       tag = CodeEventListener::STUB_TAG;
+       break;
+@@ -2031,8 +2031,13 @@ void ExistingCodeLogger::LogCodeObject(Object* object) {
+       tag = CodeEventListener::REG_EXP_TAG;
+       break;
+     case AbstractCode::BUILTIN:
++      if (Code::cast(object)->is_interpreter_trampoline_builtin() &&
++          Code::cast(object) ==
++              *BUILTIN_CODE(isolate_, InterpreterEntryTrampoline)) {
++        return;
++      }
+       description =
+-          isolate_->builtins()->name(code_object->GetCode()->builtin_index());
++          isolate_->builtins()->name(abstract_code->GetCode()->builtin_index());
+       tag = CodeEventListener::BUILTIN_TAG;
+       break;
+     case AbstractCode::WASM_FUNCTION:
+@@ -2058,7 +2063,7 @@ void ExistingCodeLogger::LogCodeObject(Object* object) {
+     case AbstractCode::NUMBER_OF_KINDS:
+       UNIMPLEMENTED();
+   }
+-  CALL_CODE_EVENT_HANDLER(CodeCreateEvent(tag, code_object, description))
++  CALL_CODE_EVENT_HANDLER(CodeCreateEvent(tag, abstract_code, description))
+ }
+
+ void ExistingCodeLogger::LogCodeObjects() {
+@@ -2084,6 +2089,12 @@ void ExistingCodeLogger::LogCompiledFunctions() {
+   // During iteration, there can be heap allocation due to
+   // GetScriptLineNumber call.
+   for (int i = 0; i < compiled_funcs_count; ++i) {
++    if (sfis[i]->function_data()->IsInterpreterData()) {
++      LogExistingFunction(sfis[i],
++                          Handle<AbstractCode>(AbstractCode::cast(
++                              sfis[i]->InterpreterTrampoline())),
++                          CodeEventListener::INTERPRETED_FUNCTION_TAG);
++    }
+     if (code_objects[i].is_identical_to(BUILTIN_CODE(isolate_, CompileLazy)))
+       continue;
+     LogExistingFunction(sfis[i], code_objects[i]);
+@@ -2128,8 +2139,9 @@ void ExistingCodeLogger::LogBytecodeHandlers() {
+   }
+ }
+
+-void ExistingCodeLogger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
+-                                             Handle<AbstractCode> code) {
++void ExistingCodeLogger::LogExistingFunction(
++    Handle<SharedFunctionInfo> shared, Handle<AbstractCode> code,
++    CodeEventListener::LogEventsAndTags tag) {
+   if (shared->script()->IsScript()) {
+     Handle<Script> script(Script::cast(shared->script()));
+     int line_num = Script::GetLineNumber(script, shared->StartPosition()) + 1;
+@@ -2139,9 +2151,8 @@ void ExistingCodeLogger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
+       Handle<String> script_name(String::cast(script->name()));
+       if (line_num > 0) {
+         CALL_CODE_EVENT_HANDLER(
+-            CodeCreateEvent(Logger::ToNativeByScript(
+-                                CodeEventListener::LAZY_COMPILE_TAG, *script),
+-                            *code, *shared, *script_name, line_num, column_num))
++            CodeCreateEvent(Logger::ToNativeByScript(tag, *script), *code,
++                            *shared, *script_name, line_num, column_num))
+       } else {
+         // Can't distinguish eval and script here, so always use Script.
+         CALL_CODE_EVENT_HANDLER(CodeCreateEvent(
+@@ -2149,11 +2160,9 @@ void ExistingCodeLogger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
+             *code, *shared, *script_name))
+       }
+     } else {
+-      CALL_CODE_EVENT_HANDLER(
+-          CodeCreateEvent(Logger::ToNativeByScript(
+-                              CodeEventListener::LAZY_COMPILE_TAG, *script),
+-                          *code, *shared, isolate_->heap()->empty_string(),
+-                          line_num, column_num))
++      CALL_CODE_EVENT_HANDLER(CodeCreateEvent(
++          Logger::ToNativeByScript(tag, *script), *code, *shared,
++          isolate_->heap()->empty_string(), line_num, column_num))
+     }
+   } else if (shared->IsApiFunction()) {
+     // API function.
+@@ -2169,9 +2178,8 @@ void ExistingCodeLogger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
+       CALL_CODE_EVENT_HANDLER(CallbackEvent(shared->DebugName(), entry_point))
+     }
+   } else {
+-    CALL_CODE_EVENT_HANDLER(CodeCreateEvent(CodeEventListener::LAZY_COMPILE_TAG,
+-                                            *code, *shared,
+-                                            isolate_->heap()->empty_string()))
++    CALL_CODE_EVENT_HANDLER(
++        CodeCreateEvent(tag, *code, *shared, isolate_->heap()->empty_string()))
+   }
+ }
+
+diff --git a/src/log.h b/src/log.h
+index 738aef4d73..ad254097e6 100644
+--- a/src/log.h
++++ b/src/log.h
+@@ -109,7 +109,9 @@ class ExistingCodeLogger {
+
+   void LogCompiledFunctions();
+   void LogExistingFunction(Handle<SharedFunctionInfo> shared,
+-                           Handle<AbstractCode> code);
++                           Handle<AbstractCode> code,
++                           CodeEventListener::LogEventsAndTags tag =
++                               CodeEventListener::LAZY_COMPILE_TAG);
+   void LogCodeObject(Object* object);
+   void LogBytecodeHandler(interpreter::Bytecode bytecode,
+                           interpreter::OperandScale operand_scale, Code* code);
+diff --git a/test/cctest/test-log.cc b/test/cctest/test-log.cc
+index 97071a63f5..c7864034c9 100644
+--- a/test/cctest/test-log.cc
++++ b/test/cctest/test-log.cc
+@@ -875,6 +875,49 @@ TEST(ExternalCodeEventListener) {
+   isolate->Dispose();
+ }
+
++TEST(ExternalCodeEventListenerWithInterpretedFramesNativeStack) {
++  i::FLAG_log = false;
++  i::FLAG_prof = false;
++  i::FLAG_interpreted_frames_native_stack = true;
++
++  v8::Isolate::CreateParams create_params;
++  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
++  v8::Isolate* isolate = v8::Isolate::New(create_params);
++
++  {
++    v8::HandleScope scope(isolate);
++    v8::Isolate::Scope isolate_scope(isolate);
++    v8::Local<v8::Context> context = v8::Context::New(isolate);
++    context->Enter();
++
++    TestCodeEventHandler code_event_handler(isolate);
++
++    const char* source_text_before_start =
++        "function testCodeEventListenerBeforeStart(a,b) { return a + b };"
++        "testCodeEventListenerBeforeStart('1', 1);";
++    CompileRun(source_text_before_start);
++
++    CHECK_NULL(code_event_handler.FindLine("InterpretedFunction",
++                                           "testCodeEventListenerBeforeStart"));
++
++    code_event_handler.Enable();
++
++    CHECK_NOT_NULL(code_event_handler.FindLine(
++        "InterpretedFunction", "testCodeEventListenerBeforeStart"));
++
++    const char* source_text_after_start =
++        "function testCodeEventListenerAfterStart(a,b) { return a + b };"
++        "testCodeEventListenerAfterStart('1', 1);";
++    CompileRun(source_text_after_start);
++
++    CHECK_NOT_NULL(code_event_handler.FindLine(
++        "InterpretedFunction", "testCodeEventListenerAfterStart"));
++
++    context->Exit();
++  }
++  isolate->Dispose();
++}
++
+ TEST(TraceMaps) {
+   SETUP_FLAGS();
+   i::FLAG_trace_maps = true;

--- a/script/README.md
+++ b/script/README.md
@@ -11,7 +11,7 @@ $ ./script/get-patch --repo src --commit 8e8216e5
 
 2. Create a patch file with a default name if a specified directory.
 ```
-$ ./script/get-patch --repo src --commit 8e8216e5 --output_dir patches
+$ ./script/get-patch --repo src --commit 8e8216e5 --output-dir patches
 ```
 
 3. Create a patch file with a custom name in the current directory.
@@ -21,16 +21,16 @@ $ ./script/get-patch --repo src --commit 8e8216e5 --filename my.patch
 
 4. Create a patch file with a custom name in a specified directory.
 ```
-$ ./script/get-patch --repo src --commit 8e8216e5 --output_dir patches --filename my.patch
+$ ./script/get-patch --repo src --commit 8e8216e5 --output-dir patches --filename my.patch
 ```
 
 5. Create patch files with default names in a specified directory.
 ```
-$ ./script/get-patch --repo src --output_dir patches --commit 8e8216e5 164c37e3
+$ ./script/get-patch --repo src --output-dir patches --commit 8e8216e5 164c37e3
 ```
 
 6. Create patch files with custom names in a specified directory.
 Note that number of filenames must match the number of commits.
 ```
-$ ./script/get-patch --repo src --output_dir patches --commit 8e8216e5 164c37e3 --filename first.patch second.patch
+$ ./script/get-patch --repo src --output-dir patches --commit 8e8216e5 164c37e3 --filename first.patch second.patch
 ```


### PR DESCRIPTION
This PR adds patches for the Node upgrade to `v10.6.0`. It also corrects the `get-patch` script doc for the `--output-dir` cli flag.

/cc @alexeykuzmin 