### PR TITLE
build: optionally commit patches after they have been applied

### DIFF
--- a/patches/common/angle/.patches.yaml
+++ b/patches/common/angle/.patches.yaml
@@ -1,6 +1,6 @@
 repo: src/third_party/angle
 patches:
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: dcheck.patch
   description: null

--- a/patches/common/boringssl/.patches.yaml
+++ b/patches/common/boringssl/.patches.yaml
@@ -1,6 +1,6 @@
 repo: src/third_party/boringssl/src
 patches:
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: 0001-Implement-legacy-OCSP-APIs-for-libssl.patch
   description: see patch header

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -1,11 +1,11 @@
 repo: src
 patches:
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: build_gn.patch
   description: null
 -
-  owners: alespergl, deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: dcheck.patch
   description: |
     This disables some debug checks which currently fail when running the Electron
@@ -42,23 +42,23 @@ patches:
       third_party/WebKit/Source/platform/wtf/text/StringImpl.h
       ui/base/clipboard/clipboard_win.cc
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: accelerator.patch
   description: null
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: allow_new_privs.patch
   description: null
 -
-  owners: null
+  author: null
   file: app_indicator_icon_menu.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: blink_file_path.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: blink_local_frame.patch
   description: |
     According to electron/electron#3699, it is unreliable to use |unload|
@@ -71,19 +71,19 @@ patches:
 
     This patch reverts the change to fix the crash in Electron.
 -
-  owners: null
+  author: null
   file: blink_world_context.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: browser_compositor_mac.patch
   description: null
 -
-  owners: null
+  author: null
   file: browser_plugin_wheel.patch
   description: null
 -
-  owners: null
+  author: null
   file: build_toolchain_win_patch.patch
   description: |
     Patch the Windows build toolchain to generate unique PDB names
@@ -100,67 +100,67 @@ patches:
     For example, instead of generating `obj/ui/base/base_cc.pdb` the
     build will now generate `obj/ui/base/obj_ui_base_base_cc.pdb`.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: can_create_window.patch
   description: null
 -
-  owners: null
+  author: null
   file: compositor_delegate.patch
   description: null
 -
-  owners: null
+  author: null
   file: desktop_screen_win.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: disable_hidden.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: dom_storage_map.patch
   description: null
 -
-  owners: zcbenz, deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: frame_host_manager.patch
   description: null
 -
-  owners: tonyganch
+  author: Tony Ganch <tonyganch@gmail.com>
   file: latency_info.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: net_url_request_job.patch
   description: null
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: no_stack_dumping.patch
   description: null
 -
-  owners: deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: out_of_process_instance.patch
   description: null
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: protobuf_build_gn.patch
   description: null
 -
-  owners: null
+  author: null
   file: render_widget_host_view_base.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: render_widget_host_view_mac.patch
   description: null
 -
-  owners: null
+  author: null
   file: scoped_clipboard_writer.patch
   description: null
 -
-  owners: deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: stream_resource_handler.patch
   description: null
 -
-  owners: null
+  author: null
   file: thread_capabilities.patch
   description: |
     Chromium automatically drops all capabilities of renderer threads in
@@ -170,67 +170,67 @@ patches:
 
     See https://github.com/atom/electron/issues/3666
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: use_transparent_window.patch
   description: null
 -
-  owners: null
+  author: null
   file: web_contents.patch
   description: null
 -
-  owners: miniak
+  author: Milan Burda <milan.burda@gmail.com>
   file: webgl_context_attributes.patch
   description: null
 -
-  owners: null
+  author: null
   file: webview_cross_drag.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: worker_context_will_destroy.patch
   description: null
 -
-  owners: null
+  author: null
   file: webui_in_subframes.patch
   description: null
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: export_blink_webdisplayitemlist.patch
   description: null
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: statically_build_power_save_blocker.patch
   description: null
 -
