### PR TITLE
fix: add patch to re-enable osr MouseWheelPhaseHandler

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -408,7 +408,7 @@ patches:
   description: |
     Allow use of cc_wrapper (eg sccache).
 _ 
-  owners: codebytere
+  author: Shelley Vohr <shelley.vohr@gmail.com>
   file: enable_osr_components.patch
   description: |
     Add MouseWheelPhaseHandler for OSR.

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -407,7 +407,7 @@ patches:
   file: windows_cc_wrapper.patch
   description: |
     Allow use of cc_wrapper (eg sccache).
-_ 
+-
   author: Shelley Vohr <shelley.vohr@gmail.com>
   file: enable_osr_components.patch
   description: |

--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -407,3 +407,8 @@ patches:
   file: windows_cc_wrapper.patch
   description: |
     Allow use of cc_wrapper (eg sccache).
+_ 
+  owners: codebytere
+  file: enable_osr_components.patch
+  description: |
+    Add MouseWheelPhaseHandler for OSR.

--- a/patches/common/chromium/enable_osr_components.patch
+++ b/patches/common/chromium/enable_osr_components.patch
@@ -1,0 +1,22 @@
+diff --git content/browser/renderer_host/input/mouse_wheel_phase_handler.h content/browser/renderer_host/input/mouse_wheel_phase_handler.h
+index 305095fc420e..f5ca4eda4a66 100644
+--- a/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
++++ b/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
+@@ -7,6 +7,7 @@
+ 
+ #include "base/timer/timer.h"
+ #include "content/browser/renderer_host/render_widget_host_delegate.h"
++#include "content/common/content_export.h"
+ #include "content/public/common/input_event_ack_state.h"
+ #include "third_party/blink/public/platform/web_mouse_wheel_event.h"
+ 
+@@ -55,7 +56,7 @@ enum class FirstScrollUpdateAckState {
+ // The MouseWheelPhaseHandler is responsible for adding the proper phase to
+ // wheel events. Phase information is necessary for wheel scrolling since it
+ // shows the start and end of a scrolling sequence.
+-class MouseWheelPhaseHandler {
++class CONTENT_EXPORT MouseWheelPhaseHandler {
+  public:
+   MouseWheelPhaseHandler(RenderWidgetHostViewBase* const host_view);
+   ~MouseWheelPhaseHandler() {}
+ 

--- a/patches/common/chromium/enable_osr_components.patch
+++ b/patches/common/chromium/enable_osr_components.patch
@@ -1,5 +1,5 @@
-diff --git content/browser/renderer_host/input/mouse_wheel_phase_handler.h content/browser/renderer_host/input/mouse_wheel_phase_handler.h
-index 305095fc420e..f5ca4eda4a66 100644
+diff --git a/content/browser/renderer_host/input/mouse_wheel_phase_handler.h b/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
+index 2d3771ab800b..16113fe46174 100644
 --- a/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
 +++ b/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
 @@ -7,6 +7,7 @@
@@ -8,15 +8,14 @@ index 305095fc420e..f5ca4eda4a66 100644
  #include "content/browser/renderer_host/render_widget_host_delegate.h"
 +#include "content/common/content_export.h"
  #include "content/public/common/input_event_ack_state.h"
- #include "third_party/blink/public/platform/web_mouse_wheel_event.h"
+ #include "third_party/WebKit/public/platform/WebMouseWheelEvent.h"
  
-@@ -55,7 +56,7 @@ enum class FirstScrollUpdateAckState {
- // The MouseWheelPhaseHandler is responsible for adding the proper phase to
- // wheel events. Phase information is necessary for wheel scrolling since it
- // shows the start and end of a scrolling sequence.
+@@ -50,7 +51,7 @@ enum class FirstScrollUpdateAckState {
+   kNotConsumed,
+ };
+ 
 -class MouseWheelPhaseHandler {
 +class CONTENT_EXPORT MouseWheelPhaseHandler {
   public:
-   MouseWheelPhaseHandler(RenderWidgetHostViewBase* const host_view);
-   ~MouseWheelPhaseHandler() {}
- 
+   MouseWheelPhaseHandler(RenderWidgetHostImpl* const host,
+                          RenderWidgetHostViewBase* const host_view);


### PR DESCRIPTION
Backport [this commit](https://bitbucket.org/chromiumembedded/cef/commits/fad6aec5d0f02853ff6b8af403c5b75d4764e3cb) from CEF in order to add `MouseWheelPhaseHandler` in osr. 

Related: https://github.com/electron/electron/pull/14074

/cc @brenca @alexeykuzmin @deepak1556 