### PR TITLE
fix: add patch to re-enable osr MouseWheelPhaseHandler (backport 3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -344,3 +344,8 @@ patches:
   file: allow_webview_file_url.patch
   description: |
     Allow webview to load non-web URLs.
+-
+  owners: codebytere
+  file: enable_osr_components.patch
+  description: |
+    Add MouseWheelPhaseHandler for OSR.

--- a/patches/common/chromium/enable_osr_components.patch
+++ b/patches/common/chromium/enable_osr_components.patch
@@ -1,0 +1,21 @@
+diff --git a/content/browser/renderer_host/input/mouse_wheel_phase_handler.h b/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
+index 2d3771ab800b..16113fe46174 100644
+--- a/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
++++ b/content/browser/renderer_host/input/mouse_wheel_phase_handler.h
+@@ -7,6 +7,7 @@
+ 
+ #include "base/timer/timer.h"
+ #include "content/browser/renderer_host/render_widget_host_delegate.h"
++#include "content/common/content_export.h"
+ #include "content/public/common/input_event_ack_state.h"
+ #include "third_party/WebKit/public/platform/WebMouseWheelEvent.h"
+ 
+@@ -50,7 +51,7 @@ enum class FirstScrollUpdateAckState {
+   kNotConsumed,
+ };
+ 
+-class MouseWheelPhaseHandler {
++class CONTENT_EXPORT MouseWheelPhaseHandler {
+  public:
+   MouseWheelPhaseHandler(RenderWidgetHostImpl* const host,
+                          RenderWidgetHostViewBase* const host_view);


### PR DESCRIPTION
##### Description of Change

Backport of https://github.com/electron/libchromiumcontent/pull/649.

/cc @brenca @deepak1556 @alexeykuzmin 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)