-  owners: gavignus
+  author: Tomas Rycl <torycl@microsoft.com>
   file: browser_plugin_guest.patch
   description: null
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: disable_user_gesture_requirement_for_beforeunload_dialogs.patch
   description: See https://github.com/electron/electron/issues/10754
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: add_atomic_lib_to_dependencies_even_for_sysroot_builds.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: gin_enable_disable_v8_platform.patch
   description: null
 -
-  owners: deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: disable-recursive-surface-sync.patch
   description: null
 -
-  owners: deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: blink-worker-enable-csp-in-file-scheme.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: fix-arm64-linking-error.patch
   description: Do not use system freetype for arm64
 -
-  owners: brenca
+  author: Heilig Benedek <benecene@gmail.com>
   file: disable-redraw-lock.patch
   description:  |
     Chromium uses a custom window titlebar implementation on Windows when DWM
@@ -244,30 +244,30 @@ patches:
     the redraw locking mechanism, which fixes these issues. The electron issue
     can be found at https://github.com/electron/electron/issues/1821
 -
-  owners: MarshallOfSound
+  author: Samuel Attard <sattard@atlassian.com>
   file: backport_35dabc0.patch
   description: |
       Backports "ServiceWorker: Fix a jumbo build error",
       see https://chromium-review.googlesource.com/957568
       Original change's landed in 67.0.3369.0.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: exclude_next_version_mini_installer_from_deps.patch
   description: |
       It breaks ninja files generation for the "shared_library" configuration.
       Probably won't be needed on the next Chromium upgrade (after 66).
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: allow_chromiumcontent_to_depend_on_device_service.patch
   description: By default we cannot depend on it, but we want to use it.
 -
-  owners: nitsakh
+  author: Nitish Sakhawalkar <nitsakh@icloud.com>
   file: v8_context_snapshot_generator.patch
   description: |
       v8_context_snapshot_generator is a build time executable.
       The patch adds the config.
 -
-  owners: codebytere
+  author: Shelley Vohr <shelley.vohr@gmail.com>
   file: backport_953144.patch
   description: |
     Fixes failing <webview> loads devtools extensions registered on the parent
@@ -276,13 +276,13 @@ patches:
     https://chromium-review.googlesource.com/c/chromium/src/+/953144 for more
     details.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_ef091c206.patch
   description: |
       https://chromium-review.googlesource.com/969968
       The change originally landed in 67.0.3378.0.
 -
-  owners: torycl
+  author: Tomas Rycl <torycl@microsoft.com>
   file: crashpad-disabled-windows.patch
   description: |
       On Windows Electron does not link Crashpad. This causes linking
@@ -290,24 +290,24 @@ patches:
       This patch will disable Crashpad in Chromium using fallback
       mechanism which uses Breakpad.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: boringssl_build_gn.patch
   description: |
     Build BoringSSL with some extra functions that nodejs needs. Only affects
     the GN build; with the GYP build, nodejs is still built with OpenSSL.
 -
-  owners: deepak1556
+  author: deepak1556 <hop2deep@gmail.com>
   file: pepper_flash.patch
   description: |
     Allows building chrome pepper flash integration for Electron.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: no_cache_storage_check.patch
   description: |
     Do not check for unique origin in CacheStorage, in Electron we may have
     scripts running without an origin.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: blink_fix_prototype_assert.patch
   description: |
     A recent Chromium change has accidentally added assertion for the case when
@@ -317,42 +317,42 @@ patches:
     In the long term we should investigate why it happened, and take a more
     formal fix. But for now I'm just make this assertion silently pass away.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: disable_scroll_begin_dcheck.patch
   description: |
     When testing https://github.com/electron/electron/issues/13137 I have met
     these assertions. I grouped them together since they are all related to the
     ScrollBegin event.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: libgtkui_export.patch
   description: |
     Export libgtkui symbols for the GN component build.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: gtk_visibility.patch
   description: |
     Allow electron and brightray to depend on GTK in the GN build.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: sysroot.patch
   description: |
     Make chrome's install-sysroot scripts point to our custom sysroot builds,
     which include extra deps that Electron needs (e.g. libnotify)
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: mas_blink_no_private_api.patch
   description: |
     Guard usages in chromium code of private Mac APIs by MAS_BUILD, so they can
     be excluded for people who want to submit their apps to the Mac App store.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: mas_no_private_api.patch
   description: |
     Guard usages in blink of private Mac APIs by MAS_BUILD, so they can be
     excluded for people who want to submit their apps to the Mac App store.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: resource_file_conflict.patch
   description: |
     Resolve conflict between //chrome's .pak files and //electron's. The paths
