### PR TITLE
build: [gyp] explicitly override rtc_use_h264

### DIFF
--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -11,6 +11,13 @@ proprietary_codecs = true
 is_component_ffmpeg = true
 ffmpeg_branding = "Chrome"
 
+# This may be guarded behind is_chrome_branded alongside
+# proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
+# explicitly override here to build OpenH264 encoder/FFmpeg decoder.
+# The initialization of the decoder depends on whether ffmpeg has
+# been built with H.264 support.
+rtc_use_h264 = true
+
 # Use the system provided standard library on platforms other than Linux.
 if (target_os != "linux") {
   use_custom_libcxx = false

--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -10,6 +10,13 @@ proprietary_codecs = true
 is_component_ffmpeg = true
 ffmpeg_branding = "Chrome"
 
+# This may be guarded behind is_chrome_branded alongside
+# proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
+# explicitly override here to build OpenH264 encoder/FFmpeg decoder.
+# The initialization of the decoder depends on whether ffmpeg has
+# been built with H.264 support.
+rtc_use_h264 = true
+
 # CFI is disabled for the time being, as Electron is not a monolithic binary
 # with at least one shared library component (Node) and CFI is tricky in that
 # scenario


### PR DESCRIPTION
##### Description of Change

The flag got guarded behind `is_chrome_banded` in https://webrtc-review.googlesource.com/c/src/+/36321 , although it got reverted in https://webrtc-review.googlesource.com/c/src/+/62380 we cannot be sure that might not happen in future for the reasoning in that CL. So we explicitly override it, whenever we build with `proprietary_codecs`

Fixes https://github.com/electron/electron/issues/14256

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)