### PR TITLE
build: Add optional --project-root arg for the patching related scripts

### DIFF
--- a/script/apply-patches
+++ b/script/apply-patches
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 
+import lib.git as git
 from lib.patches import PatchesConfig
 
 
@@ -19,8 +20,10 @@ SRC_DIR = os.path.join(SOURCE_ROOT, SRC)
 def main():
   args = parse_args()
 
+  project_root = os.path.abspath(args.project_root)
+
   for folder in args.folders:
-    error = apply_patches_for_dir(folder, args.commit)
+    error = apply_patches_for_dir(folder, project_root, args.commit)
     if error:
       sys.stderr.write(error + '\n')
       sys.stderr.flush()
@@ -29,9 +32,9 @@ def main():
   return 0
 
 
-def apply_patches_for_dir(directory, commit):
+def apply_patches_for_dir(directory, project_root, commit):
   for root, dirs, files in os.walk(directory):
-    config = PatchesConfig.from_directory(root)
+    config = PatchesConfig.from_directory(root, project_root=project_root)
     patches_list = config.get_patches_list()
     if patches_list is None:
       continue
@@ -47,6 +50,8 @@ def parse_args():
 
   parser.add_argument('--commit', default=False, action='store_true',
                       help='Commit a patch after it has been applied')
+  parser.add_argument('--project-root', required=False, default=git.get_repo_root(os.path.abspath(__file__)),
+                      help='Parent folder to resolve repos relative paths against')
   parser.add_argument('-t', '--target_arch',
                       help='Target architecture')
 

--- a/script/patch.py
+++ b/script/patch.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 
+import lib.git as git
 from lib.patches import Patch, PatchesList, PatchesConfig
 
 
@@ -20,11 +21,12 @@ def main():
   directory = args.directory
   force = args.force
   patches = args.patch
+  project_root = args.project_root
   repo = args.repo
   reverse = args.reverse
 
   if directory:
-    (success, failed_patches) = apply_patches_from_directory(directory, force, reverse)
+    (success, failed_patches) = apply_patches_from_directory(directory, project_root, force, reverse)
   else:
     (success, failed_patches) = apply_patches(repo, patches, force, reverse)
 
@@ -44,8 +46,8 @@ def apply_patches(repo_path, patches_paths, force=False, reverse=False):
   return patches_list.apply(reverse=reverse, stop_on_error=stop_on_error)
 
 
-def apply_patches_from_directory(directory, force=False, reverse=False):
-  config = PatchesConfig.from_directory(directory)
+def apply_patches_from_directory(directory, project_root, force=False, reverse=False):
+  config = PatchesConfig.from_directory(directory, project_root=project_root)
   patches_list = config.get_patches_list()
 
   # Notify user if we didn't find any patch files.
@@ -62,6 +64,8 @@ def parse_args():
   parser = argparse.ArgumentParser(description='Apply patches to a git repo')
   parser.add_argument('-f', '--force', default=False, action='store_true',
                       help='Do not stop on the first failed patch.')
+  parser.add_argument('--project-root', required=False, default=git.get_repo_root(os.path.abspath(__file__)),
+                      help='Parent folder to resolve repos relative paths against')
   parser.add_argument('-R', '--reverse', default=False, action='store_true', help='Apply patches in reverse.')
   parser.add_argument('-r', '--repo', help='Path to a repository root folder.')
 


### PR DESCRIPTION
It is necessary because we have different folders hierarchy
in traditional build setup with libchromiumcontent being a separate repo
and in gn-based build with libchromiumcontent repo checked out inside the src/.

Usage:
`./script/apply-patches --project-root=SRC_PARENT_FOLDER`

##### Description of Change
<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)