@@ -360,45 +360,45 @@ patches:
     paths, but GN throws errors if there are multiple targets that generate the
     same files.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: scroll_bounce_flag.patch
   description: |
     Patch to make scrollBounce option work.
 -
-  owners: poiru
+  author: Birunthan Mohanathas <birunthan@mohanathas.com>
   file: backport_d65792a.patch
   description: |
     https://chromium-review.googlesource.com/c/chromium/src/+/1105698
     Fixes https://github.com/electron/electron/issues/13256
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: webview_reattach.patch
   description: |
     Backports https://chromium-review.googlesource.com/c/chromium/src/+/1161391
     Fixes webview not working after renderer process restarted.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: mas-cfisobjc.patch
   description: |
     Removes usage of the _CFIsObjC private API.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: mas-cgdisplayusesforcetogray.patch
   description: |
     Removes usage of the CGDisplayUsesForceToGray private API.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: mas-audiodeviceduck.patch
   description: |
     Removes usage of the AudioDeviceDuck private API.
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
   description: |
     Removes usage of the _LSSetApplicationLaunchServicesServerConnectionStatus
     private API.
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: allow_webview_file_url.patch
   description: |
     Allow webview to load non-web URLs.

--- a/patches/common/crashpad/.patches.yaml
+++ b/patches/common/crashpad/.patches.yaml
@@ -1,4 +1,4 @@
-repo: src/third_party/crashpad/crashpad
+repo: src
 patches:
 -
   owners: nornagon

--- a/patches/common/crashpad/.patches.yaml
+++ b/patches/common/crashpad/.patches.yaml
@@ -1,7 +1,7 @@
 repo: src
 patches:
 -
-  owners: nornagon
+  author: Jeremy Apthorp <nornagon@nornagon.net>
   file: http_status.patch
   description: |
     Accept all HTTP codes in [200, 300) as successful, instead of just 200.

--- a/patches/common/crashpad/http_status.patch
+++ b/patches/common/crashpad/http_status.patch
@@ -8,15 +8,15 @@ Subject: [PATCH] Handle everything not in [200, 300) as error. For example
 (cherry picked from commit 1875fddc7e671b14d8b54068301d9648d12e9dc2)
 (cherry picked from commit 670fb453b0c3d6ae0a0d5923f68df02464337617)
 ---
- util/net/http_transport_libcurl.cc | 2 +-
- util/net/http_transport_mac.mm     | 2 +-
- util/net/http_transport_win.cc     | 2 +-
+ third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc | 2 +-
+ third_party/crashpad/crashpad/util/net/http_transport_mac.mm     | 2 +-
+ third_party/crashpad/crashpad/util/net/http_transport_win.cc     | 2 +-
  3 files changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/util/net/http_transport_libcurl.cc b/util/net/http_transport_libcurl.cc
+diff --git a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
 index c16a593..0e262b0 100644
---- a/util/net/http_transport_libcurl.cc
-+++ b/util/net/http_transport_libcurl.cc
+--- a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
++++ b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
 @@ -338,7 +338,7 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
      return false;
    }
@@ -26,10 +26,10 @@ index c16a593..0e262b0 100644
      LOG(ERROR) << base::StringPrintf("HTTP status %ld", status);
      return false;
    }
-diff --git a/util/net/http_transport_mac.mm b/util/net/http_transport_mac.mm
+diff --git a/third_party/crashpad/crashpad/util/net/http_transport_mac.mm b/third_party/crashpad/crashpad/util/net/http_transport_mac.mm
 index 8d5f78c..a6434c2 100644
