### PR TITLE
Use VS2017 15.4.5 for Chromium 66

### DIFF
--- a/appveyor-override.yml
+++ b/appveyor-override.yml
@@ -1,0 +1,23 @@
+version: 1.0.{build}
+build_cloud: libcc-20
+image: libcc-20-vs2017-15.4.5
+build_script:
+- ps: >-
+    if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
+      Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
+    } else {
+      if($env:APPVEYOR_SCHEDULED_BUILD -eq 'True')  {
+        script\cibuild.ps1 -buildTests
+      } else {
+        script\cibuild.ps1
+      }
+      if ($? -ne 'True') {
+        throw "Build failed with exit code $?"
+      } else {
+        "Build succeeded."
+      }
+    }
+test: off
+artifacts:
+- path: libchromiumcontent*
+  name: libchromiumcontent


### PR DESCRIPTION
Use Visual Studio 2017 15.4.5 instead of vs2017-15.7.4
@MarshallOfSound and @deepak1556 discovered that electron/electron#13618 was caused by the version of Visual Studio that we built with. This PR changes the master branch to use Visual Studio 2017 v15.4.5 which resolves the issue.
(cherry picked from commit ff3f2a71da778cd8c366b08681ba6b3f59b02606)