### PR TITLE
fix: do not let Chromium manage webview's frame's lifetime (3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -389,3 +389,12 @@ patches:
     of DidCreateScriptContext notification with initialization of window globals
     to fix electron/electron#13787.  The backport landed in Chromium 67 but the
     DidCreateScriptContext re-ordering needs to be upstreamed or kept indefinitely
+-
+  author: zcbenz <zcbenz@gmail.com>
+  file: disable_detach_webview_frame.patch
+  description: |
+    Don't detach the frame for webview, we will manage the WebContents
+    manually.
+    This is part of the fixes for https://github.com/electron/electron/issues/14211.
+    We should revisit this bug after upgrading to newer versions of Chrome,
+    this patch was introduced in Chrome 66.

--- a/patches/common/chromium/disable_detach_webview_frame.patch
+++ b/patches/common/chromium/disable_detach_webview_frame.patch
@@ -1,0 +1,17 @@
+diff --git a/content/browser/frame_host/render_frame_proxy_host.cc b/content/browser/frame_host/render_frame_proxy_host.cc
+index b44b0fd..a74d827 100644
+--- a/content/browser/frame_host/render_frame_proxy_host.cc
++++ b/content/browser/frame_host/render_frame_proxy_host.cc
+@@ -253,6 +253,12 @@ void RenderFrameProxyHost::SetDestructionCallback(
+ 
+ void RenderFrameProxyHost::OnDetach() {
+   if (frame_tree_node_->render_manager()->ForInnerDelegate()) {
++    // Don't detach the frame for webview, we will manage the WebContents
++    // manually.
++    // We should revisit this bug after upgrading to newer versions of Chrome,
++    // this patch was introduced in Chrome 66.
++    return;
++
+     // Only main frame proxy can detach for inner WebContents.
+     DCHECK(frame_tree_node_->IsMainFrame());
+     frame_tree_node_->render_manager()->RemoveOuterDelegateFrame();


### PR DESCRIPTION
Backports https://github.com/electron/libchromiumcontent/pull/676 to `electron-3-0-x`.