### PR TITLE
chore: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+##### Description of Change
+<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] PR description included and stakeholders cc'd
+- [ ] Patch information is added to appropriate `.patches.yaml`
+- [ ] `script/update` runs without error
+- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


### PR DESCRIPTION
This PR adds a PR template similar to that of `electron/electron`.

/cc @alexeykuzmin

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)