### PR TITLE
perf: commit our patches in batches instead of 1 by 1

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -78,21 +78,53 @@ def get_head_commit(repo):
     return subprocess.check_output(args).strip()
 
 
-def commit(repo, author, message):
+commits = {}
+
+def prepare_commit(repo, author, message):
+  global commits
   """ Commit whatever in the index is now."""
 
+  if repo not in commits:
+    commits[repo] = []
+    
+  commits[repo].append((author, message))
+
+  return True
+
+def finalize_commits():
+  global commits
+  print('\n\nfinalizing commits')
   # Let's setup committer info so git won't complain about it being missing.
   # TODO: Is there a better way to set committer's name and email?
   env = os.environ.copy()
   env['GIT_COMMITTER_NAME'] = 'Anonymous Committer'
   env['GIT_COMMITTER_EMAIL'] = 'anonymous@electronjs.org'
 
-  args = ['git', 'commit',
-          '--author', author,
-          '--message', message
-          ]
+  committed_successfully = True
 
-  with scoped_cwd(repo):
-    return_code = subprocess.call(args, env=env)
-    committed_successfully = (return_code == 0)
-    return committed_successfully
+  for repo in commits:
+    details = commits[repo]
+    # Skip the commit when nothing to commit
+    if len(details) == 0:
+      continue
+
+    # Reset the list of commits for next time
+    commits[repo] = []
+    generated_message = 'Applied ' + str(len(details)) + ' Electron Patches\n\n'
+
+    for item in details:
+      generated_message += 'Author: ' + item[0] + '\n' + 'Message: ' + item[1] + '\n\n'
+
+    args = ['git', 'commit',
+            '--author', 'Electron Build Process <build@electronjs.org>',
+            '--message', generated_message,
+            '-n'
+            ]
+
+    with scoped_cwd(repo):
+      return_code = subprocess.call(args, env=env)
+      if not (return_code == 0):
+        print('failed to commit', repo)
+      committed_successfully = (return_code == 0) and committed_successfully
+
+  return committed_successfully

--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -26,7 +26,7 @@ class Patch:
 
     if commit:
       message = self.__get_commit_message(reverse)
-      patch_committed = git.commit(self.repo_path, author=self.author, message=message)
+      patch_committed = git.prepare_commit(self.repo_path, author=self.author, message=message)
       return patch_committed
 
     return True
@@ -72,6 +72,8 @@ class PatchesList:
       should_stop_now = not applied_successfully and stop_on_error
       if should_stop_now:
         break
+
+    all_patches_applied = git.finalize_commits() and all_patches_applied
 
     return (all_patches_applied, failed_patches)
 


### PR DESCRIPTION
This updates @alexeykuzmin's commit logic to commit our patches in batches so that we don't run commit a lot of times on a massive repo.  This drops the re-sync time from 10 minutes to 2 minutes on my local machine, disabling commits drops it to 1min 52 seconds so this is wayyy better now 👍 