### PR TITLE
fix: Re-enable GPU acceleration for recent VMWare drivers (backport: 3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -355,3 +355,9 @@ patches:
   description: |
     Allow content_browser service to access GeolocationControl
     interface from device service.
+-
+  author: deepak1556 <hop2deep@gmail.com>
+  file: vmware_gpu_acceleration.patch
+  description: |
+    Re-enable GPU acceleration for recent VMWare drivers.
+    Backports https://chromium-review.googlesource.com/952778

--- a/patches/common/chromium/vmware_gpu_acceleration.patch
+++ b/patches/common/chromium/vmware_gpu_acceleration.patch
@@ -1,0 +1,128 @@
+diff --git a/content/browser/gpu/compositor_util.cc b/content/browser/gpu/compositor_util.cc
+index 63705c8f0b4f..a5e7b7c354c5 100644
+--- a/content/browser/gpu/compositor_util.cc
++++ b/content/browser/gpu/compositor_util.cc
+@@ -21,6 +21,7 @@
+ #include "cc/base/switches.h"
+ #include "components/viz/common/features.h"
+ #include "content/browser/gpu/gpu_data_manager_impl.h"
++#include "content/browser/gpu/gpu_process_host.h"
+ #include "content/public/common/content_features.h"
+ #include "content/public/common/content_switches.h"
+ #include "gpu/command_buffer/common/gpu_memory_buffer_support.h"
+@@ -53,21 +54,32 @@ bool IsForceGpuRasterizationEnabled() {
+   return command_line->HasSwitch(switches::kForceGpuRasterization);
+ }
+ 
++gpu::GpuFeatureStatus SafeGetFeatureStatus(GpuDataManagerImpl* manager,
++                                           gpu::GpuFeatureType feature) {
++  if (!manager->IsGpuFeatureInfoAvailable()) {
++    // The GPU process probably crashed during startup, but we can't
++    // assert this as the test bots are slow, and recording the crash
++    // is racy. Be robust and just say that all features are disabled.
++    return gpu::kGpuFeatureStatusDisabled;
++  }
++  return manager->GetFeatureStatus(feature);
++}
++
+ const GpuFeatureData GetGpuFeatureData(size_t index, bool* eof) {
+   const base::CommandLine& command_line =
+       *base::CommandLine::ForCurrentProcess();
+   GpuDataManagerImpl* manager = GpuDataManagerImpl::GetInstance();
+-  DCHECK(manager->IsGpuFeatureInfoAvailable());
+ 
+   const GpuFeatureData kGpuFeatureData[] = {
+       {"2d_canvas",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_ACCELERATED_2D_CANVAS),
++       SafeGetFeatureStatus(manager,
++                            gpu::GPU_FEATURE_TYPE_ACCELERATED_2D_CANVAS),
+        command_line.HasSwitch(switches::kDisableAccelerated2dCanvas),
+        "Accelerated 2D canvas is unavailable: either disabled via blacklist or"
+        " the command line.",
+        true},
+       {"gpu_compositing",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_GPU_COMPOSITING),
++       SafeGetFeatureStatus(manager, gpu::GPU_FEATURE_TYPE_GPU_COMPOSITING),
+        command_line.HasSwitch(switches::kDisableGpuCompositing),
+        "Gpu compositing has been disabled, either via blacklist, about:flags"
+        " or the command line. The browser will fall back to software "
+@@ -75,36 +87,37 @@ const GpuFeatureData GetGpuFeatureData(size_t index, bool* eof) {
+        " and hardware acceleration will be unavailable.",
+        true},
+       {"webgl",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_ACCELERATED_WEBGL),
++       SafeGetFeatureStatus(manager, gpu::GPU_FEATURE_TYPE_ACCELERATED_WEBGL),
+        command_line.HasSwitch(switches::kDisableWebGL),
+        "WebGL has been disabled via blacklist or the command line.", false},
+-      {"flash_3d", manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_FLASH3D),
++      {"flash_3d", SafeGetFeatureStatus(manager, gpu::GPU_FEATURE_TYPE_FLASH3D),
+        command_line.HasSwitch(switches::kDisableFlash3d),
+        "Using 3d in flash has been disabled, either via blacklist, about:flags "
+        "or"
+        " the command line.",
+        true},
+       {"flash_stage3d",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_FLASH_STAGE3D),
++       SafeGetFeatureStatus(manager, gpu::GPU_FEATURE_TYPE_FLASH_STAGE3D),
+        command_line.HasSwitch(switches::kDisableFlashStage3d),
+        "Using Stage3d in Flash has been disabled, either via blacklist,"
+        " about:flags or the command line.",
+        true},
+       {"flash_stage3d_baseline",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_FLASH_STAGE3D_BASELINE),
++       SafeGetFeatureStatus(manager,
++                            gpu::GPU_FEATURE_TYPE_FLASH_STAGE3D_BASELINE),
+        command_line.HasSwitch(switches::kDisableFlashStage3d),
+        "Using Stage3d Baseline profile in Flash has been disabled, either"
+        " via blacklist, about:flags or the command line.",
+        true},
+       {"video_decode",
+-       manager->GetFeatureStatus(
+-           gpu::GPU_FEATURE_TYPE_ACCELERATED_VIDEO_DECODE),
++       SafeGetFeatureStatus(manager,
++                            gpu::GPU_FEATURE_TYPE_ACCELERATED_VIDEO_DECODE),
+        command_line.HasSwitch(switches::kDisableAcceleratedVideoDecode),
+        "Accelerated video decode has been disabled, either via blacklist,"
+        " about:flags or the command line.",
+        true},
+       {"rasterization",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_GPU_RASTERIZATION),
++       SafeGetFeatureStatus(manager, gpu::GPU_FEATURE_TYPE_GPU_RASTERIZATION),
+        (command_line.HasSwitch(switches::kDisableGpuRasterization) &&
+         !IsForceGpuRasterizationEnabled()),
+        "Accelerated rasterization has been disabled, either via blacklist,"
+@@ -124,7 +137,7 @@ const GpuFeatureData GetGpuFeatureData(size_t index, bool* eof) {
+        "line.",
+        false},
+       {"webgl2",
+-       manager->GetFeatureStatus(gpu::GPU_FEATURE_TYPE_ACCELERATED_WEBGL2),
++       SafeGetFeatureStatus(manager, gpu::GPU_FEATURE_TYPE_ACCELERATED_WEBGL2),
+        (command_line.HasSwitch(switches::kDisableWebGL) ||
+         command_line.HasSwitch(switches::kDisableWebGL2)),
+        "WebGL2 has been disabled via blacklist or the command line.", false},
+diff --git a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
+index b1679dcf4e20..39c633e2c7f1 100644
+--- a/gpu/config/software_rendering_list.json
++++ b/gpu/config/software_rendering_list.json
+@@ -475,8 +475,8 @@
+     },
+     {
+       "id": 68,
+-      "description": "VMware has corrupt rendering on Windows",
+-      "cr_bugs": [169470, 754435],
++      "description": "VMware Fusion 4 has corrupt rendering with Win Vista+",
++      "cr_bugs": [169470],
+       "os": {
+         "type": "win",
+         "version": {
+@@ -485,6 +485,10 @@
+         }
+       },
+       "vendor_id": "0x15ad",
++      "driver_version": {
++        "op": "<=",
++        "value": "7.14.1.1134"
++      },
+       "features": [
+         "all"
+       ]


### PR DESCRIPTION
##### Description of Change

Backports https://github.com/electron/libchromiumcontent/pull/665

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)