### PR TITLE
feat: implement ArrayBuffer realloc

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -1,6 +1,17 @@
 repo: src
 patches:
 -
+  author: Shelley Vohr <shelley.vohr@gmail.com>
+  file: add_realloc.patch
+  description: |
+    Blink overrides ArrayBuffer's allocator with its own one, while Node simply
+    uses malloc and free, so we need to use v8's allocator in Node. As part of the
+    10.6.0 upgrade, we needed to make SerializerDelegate accept an allocator
+    argument in its constructor, and override ReallocateBufferMemory and
+    FreeBufferMemory to use the allocator. We cannot simply allocate and then memcpy
+    when we override ReallocateBufferMemory, so we therefore need to implement
+    Realloc on the v8 side and correspondingly in gin.
+-
   author: Ales Pergl <alpergl@microsoft.com>
   file: build_gn.patch
   description: null

--- a/patches/common/chromium/add_realloc.patch
+++ b/patches/common/chromium/add_realloc.patch
@@ -1,0 +1,68 @@
+diff --git a/gin/array_buffer.cc b/gin/array_buffer.cc
+index f84934bfd712..63bce16a9d06 100644
+--- a/gin/array_buffer.cc
++++ b/gin/array_buffer.cc
+@@ -43,6 +43,10 @@ void* ArrayBufferAllocator::AllocateUninitialized(size_t length) {
+   return malloc(length);
+ }
+ +void* ArrayBufferAllocator::Realloc(void* data, size_t length) {
++  return realloc(data, length);
++}
++
+ void ArrayBufferAllocator::Free(void* data, size_t length) {
+   free(data);
+ }
+diff --git a/gin/array_buffer.h b/gin/array_buffer.h
+index 2aef366ac819..c037808a9bb3 100644
+--- a/gin/array_buffer.h
++++ b/gin/array_buffer.h
+@@ -21,6 +21,7 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+  public:
+   void* Allocate(size_t length) override;
+   void* AllocateUninitialized(size_t length) override;
++  void* Realloc(void* data, size_t length) override;
+   void Free(void* data, size_t length) override;
+    GIN_EXPORT static ArrayBufferAllocator* SharedInstance();
+diff --git a/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp b/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp
+index dab26bdea361..8f32802a1750 100644
+--- a/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp
++++ b/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp
+@@ -121,6 +121,11 @@ void* ArrayBufferContents::AllocateMemoryOrNull(size_t size,
+   return AllocateMemoryWithFlags(size, policy, base::PartitionAllocReturnNull);
+ }
+ 
++void* ArrayBufferContents::Realloc(void* data, size_t size) {
++  return Partitions::ArrayBufferPartition()->Realloc(data, size,
++      WTF_HEAP_PROFILER_TYPE_NAME(ArrayBufferContents));
++}
++
+ void ArrayBufferContents::FreeMemory(void* data) {
+   Partitions::ArrayBufferPartition()->Free(data);
+ }
+diff --git a/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.h b/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.h
+index de63006a4bd5..4bc6c848192a 100644
+--- a/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.h
++++ b/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.h
+@@ -178,6 +178,7 @@ class WTF_EXPORT ArrayBufferContents {
+   void CopyTo(ArrayBufferContents& other);
+ 
+   static void* AllocateMemoryOrNull(size_t, InitializationPolicy);
++  static void* Realloc(void* data, size_t);
+   static void FreeMemory(void*);
+   static DataHandle CreateDataHandle(size_t, InitializationPolicy);
+   static void Initialize(
+diff --git a/third_party/WebKit/Source/bindings/core/v8/V8Initializer.cpp b/third_party/WebKit/Source/bindings/core/v8/V8Initializer.cpp
+index ff61ebc2306b..a8361a56c7d1 100644
+--- a/third_party/WebKit/Source/bindings/core/v8/V8Initializer.cpp
++++ b/third_party/WebKit/Source/bindings/core/v8/V8Initializer.cpp
+@@ -557,6 +557,10 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+         size, WTF::ArrayBufferContents::kDontInitialize);
+   }
+ 
++  void* Realloc(void* data, size_t size) override {
++    return WTF::ArrayBufferContents::Realloc(data, size);
++  }
++
+   void Free(void* data, size_t size) override {
+     WTF::ArrayBufferContents::FreeMemory(data);
+   }

--- a/patches/common/chromium/add_realloc.patch
+++ b/patches/common/chromium/add_realloc.patch
@@ -5,7 +5,8 @@ index f84934bfd712..63bce16a9d06 100644
 @@ -43,6 +43,10 @@ void* ArrayBufferAllocator::AllocateUninitialized(size_t length) {
    return malloc(length);
  }