---- a/util/net/http_transport_mac.mm
-+++ b/util/net/http_transport_mac.mm
+--- a/third_party/crashpad/crashpad/util/net/http_transport_mac.mm
++++ b/third_party/crashpad/crashpad/util/net/http_transport_mac.mm
 @@ -293,7 +293,7 @@ static void Unschedule(CFReadStreamRef stream,
        return false;
      }
@@ -39,10 +39,10 @@ index 8d5f78c..a6434c2 100644
        LOG(ERROR) << base::StringPrintf("HTTP status %ld",
                                         implicit_cast<long>(http_status));
        return false;
-diff --git a/util/net/http_transport_win.cc b/util/net/http_transport_win.cc
+diff --git a/third_party/crashpad/crashpad/util/net/http_transport_win.cc b/third_party/crashpad/crashpad/util/net/http_transport_win.cc
 index 18d343c..40c3061 100644
---- a/util/net/http_transport_win.cc
-+++ b/util/net/http_transport_win.cc
+--- a/third_party/crashpad/crashpad/util/net/http_transport_win.cc
++++ b/third_party/crashpad/crashpad/util/net/http_transport_win.cc
 @@ -375,7 +375,7 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
      return false;
    }

--- a/patches/common/ffmpeg/.patches.yaml
+++ b/patches/common/ffmpeg/.patches.yaml
@@ -1,14 +1,14 @@
 repo: src/third_party/ffmpeg
 patches:
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: build_gn.patch
   description: |
     Chromium's Mac toolchain sets the "install_name" linker parameter only
     when "is_component_build" is true, but we want to set even if it's false,
     because we are making a dylib which will be distributed inside a bundle.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: fix_build_on_linux_x86.patch
   description: |
     Builds on Linux x86 fail with a clang error. See https://crbug.com/796379.

--- a/patches/common/icu/.patches.yaml
+++ b/patches/common/icu/.patches.yaml
@@ -1,10 +1,10 @@
 repo: src/third_party/icu
 patches:
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: build_gn.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: no_inline_default_constructor.patch
   description: null

--- a/patches/common/skia/.patches.yaml
+++ b/patches/common/skia/.patches.yaml
@@ -1,6 +1,6 @@
 repo: src/third_party/skia
 patches:
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: dcheck.patch
   description: null

--- a/patches/common/v8/.patches.yaml
+++ b/patches/common/v8/.patches.yaml
@@ -1,62 +1,62 @@
 repo: src/v8
 patches:
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: build_gn.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: array_buffer.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: ostreams.patch
   description: null
 -
-  owners: alexeykuzmin,alespergl
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: export_platform.patch
   description: |
     v8::Platform::SystemClockTimeMillis must be exported so that node::NodePlatform can call it
 -
-  owners: alespergl
+  author: Ales Pergl <alpergl@microsoft.com>
   file: dcheck.patch
   description: null
 -
-  owners: nitsakh
+  author: Nitish Sakhawalkar <nitsakh@icloud.com>
   file: disable-warning-win.patch
   description:
     Disable unit test windows build warning
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_b767cde1e7.patch
   description: Node 10.0.0 needs it.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_39d546a.patch
   description: Node 10.0.0 needs it.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_ff0a97933.patch
   description: Node 10.2.0 needs it.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_9fb02b526.patch
   description: Node 10.2.0 needs it.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_23652c5f.patch
   description: Node 10.2.0 needs it.
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_b49206d.patch
   description: Node 10.2.0 needs it.
 -
-  owners: nitsakh
+  author: Nitish Sakhawalkar <nitsakh@icloud.com>
   file: backport_50206308.patch
   description: |
     Part (1/2) of backporting the array splice perf regression caused in ch66
 -
-  owners: nitsakh
+  author: Nitish Sakhawalkar <nitsakh@icloud.com>
   file: backport_2eb23a17.patch
   description: |
     Part (2/2) of backporting the array splice perf regression caused in ch66

