### PR TITLE
fix: allow content_browser service to access GeolocationControl interface

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -418,3 +418,9 @@ patches:
   description: |
     Dont compare RC.exe and RC.py output.
     FIXME: It has to be reverted once the script is fixed.
+-
+  author: deepak1556 <hop2deep@gmail.com>
+  file: content_browser_manifest.patch
+  description: |
+    Allow content_browser service to access GeolocationControl
+    interface from device service.

--- a/patches/common/chromium/content_browser_manifest.patch
+++ b/patches/common/chromium/content_browser_manifest.patch
@@ -1,0 +1,12 @@
+diff --git a/content/public/app/mojo/content_browser_manifest.json b/content/public/app/mojo/content_browser_manifest.json
+index 5a217fa9b741..8fd1b39ea6ca 100644
+--- a/content/public/app/mojo/content_browser_manifest.json
++++ b/content/public/app/mojo/content_browser_manifest.json
+@@ -82,6 +82,7 @@
+           "device:battery_monitor",
+           "device:generic_sensor",
+           "device:geolocation",
++          "device:geolocation_control",
+           "device:hid",
+           "device:input_service",
+           "device:nfc",


### PR DESCRIPTION
##### Description of Change

Required for https://github.com/electron/electron/pull/14253

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)