- +void* ArrayBufferAllocator::Realloc(void* data, size_t length) {
+
++void* ArrayBufferAllocator::Realloc(void* data, size_t length) {
 +  return realloc(data, length);
 +}
 +
@@ -22,7 +23,8 @@ index 2aef366ac819..c037808a9bb3 100644
    void* AllocateUninitialized(size_t length) override;
 +  void* Realloc(void* data, size_t length) override;
    void Free(void* data, size_t length) override;
-    GIN_EXPORT static ArrayBufferAllocator* SharedInstance();
+
+   GIN_EXPORT static ArrayBufferAllocator* SharedInstance();
 diff --git a/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp b/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp
 index dab26bdea361..8f32802a1750 100644
 --- a/third_party/WebKit/Source/platform/wtf/typed_arrays/ArrayBufferContents.cpp

--- a/patches/common/v8/.patches.yaml
+++ b/patches/common/v8/.patches.yaml
@@ -1,6 +1,17 @@
 repo: src/v8
 patches:
 -
+  author: Shelley Vohr <shelley.vohr@gmail.com>
+  file: add_realloc.patch
+  description: |
+    Blink overrides ArrayBuffer's allocator with its own one, while Node simply
+    uses malloc and free, so we need to use v8's allocator in Node. As part of the
+    10.6.0 upgrade, we needed to make SerializerDelegate accept an allocator
+    argument in its constructor, and override ReallocateBufferMemory and
+    FreeBufferMemory to use the allocator. We cannot simply allocate and then memcpy
+    when we override ReallocateBufferMemory, so we therefore need to implement
+    Realloc on the v8 side.
+-
   author: Ales Pergl <alpergl@microsoft.com>
   file: build_gn.patch
   description: null

--- a/patches/common/v8/add_realloc.patch
+++ b/patches/common/v8/add_realloc.patch
@@ -1,0 +1,32 @@
+diff --git a/include/v8.h b/include/v8.h
+index 277cbd442a..a99fdf9fbe 100644
+--- a/include/v8.h
++++ b/include/v8.h
+@@ -4266,6 +4266,13 @@ class V8_EXPORT ArrayBuffer : public Object {
+      */
+     virtual void* AllocateUninitialized(size_t length) = 0;
+ +    /**
++     * Free the memory block of size |length|, pointed to by |data|.
++     * That memory must be previously allocated by |Allocate| and not yet freed
++     * with a call to |Free| or |Realloc|
++     */
++    virtual void* Realloc(void* data, size_t length);
++
+     /**
+      * Reserved |length| bytes, but do not commit the memory. Must call
+      * |SetProtection| to make memory accessible.
+diff --git a/src/api.cc b/src/api.cc
+index 8531cd5c05..1157d4eec2 100644
+--- a/src/api.cc
++++ b/src/api.cc
+@@ -458,6 +458,10 @@ void V8::SetSnapshotDataBlob(StartupData* snapshot_blob) {
+ 
+ void* v8::ArrayBuffer::Allocator::Reserve(size_t length) { UNIMPLEMENTED(); }
+ 
++void* v8::ArrayBuffer::Allocator::Realloc(void* data, size_t length) {
++  UNIMPLEMENTED();
++}
++
+ void v8::ArrayBuffer::Allocator::Free(void* data, size_t length,
+                                       AllocationMode mode) {
+   UNIMPLEMENTED();

--- a/patches/common/v8/add_realloc.patch
+++ b/patches/common/v8/add_realloc.patch
@@ -5,7 +5,8 @@ index 277cbd442a..a99fdf9fbe 100644
 @@ -4266,6 +4266,13 @@ class V8_EXPORT ArrayBuffer : public Object {
       */
      virtual void* AllocateUninitialized(size_t length) = 0;
- +    /**
+
++    /**
 +     * Free the memory block of size |length|, pointed to by |data|.
 +     * That memory must be previously allocated by |Allocate| and not yet freed
 +     * with a call to |Free| or |Realloc|


### PR DESCRIPTION
##### Description of Change

This PR was previously opened and then closed, because we believed we could implement the needed changes on the `electron/node` side without needing to change libcc. However, as a result of [this change](https://github.com/electron/node/commit/efa2380edfbc95be0b5bf189303c58fc75c99c1c#diff-24260586604e0dc8a2dc3ad5812a93bbR197) we do in fact need to implement it. This is because the alternative, implementing with `memcpy`, requires knowledge of how many bytes are needed for the memcpy and we can't know that. 

/cc @ckerr 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)