--- a/patches/common/webrtc/.patches.yaml
+++ b/patches/common/webrtc/.patches.yaml
@@ -1,20 +1,20 @@
 repo: src/third_party/webrtc
 patches:
 -
-  owners: null
+  author: null
   file: webrtc-desktop_capturer_mac.patch
   description: null
 -
-  owners: null
+  author: null
   file: webrtc-rwlock_null.patch
   description: null
 -
-  owners: nitsakh
+  author: Nitish Sakhawalkar <nitsakh@icloud.com>
   file: disable-warning-win.patch
   description:
     Disable windows warning
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: allow_chromiumcontent_to_depend_on_webrtc_common.patch
   description: |
     ERROR at //chromiumcontent/BUILD.gn:152:3: Dependency not allowed.
@@ -27,7 +27,7 @@ patches:
       //third_party/webrtc_overrides/*
     ]
 -
-  owners: alexeykuzmin
+  author: Aleksei Kuzmin <alkuzmin@microsoft.com>
   file: backport_a157e0809.patch
   description:
     VP9 temporal index bounds check. Landed in 67.0.3396.62.

--- a/patches/mips64el/chromium/.patches.yaml
+++ b/patches/mips64el/chromium/.patches.yaml
@@ -1,38 +1,38 @@
 repo: src
 patches:
 -
-  owners: null
+  author: null
   file: Add-support-for-using-seccomp_bpf-on-mips64el.patch
   description: null
 -
-  owners: null
+  author: null
   file: Set-kernal-page-size-to-16K-on-loongson-MIPS-archtec.patch
   description: null
 -
-  owners: null
+  author: null
   file: Add-mips64el-redhat-linux-to-gcc_toolchain-for-mips6.patch
   description: null
 -
-  owners: null
+  author: null
   file: Fix-mips-cross-toolchain-build-src-crypto-ec-p256-64.patch
   description: null
 -
-  owners: null
+  author: null
   file: Fix-error-about-relocation-truncated-to-fit-R_MIPS_C.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: backport-sqlite-8a87f7e.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: backport-sqlite-9851f2e.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: backport-sqlite-3d8ec48.patch
   description: null
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: support-old-nss.patch
   description: null

--- a/patches/mips64el/ffmpeg/.patches.yaml
+++ b/patches/mips64el/ffmpeg/.patches.yaml
@@ -1,6 +1,6 @@
 repo: src/third_party/ffmpeg
 patches:
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: Fix-build_ffmpeg-with-cross-prefix-mips64el-redhat-l.patch
   description: null

--- a/patches/mips64el/v8/.patches.yaml
+++ b/patches/mips64el/v8/.patches.yaml
@@ -1,6 +1,6 @@
 repo: src/v8
 patches:
 -
-  owners: zcbenz
+  author: Cheng Zhao <zcbenz@gmail.com>
   file: Fix-v8-loongson-page-size.patch
   description: null

--- a/script/apply-patches
+++ b/script/apply-patches
@@ -20,7 +20,7 @@ def main():
   args = parse_args()
 
   for folder in args.folders:
-    error = apply_patches_for_dir(folder)
+    error = apply_patches_for_dir(folder, args.commit)
     if error:
       sys.stderr.write(error + '\n')
       sys.stderr.flush()
@@ -29,14 +29,14 @@ def main():
   return 0
 
 
-def apply_patches_for_dir(directory):
+def apply_patches_for_dir(directory, commit):
   for root, dirs, files in os.walk(directory):
     config = PatchesConfig.from_directory(root)
     patches_list = config.get_patches_list()
     if patches_list is None:
       continue
 
-    (success, failed_patches) = patches_list.apply()
+    (success, failed_patches) = patches_list.apply(commit=commit)
     if not success:
       patch_path = failed_patches[0].get_file_path()
       return '{0} failed to apply'.format(os.path.basename(patch_path))
@@ -45,6 +45,8 @@ def apply_patches_for_dir(directory):
 def parse_args():
   parser = argparse.ArgumentParser(description='Apply all required patches.')
 
