### PR TITLE
fix: backport MAS api removal to 2-0-x

### DIFF
--- a/patches-mas/004-no-cgdisplayusesforcetogray-cfisobjc.patch
+++ b/patches-mas/004-no-cgdisplayusesforcetogray-cfisobjc.patch
@@ -1,0 +1,79 @@
+From 6262d2684ceb606180c5356a8e138f26d3f0230a Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <jeremya@chromium.org>
+Date: Mon, 6 Aug 2018 17:11:14 -0700
+Subject: fix: [mas] remove usage of _CFIsObjC
+
+---
+ base/mac/foundation_util.mm | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/base/mac/foundation_util.mm b/base/mac/foundation_util.mm
+index eb8284ee58fe..70cb94b5cdbb 100644
+--- a/base/mac/foundation_util.mm
++++ b/base/mac/foundation_util.mm
+@@ -25,7 +25,6 @@
+ extern "C" {
+ CFTypeID SecACLGetTypeID();
+ CFTypeID SecTrustedApplicationGetTypeID();
+-Boolean _CFIsObjC(CFTypeID typeID, CFTypeRef obj);
+ }  // extern "C"
+ #endif
+ 
+@@ -323,8 +322,7 @@ NSFont* CFToNSCast(CTFontRef cf_val) {
+       const_cast<NSFont*>(reinterpret_cast<const NSFont*>(cf_val));
+   DCHECK(!cf_val ||
+          CTFontGetTypeID() == CFGetTypeID(cf_val) ||
+-         (_CFIsObjC(CTFontGetTypeID(), cf_val) &&
+-          [ns_val isKindOfClass:[NSFont class]]));
++         ([ns_val isKindOfClass:[NSFont class]]));
+   return ns_val;
+ }
+ 
+@@ -392,9 +390,6 @@ CFCast<CTFontRef>(const CFTypeRef& cf_val) {
+     return (CTFontRef)(cf_val);
+   }
+ 
+-  if (!_CFIsObjC(CTFontGetTypeID(), cf_val))
+-    return NULL;
+-
+   id<NSObject> ns_val = reinterpret_cast<id>(const_cast<void*>(cf_val));
+   if ([ns_val isKindOfClass:[NSFont class]]) {
+     return (CTFontRef)(cf_val);
+-- 
+2.17.0
+
+
+From da6fcc162bd9699195bbda084a6b58431ae204fe Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Mon, 6 Aug 2018 10:58:46 -0700
+Subject: fix: [mas] remove usage of CGDisplayUsesForceToGray
+
+---
+ ui/display/mac/screen_mac.mm | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/ui/display/mac/screen_mac.mm b/ui/display/mac/screen_mac.mm
+index 11eca13659c7..5453d2243220 100644
+--- a/ui/display/mac/screen_mac.mm
++++ b/ui/display/mac/screen_mac.mm
+@@ -95,7 +95,17 @@ Display BuildDisplayForScreen(NSScreen* screen) {
+   }
+   display.set_color_depth(NSBitsPerPixelFromDepth([screen depth]));
+   display.set_depth_per_component(NSBitsPerSampleFromDepth([screen depth]));
++#ifdef MAS_BUILD
++  // This is equivalent to the CGDisplayUsesForceToGray() API as at 2018-08-06,
++  // but avoids usage of the private API.
++  CFStringRef app = CFSTR("com.apple.CoreGraphics");
++  CFStringRef key = CFSTR("DisplayUseForcedGray");
++  Boolean key_valid = false;
++  display.set_is_monochrome(
++      CFPreferencesGetAppBooleanValue(key, app, &key_valid));
++#else
+   display.set_is_monochrome(CGDisplayUsesForceToGray());
++#endif
+ 
+   // CGDisplayRotation returns a double. Display::SetRotationAsDegree will
+   // handle the unexpected situations were the angle is not a multiple of 90.
+-- 
+2.17.0
+


### PR DESCRIPTION
see #633 

Ref electron/electron#13938

The patches for `AudioDeviceDuck` and `_LSSetApplicationLaunchServicesServerConnectionStatus` aren't needed as those APIs were not present in Chromium 61.