### PR TITLE
fix: allow webview to load non-web URLs (3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -339,3 +339,8 @@ patches:
   description: |
     Removes usage of the _LSSetApplicationLaunchServicesServerConnectionStatus
     private API.
+-
+  owners: zcbenz
+  file: allow_webview_file_url.patch
+  description: |
+    Allow webview to load non-web URLs.

--- a/patches/common/chromium/allow_webview_file_url.patch
+++ b/patches/common/chromium/allow_webview_file_url.patch
@@ -1,0 +1,13 @@
+diff --git a/content/browser/loader/resource_dispatcher_host_impl.cc b/content/browser/loader/resource_dispatcher_host_impl.cc
+index 0c57d20..0916ed0 100644
+--- a/content/browser/loader/resource_dispatcher_host_impl.cc
++++ b/content/browser/loader/resource_dispatcher_host_impl.cc
+@@ -1870,6 +1870,8 @@ void ResourceDispatcherHostImpl::BeginNavigationRequest(
+       !policy->IsWebSafeScheme(info.common_params.url.scheme()) &&
+       !is_external_protocol;
+ 
++  non_web_url_in_guest = false;
++
+   if (is_shutdown_ || non_web_url_in_guest ||
+       (delegate_ && !delegate_->ShouldBeginRequest(
+           info.common_params.method,


### PR DESCRIPTION
Backports https://github.com/electron/libchromiumcontent/pull/635 to `electron-3-0-x`.