+  parser.add_argument('--commit', default=False, action='store_true',
+                      help='Commit a patch after it has been applied')
   parser.add_argument('-t', '--target_arch',
                       help='Target architecture')
 

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -4,26 +4,60 @@ Everything in here should be project agnostic, shouldn't rely on project's struc
 and make any assumptions about the passed arguments or calls outcomes.
 """
 
+import os
 import subprocess
 
 from util import scoped_cwd
 
 
-def apply(repo, patch_path, reverse=False):
+def is_repo_root(path):
+  path_exists = os.path.exists(path)
+  if not path_exists:
+    return False
+
+  git_folder_path = os.path.join(path, '.git')
+  git_folder_exists = os.path.exists(git_folder_path)
+
+  return git_folder_exists
+
+
+def get_repo_root(path):
+  """Finds a closest ancestor folder which is a repo root."""
+  norm_path = os.path.normpath(path)
+  norm_path_exists = os.path.exists(norm_path)
+  if not norm_path_exists:
+    return None
+
+  if is_repo_root(norm_path):
+    return norm_path
+
+  parent_path = os.path.dirname(norm_path)
+
+  # Check if we're in the root folder already.
+  if parent_path == norm_path:
+    return None
+
+  return get_repo_root(parent_path)
+
+
+def apply(repo, patch_path, directory=None, index=False, reverse=False):
   args = ['git', 'apply',
-          '--directory', repo,
           '--ignore-space-change',
           '--ignore-whitespace',
           '--whitespace', 'fix'
           ]
+  if directory:
+    args += ['--directory', directory]
+  if index:
+    args += ['--index']
   if reverse:
     args += ['--reverse']
   args += ['--', patch_path]
 
-  return_code = subprocess.call(args)
-  applied_successfully = (return_code == 0)
-
-  return applied_successfully
+  with scoped_cwd(repo):
+    return_code = subprocess.call(args)
+    applied_successfully = (return_code == 0)
+    return applied_successfully
 
 
 def get_patch(repo, commit_hash):
@@ -42,3 +76,23 @@ def get_head_commit(repo):
 
   with scoped_cwd(repo):
     return subprocess.check_output(args).strip()
+
+
+def commit(repo, author, message):
+  """ Commit whatever in the index is now."""
+
+  # Let's setup committer info so git won't complain about it being missing.
+  # TODO: Is there a better way to set committer's name and email?
+  env = os.environ.copy()
+  env['GIT_COMMITTER_NAME'] = 'Anonymous Committer'
+  env['GIT_COMMITTER_EMAIL'] = 'anonymous@electronjs.org'
+
+  args = ['git', 'commit',
+          '--author', author,
+          '--message', message
+          ]
+
+  with scoped_cwd(repo):
+    return_code = subprocess.call(args, env=env)
+    committed_successfully = (return_code == 0)
+    return committed_successfully

--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -1,22 +1,46 @@
 import os
 import sys
 
+import git
 from config import VENDOR_DIR
 
 PYYAML_LIB_DIR = os.path.join(VENDOR_DIR, 'pyyaml', 'lib')
 sys.path.append(PYYAML_LIB_DIR)
 import yaml
 
-from git import apply as git_apply
-
 
 class Patch:
-  def __init__(self, file_path, repo_path):
+  def __init__(self, file_path, repo_path, paths_prefix=None, author='Anonymous <anonymous@electronjs.org>', description=None):
+    self.author = author
+    self.description = description
     self.file_path = file_path
+    self.paths_prefix = paths_prefix
     self.repo_path = repo_path
 
-  def apply(self, reverse=False):
-    return git_apply(self.repo_path, self.file_path, reverse=reverse)
+  def apply(self, reverse=False, commit=False):
+    # Add the change to index only if we're going to commit it later.
+    patch_applied = git.apply(self.repo_path, self.file_path, directory=self.paths_prefix, index=commit, reverse=reverse)
+
+    if not patch_applied:
+      return False
+
+    if commit:
+      message = self.__get_commit_message(reverse)
+      patch_committed = git.commit(self.repo_path, author=self.author, message=message)
+      return patch_committed
+
+    return True
+
+  def __get_commit_message(self, reverse):
+    message = self.description
+
+    if message is None:
+      message = os.path.basename(self.file_path)
+
+    if reverse:
+      message = 'Revert: ' + message
+
+    return message
 
   def reverse(self):
     return self.apply(reverse=True)
@@ -32,12 +56,12 @@ class PatchesList:
   def __len__(self):
     return len(self.patches)
 
-  def apply(self, reverse=False, stop_on_error=True):
+  def apply(self, reverse=False, stop_on_error=True, commit=False):
     all_patches_applied = True
     failed_patches = []
 
     for patch in self.patches:
-      applied_successfully = patch.apply(reverse=reverse)
+      applied_successfully = patch.apply(reverse=reverse, commit=commit)
 
       if not applied_successfully:
         all_patches_applied = False
@@ -74,25 +98,44 @@ class PatchesConfig:
 
     return contents
 
-  def __create_patch(self, raw_data, base_directory, repo_path):
+  def __create_patch(self, raw_data, base_directory, repo_path, paths_prefix):
+    author = raw_data['author']
+    if author is None:  # Shouldn't actually happen.
+      author = 'Anonymous <anonymous@electronjs.org>'
+
     relative_file_path = raw_data['file']
     absolute_file_path = os.path.join(base_directory, relative_file_path)
 
-    return Patch(absolute_file_path, repo_path)
+    # Use a patch file path as a commit summary
+    # and optional description as a commit body.
+    description = relative_file_path
+    if raw_data['description'] is not None:
+      description += '\n\n' + raw_data['description']
+
+    return Patch(absolute_file_path, repo_path, paths_prefix=paths_prefix, author=author, description=description)
 
   def get_patches_list(self):
     config_contents = self.__parse()
     if config_contents is None:
       return None
 
-    repo_path = config_contents['repo']
-    if sys.platform == 'win32':
-      repo_path = repo_path.replace('/', '\\')
+    project_root = git.get_repo_root(self.path)
+    assert(project_root)
+
+    relative_repo_path = os.path.normpath(config_contents['repo'])
+    absolute_repo_path = os.path.join(project_root, relative_repo_path)
+
+    # If the 'repo' path is not really a git repository,
+    # then use that path as a prefix for patched files.
+    paths_prefix = None
+    if not git.is_repo_root(absolute_repo_path):
+      absolute_repo_path = project_root
+      paths_prefix = relative_repo_path
 
     patches_data = config_contents['patches']
     base_directory = os.path.dirname(self.path)
 
-    patches = [self.__create_patch(data, base_directory, repo_path) for data in patches_data]
+    patches = [self.__create_patch(data, base_directory, absolute_repo_path, paths_prefix) for data in patches_data]
     patches_list = PatchesList(patches)
 
     return patches_list

--- a/script/patch.py
+++ b/script/patch.py
@@ -38,7 +38,7 @@ def main():
 
 
 def apply_patches(repo_path, patches_paths, force=False, reverse=False):
-  patches = [Patch(patch_path, repo_path) for patch_path in patches_paths]
+  patches = [Patch(os.path.abspath(patch_path), os.path.abspath(repo_path)) for patch_path in patches_paths]
   patches_list = PatchesList(patches)
   stop_on_error = not force
   return patches_list.apply(reverse=reverse, stop_on_error=stop_on_error)


### PR DESCRIPTION
Adds an optional `--commit` arg to the `apply-patches` script.
Shouldn't affect regular builds in any way, but will allow the GN build to commit libcc patches after they have been applied to prevent issues with untracked files in the Chromium tree.

Step 2 of this change will be converting all `.patch` files to a format that [`git-format-patch`](https://git-scm.com/docs/git-format-patch) understands, this way we will get rid of authors and descriptions in the `.patches.yaml` files and will be able to commit those patches easier.
It will be done in a separate PR.

/cc @nornagon 