### PR TITLE
chore: roll clang 307486:308728

### DIFF
--- a/patches/093-roll-clang.patch
+++ b/patches/093-roll-clang.patch
@@ -1,0 +1,21 @@
+diff --git a/tools/clang/scripts/update.py b/tools/clang/scripts/update.py
+index 8d9e1ebb56c4..6eaed04c4a22 100755
+--- a/tools/clang/scripts/update.py
++++ b/tools/clang/scripts/update.py
+@@ -27,14 +27,14 @@ import zipfile
+ # Do NOT CHANGE this if you don't know what you're doing -- see
+ # https://chromium.googlesource.com/chromium/src/+/master/docs/updating_clang.md
+ # Reverting problematic clang rolls is safe, though.
+-CLANG_REVISION = '307486'
++CLANG_REVISION = '308728'
+ 
+ use_head_revision = 'LLVM_FORCE_HEAD_REVISION' in os.environ
+ if use_head_revision:
+   CLANG_REVISION = 'HEAD'
+ 
+ # This is incremented when pushing a new build of Clang at the same revision.
+-CLANG_SUB_REVISION=1
++CLANG_SUB_REVISION=3
+ 
+ PACKAGE_VERSION = "%s-%s" % (CLANG_REVISION, CLANG_SUB_REVISION)
+ 


### PR DESCRIPTION
See upstream:

https://chromium-review.googlesource.com/c/chromium/src/+/582074

We don't need any of the other changes from that CL, because they're all
fuchsia- or iOS-only.

Ref electron/electron#13988