### PR TITLE
fix: [m67] patch leveldb to not redefine ssize_t

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -458,3 +458,10 @@ patches:
     This is part of the fixes for https://github.com/electron/electron/issues/14211.
     We should revisit this bug after upgrading to newer versions of Chrome,
     this patch was introduced in Chrome 66.
+-
+  author: Jeremy Apthorp <jeremya@chromium.org>
+  file: leveldb_ssize_t.patch
+  description: |
+    Fix conflict between leveldb & node's definition of ssize_t on
+    Windows by preventing leveldb from re-defining the type if it's
+    already defined.

--- a/patches/common/chromium/leveldb_ssize_t.patch
+++ b/patches/common/chromium/leveldb_ssize_t.patch
@@ -1,0 +1,16 @@
+﻿diff --git a/third_party/leveldatabase/port/port_chromium.h b/third_party/leveldatabase/port/port_chromium.h
+index a7c449eba19c..acbce7efd582 100644
+--- a/third_party/leveldatabase/port/port_chromium.h
++++ b/third_party/leveldatabase/port/port_chromium.h
+@@ -26,7 +26,11 @@
+ #endif
+ 
+ #if defined(OS_WIN)
++#  if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
+ typedef SSIZE_T ssize_t;
++#  define _SSIZE_T_
++#  define _SSIZE_T_DEFINED
++#  endif
+ #endif
+ 
+ namespace leveldb {


### PR DESCRIPTION
##### Description of Change
node.js (and its dependencies) define the `ssize_t` type in their headers on Windows, using a guard to prevent redefinition. leveldb also defines the `ssize_t` type in the `port_chromium.h` file, but without the redefinition guard. This causes a compilation error on windows, because the type is defined twice when compiling `atom_api_browser_window.cc` in electron.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)