### PR TITLE
fix: reattach webview after renderer process restarts (3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -312,3 +312,9 @@ patches:
   description: |
     https://chromium-review.googlesource.com/c/chromium/src/+/1105698
     Fixes https://github.com/electron/electron/issues/13256
+-
+  owners: zcbenz
+  file: webview_reattach.patch
+  description: |
+    Backports https://chromium-review.googlesource.com/c/chromium/src/+/1161391
+    Fixes webview not working after renderer process restarted.

--- a/patches/common/chromium/webview_reattach.patch
+++ b/patches/common/chromium/webview_reattach.patch
@@ -1,0 +1,16 @@
+diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
+index b2d1e63..bc2cf9a 100644
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -4562,6 +4562,11 @@ void WebContentsImpl::NotifyViewSwapped(RenderViewHost* old_host,
+   for (auto& observer : observers_)
+     observer.RenderViewHostChanged(old_host, new_host);
+ 
++  // If this is an inner WebContents that has swapped views, we need to reattach
++  // it to its outer WebContents.
++  if (node_.outer_web_contents())
++    ReattachToOuterWebContentsFrame();
++
+   // Ensure that the associated embedder gets cleared after a RenderViewHost
+   // gets swapped, so we don't reuse the same embedder next time a
+   // RenderViewHost is attached to this WebContents.


### PR DESCRIPTION
Backports https://github.com/electron/libchromiumcontent/pull/629 to `electron-3-0-x`.