### PR TITLE
fix: workaround for X11ErrorTrackers issue (3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -361,3 +361,22 @@ patches:
   description: |
     Re-enable GPU acceleration for recent VMWare drivers.
     Backports https://chromium-review.googlesource.com/952778
+-
+  author: Charles Kerr <charles@charleskerr.com>
+  file: allow_nested_error_trackers.patch
+  description: |
+    Only one X11ErrorTracker should exist at a time, but upstream has a bug
+    where two can exist if running in headless mode -- 
+      ui::(anonymous namespace)::SupportsEWMH() [inner tracker is created]
+      ui::WmSupportsHint()
+      ui::IsX11WindowFullScreen()
+      ui::ScreensaverWindowFinder::IsScreensaverWindow()
+      ui::ScreensaverWindowFinder::ShouldStopIterating()
+      ui::EnumerateTopLevelWindows()
+      ui::ScreensaverWindowFinder::ScreensaverWindowExists() [outer tracker created]
+      ui::CheckIdleStateIsLocked()
+      ui::CalculateIdleState()
+    Removal of either tracker could have side-effects in some code paths,
+    so this is probably better handled upstream. This patch tries to do the
+    least harm in the interim by removing the check that prevents more than
+    one tracker from existing at a time.

--- a/patches/common/chromium/allow_nested_error_trackers.patch
+++ b/patches/common/chromium/allow_nested_error_trackers.patch
@@ -1,0 +1,13 @@
+diff --git a/ui/gfx/x/x11_error_tracker.cc b/ui/gfx/x/x11_error_tracker.cc
+index af031de356c5..2a5c18dc473a 100644
+--- a/ui/gfx/x/x11_error_tracker.cc
++++ b/ui/gfx/x/x11_error_tracker.cc
+@@ -24,7 +24,7 @@ namespace gfx {
+ X11ErrorTracker::X11ErrorTracker() {
+   // This is a non-exhaustive check for incorrect usage. It disallows nested
+   // X11ErrorTracker instances on the same thread.
+-  DCHECK(g_handler == NULL);
++  // DCHECK(g_handler == NULL);
+   g_handler = this;
+   XSync(GetXDisplay(), False);
+   old_handler_ = XSetErrorHandler(X11ErrorHandler);


### PR DESCRIPTION
##### Description of Change

Backport https://github.com/electron/libchromiumcontent/pull/673 to `3-0-x`

/cc @ckerr 