### PR TITLE
Change to only copy proper file to s3

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -46,7 +46,11 @@ phases:
   - bash: |
      echo "===Create $COMPONENT distribution for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
      script/create-dist -t $TARGET_ARCH -c $COMPONENT > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
-     mv libchromiumcontent* s3files
+     if [ "${COMPONENT}" == "shared_library" ]; then
+       mv libchromiumcontent.zip s3files
+     else
+       mv libchromiumcontent-static.zip s3files
+     fi
      mv buildlog.txt s3files
     name: Create_distribution
 
@@ -64,7 +68,7 @@ phases:
 
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     condition: always()
-    
+
 - phase: Skip_libchromiumcontent_PR_build
   condition: and(eq(variables['System.PullRequest.IsFork'], 'False'), eq(variables['Build.Reason'], 'PullRequest'))
   steps:


### PR DESCRIPTION
We recently built 1-7-x for #639 and it was the first time doing so with VSTS.  It turns out the way that 1-7-x builds the zip files was causing issues with the S3 upload.  This PR updates VSTS to only upload the zip file for the type of build being done (static or shared).