### PR TITLE
fix: add patch for blink initialization order

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -448,3 +448,12 @@ patches:
   description: |
     Disable persiste licence support check for widevine cdm,
     as its not supported in the current version of chrome.
+-
+  author: Samuel Attard <samuel.r.attard@gmail.com>
+  file: blink_initialization_order.patch
+  description: |
+    Backport of https://chromium-review.googlesource.com/c/chromium/src/+/1030530
+    to fix the order of V8 and Blink initialization.  Also fixes order
+    of DidCreateScriptContext notification with initialization of window globals
+    to fix electron/electron#13787.  The backport landed in Chromium 67 but the
+    DidCreateScriptContext re-ordering needs to be upstreamed or kept indefinitely

--- a/patches/common/chromium/blink_initialization_order.patch
+++ b/patches/common/chromium/blink_initialization_order.patch
@@ -1,0 +1,37 @@
+diff --git a/third_party/WebKit/Source/bindings/core/v8/LocalWindowProxy.cpp b/third_party/WebKit/Source/bindings/core/v8/LocalWindowProxy.cpp
+index 33d958fb31ae..47efe62650aa 100644
+--- a/third_party/WebKit/Source/bindings/core/v8/LocalWindowProxy.cpp
++++ b/third_party/WebKit/Source/bindings/core/v8/LocalWindowProxy.cpp
+@@ -170,11 +170,11 @@ void LocalWindowProxy::Initialize() {
+                  GetFrame()->IsMainFrame());
+     MainThreadDebugger::Instance()->ContextCreated(script_state_.get(),
+                                                    GetFrame(), origin);
++
++    InstallConditionalFeatures();
+     GetFrame()->Client()->DidCreateScriptContext(context, world_->GetWorldId());
+   }
+ 
+-  InstallConditionalFeatures();
+-
+   if (World().IsMainWorld()) {
+     GetFrame()->Loader().DispatchDidClearWindowObjectInMainWorld();
+   }
+diff --git a/third_party/WebKit/Source/controller/BlinkInitializer.cpp b/third_party/WebKit/Source/controller/BlinkInitializer.cpp
+index bcb85bad6605..ef4da3e40a02 100644
+--- a/third_party/WebKit/Source/controller/BlinkInitializer.cpp
++++ b/third_party/WebKit/Source/controller/BlinkInitializer.cpp
+@@ -102,11 +102,12 @@ void Initialize(Platform* platform, service_manager::BinderRegistry* registry) {
+ #endif  // !defined(ARCH_CPU_X86_64) && !defined(ARCH_CPU_ARM64) &&
+         // defined(OS_WIN)
+ 
++  // BlinkInitializer::Initialize() must be called before InitializeMainThread
++  GetBlinkInitializer().Initialize();
++
+   V8Initializer::InitializeMainThread(
+       V8ContextSnapshotExternalReferences::GetTable());
+ 
+-  GetBlinkInitializer().Initialize();
+-
+   GetBlinkInitializer().RegisterInterfaces(*registry);
+ 
+   // currentThread is null if we are running on a thread without a message loop.


### PR DESCRIPTION
##### Description of Change
Fixes https://github.com/electron/electron/issues/13787

Backport of https://chromium-review.googlesource.com/c/chromium/src/+/1030530 to fix the order of V8 and Blink initialization.  Also fixes the order of `DidCreateScriptContext` notification with initialization of window globals to fix electron/electron#13787.  The backport landed in Chromium 67 but the `DidCreateScriptContext` re-ordering needs to be upstreamed or kept indefinitely

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

cc @deepak1556 