### PR TITLE
build: disable a DCHECK in viz::ServerSharedBitmapManager

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -34,6 +34,7 @@ patches:
       base/memory/weak_ptr.cc
       base/process/kill_win.cc
       components/viz/service/display/program_binding.h
+      components/viz/service/display_embedder/server_shared_bitmap_manager.cc
       content/browser/frame_host/navigation_controller_impl.cc
       content/browser/frame_host/render_frame_host_impl.cc
       content/browser/renderer_host/render_widget_host_view_mac.mm

--- a/patches/common/chromium/dcheck.patch
+++ b/patches/common/chromium/dcheck.patch
@@ -255,3 +255,18 @@ index 61f0bf4ad06f..259783ad67a1 100644
      process_.Set(duplicate_handle);
    }
  }
+diff --git a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+index 9477a5aa45f9..895425c8c6cc 100644
+--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
++++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+@@ -69,7 +69,9 @@ base::LazyInstance<ServerSharedBitmapManager>::DestructorAtExit
+ ServerSharedBitmapManager::ServerSharedBitmapManager() = default;
+ 
+ ServerSharedBitmapManager::~ServerSharedBitmapManager() {
+-  DCHECK(handle_map_.empty());
++  // FIXME(alexeykuzmin): Gets constantly triggered on Windows CI.
++  // Backporting https://chromium-review.googlesource.com/802574 should help.
++  // DCHECK(handle_map_.empty());
+ }
+ 
+ ServerSharedBitmapManager* ServerSharedBitmapManager::current() {


### PR DESCRIPTION
It gets constantly triggered on Windows CI, e.g.
https://windows-ci.electronjs.org/project/AppVeyor/electron-i8wjp/build/1.0.91
We expect that backporting of https://chromium-review.googlesource.com/802574
should fix it.

##### Description of Change
<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)